### PR TITLE
docs: new release process to include Status fleets

### DIFF
--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -57,7 +57,6 @@ Note that `status.staging` refers to `shards.staging` fleet (rename is wip).
   - [ ] Create GitHub release
   - [ ] Deploy the release to DockerHub
   - [ ] Announce the release
-  - [ ] Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.
 
 - [ ] **Promote release to fleets**.
   - [ ] Update infra config with any deprecated arguments or changed options

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -46,7 +46,7 @@ Note that `status.staging` refers to `shards.staging` fleet (rename is wip).
       - [ ] Close one instance, send messages with second instance, reopen first instance and confirm messages sent while offline are retrieved from store
     - [ ] Perform checks based _end user impact_
     - [ ] Ask other (Waku and Status) CCs to point their instance to `status.staging` for a week and use the app as usual.
-    - [ ] Ask Status-QA to perform sanity checks (as described above) + checks based on _end user impact_
+    - [ ] Ask Status-QA to perform sanity checks (as described above) + checks based on _end user impact_; do specify the version being tested
     - [ ] Ask Status-QA or infra to run the automated Status e2e tests against `status.staging`
     - [ ] Get other CCs sign-off: they comment on this PR "used app for a week, no problem", or problem reported, resolved and new RC
     - [ ] **Get Status-QA sign-off**. Ensuring that `status.test` update will not disturb ongoing activities.

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -41,6 +41,7 @@ All items below are to be completed by the owner of the given release.
     - [ ] Perform checks based _end user impact_
     - [ ] Ask other (Waku and Status) CCs to point their instance to `status.staging` for a week and use the app as usual.
     - [ ] Ask Status/QA to perform sanity checks (as described above) + checks based on _end user impact_
+    - [ ] Ask Status/QA or infra to run the automated Status e2e tests against `status.staging`
     - [ ] Get other CCs sign-off: they comment on this PR "used app for a week, no problem", or problem reported, resolved and new RC
     - [ ] **Get Status/QA sign-off**. Ensuring that `status.test` update will not disturb ongoing activities.
 
@@ -53,10 +54,11 @@ All items below are to be completed by the owner of the given release.
   - [ ] Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.
 
 - [ ] **Promote release to fleets**.
+  - [ ] Update infra config with any deprecated arguments or changed options
   - [ ] [Deploy final release to `waku.sandbox` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox)
-  - [ ] Deploy final release to `waku.prod`
   - [ ] [Deploy final release to `status.staging` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-shards-staging/)
   - [ ] [Deploy final release to `status.test` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-shards-test/) ([soon to be `status.prod`](https://github.com/status-im/infra-shards/issues/33))
 
 - [ ] **Post release**
   - [ ] Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.
+  - [ ] Update waku-org/nwaku-compose with the new release version.

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -35,7 +35,7 @@ Note that `status.staging` refers to `shards.staging` fleet (rename is wip).
     - [ ] Search _Kibana_ logs from the previous month (since last release was deployed), for possible crashes or errors in `waku.test` and `waku.sandbox`.
       - Most relevant logs are `(fleet: "waku.test" OR fleet: "waku.sandbox") AND message: "SIGSEGV"`
     - [ ] Run release candidate with `waku-simulator`, ensure that nodes connected to each other
-    - [ ] Unlock `waku.test`
+    - [ ] Unlock `waku.test` to resume auto-deployment of latest `master` commit
 
   - [ ] **On Status fleet**
     - [ ] Deploy release candidate to `status.staging`

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -15,15 +15,15 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
 
 ### Items to complete
 
-- [ ] create release branch
-- [ ] assign release candidate tag
-- [ ] generate and edit releases notes
+- [ ] Create release branch
+- [ ] Assign release candidate tag to the release branch HEAD. e.g. v0.30.0-rc.0
+- [ ] Generate and edit releases notes
 - [ ] _End user impact_: Summarize impact of changes on Status end users (can be a comment in this issue).
-- [ ] **validate release candidate**
+- [ ] **Validate release candidate**
 
   - [ ] **On Waku fleets**
     - [ ] Lock `waku.test` fleet to release candidate version
-    - [ ] Continuously stress `waku.test` fleet for a week (e.g. from `waku.sandbox`)
+    - [ ] Continuously stress `waku.test` fleet for a week (e.g. from `waku-dev`)
     - [ ] Search _Kibana_ logs from the previous month (since last release was deployed), for possible crashes or errors in `waku.test` and `waku.sandbox`.
       - Most relevant logs are `(fleet: "waku.test" OR fleet: "waku.sandbox") AND message: "SIGSEGV"`
     - [ ] Run release candidate with `waku-simulator`, ensure that nodes connected to each other
@@ -43,18 +43,20 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
     - [ ] Get other CCs sign-off: they comment on this PR "used app for a week, no problem", or problem reported, resolved and new RC
     - [ ] Get Status/QA sign-off
 
-- [ ] **proceed with release**
+- [ ] **Proceed with release**
 
-  - [ ] open PR and merge release notes to master
-  - [ ] cherry-pick release notes to the release branch
-  - [ ] assign release tag to the cherry-picked release notes commit
-  - [ ] create GitHub release
-  - [ ] deploy the release to DockerHub
-  - [ ] [deploy release to `waku.sandbox` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox)
-  - [ ] announce the release
+  - [ ] Assign a release tag to the same commit that contains the validated release-candidate tag
+  - [ ] Create GitHub release
+  - [ ] Deploy the release to DockerHub
+  - [ ] Announce the release
+  - [ ] Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.
 
 - [ ] **Promote release to fleets**.
+  - [ ] [Deploy final release to `waku.sandbox` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox)
   - [ ] Deploy final release to `waku.prod`
   - [ ] Deploy final release to `status.staging`
   - [ ] Deploy final release to `status.test` (soon to be `status.prod`)
 
+post release
+
+    Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -14,14 +14,47 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
  -->
 
 ### Items to complete
+
 - [ ] create release branch
 - [ ] assign release candidate tag
-- [ ] validate release candidate
 - [ ] generate and edit releases notes
-- [ ] open PR and merge release notes to master
-- [ ] cherry-pick release notes to the release branch
-- [ ] assign release tag to the cherry-picked release notes commit
-- [ ] create GitHub release
-- [ ] deploy the release to DockerHub
-- [ ] [deploy release to `waku.sandbox` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox)
-- [ ] announce the release
+- [ ] _End user impact_: Summarize impact of changes on Status end users (can be a comment in this issue).
+- [ ] **validate release candidate**
+
+  - [ ] **On Waku fleets**
+    - [ ] Lock `waku.test` fleet to release candidate version
+    - [ ] Continuously stress `waku.test` fleet for a week (e.g. from `waku.sandbox`)
+    - [ ] Search _Kibana_ logs from the previous month (since last release was deployed), for possible crashes or errors in `waku.test` and `waku.sandbox`.
+      - Most relevant logs are `(fleet: "waku.test" OR fleet: "waku.sandbox") AND message: "SIGSEGV"`
+    - [ ] Run release candidate with `waku-simulator`, ensure that nodes connected to each other
+    - [ ] Unlock `waku.test`
+
+  - [ ] **On Status fleet**
+    - [ ] Deploy release candidate to `status.staging`
+    - [ ] Perform [sanity check](https://www.notion.so/How-to-test-Nwaku-on-Status-12c6e4b9bf06420ca868bd199129b425)
+      - [ ] Connect 2 instances to `status.staging` fleet
+      - [ ] Send contact request across and accept
+      - [ ] 1:1 Chats with each other
+      - [ ] Send and receive messages in a community
+      - [ ] Close one instance, send messages with second instance, reopen first instance and confirm messages sent while offline are retrieved from store
+    - [ ] Perform checks based _end user impact_
+    - [ ] Ask other CCs to point their instance to `status.staging` for a week and use the app as usual.
+    - [ ] Ask Status/QA to perform sanity checks (as described above) + checks based on _end user impact_
+    - [ ] Get other CCs sign-off: they comment on this PR "used app for a week, no problem", or problem reported, resolved and new RC
+    - [ ] Get Status/QA sign-off
+
+- [ ] **proceed with release**
+
+  - [ ] open PR and merge release notes to master
+  - [ ] cherry-pick release notes to the release branch
+  - [ ] assign release tag to the cherry-picked release notes commit
+  - [ ] create GitHub release
+  - [ ] deploy the release to DockerHub
+  - [ ] [deploy release to `waku.sandbox` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox)
+  - [ ] announce the release
+
+- [ ] **Promote release to fleets**.
+  - [ ] Deploy final release to `waku.prod`
+  - [ ] Deploy final release to `status.staging`
+  - [ ] Deploy final release to `status.test` (soon to be `status.prod`)
+

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -15,15 +15,17 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
 
 ### Items to complete
 
+All items below are to be completed by the owner of the given release.
+
 - [ ] Create release branch
 - [ ] Assign release candidate tag to the release branch HEAD. e.g. v0.30.0-rc.0
-- [ ] Generate and edit releases notes
+- [ ] Generate and edit releases notes in CHANGELOG.md
 - [ ] _End user impact_: Summarize impact of changes on Status end users (can be a comment in this issue).
 - [ ] **Validate release candidate**
 
   - [ ] **On Waku fleets**
     - [ ] Lock `waku.test` fleet to release candidate version
-    - [ ] Continuously stress `waku.test` fleet for a week (e.g. from `waku-dev`)
+    - [ ] Continuously stress `waku.test` fleet for a week (e.g. from `wakudev`)
     - [ ] Search _Kibana_ logs from the previous month (since last release was deployed), for possible crashes or errors in `waku.test` and `waku.sandbox`.
       - Most relevant logs are `(fleet: "waku.test" OR fleet: "waku.sandbox") AND message: "SIGSEGV"`
     - [ ] Run release candidate with `waku-simulator`, ensure that nodes connected to each other
@@ -31,17 +33,16 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
 
   - [ ] **On Status fleet**
     - [ ] Deploy release candidate to `status.staging`
-    - [ ] Perform [sanity check](https://www.notion.so/How-to-test-Nwaku-on-Status-12c6e4b9bf06420ca868bd199129b425)
-      - [ ] Connect 2 instances to `status.staging` fleet
-      - [ ] Send contact request across and accept
+    - [ ] Perform [sanity check](https://www.notion.so/How-to-test-Nwaku-on-Status-12c6e4b9bf06420ca868bd199129b425) and log results as comments in this issue.
+      - [ ] Connect 2 instances to `status.staging` fleet, one in relay mode, the other one in light client.
       - [ ] 1:1 Chats with each other
       - [ ] Send and receive messages in a community
       - [ ] Close one instance, send messages with second instance, reopen first instance and confirm messages sent while offline are retrieved from store
     - [ ] Perform checks based _end user impact_
-    - [ ] Ask other CCs to point their instance to `status.staging` for a week and use the app as usual.
+    - [ ] Ask other (Waku and Status) CCs to point their instance to `status.staging` for a week and use the app as usual.
     - [ ] Ask Status/QA to perform sanity checks (as described above) + checks based on _end user impact_
     - [ ] Get other CCs sign-off: they comment on this PR "used app for a week, no problem", or problem reported, resolved and new RC
-    - [ ] Get Status/QA sign-off
+    - [ ] **Get Status/QA sign-off**. Ensuring that `status.test` update will not disturb ongoing activities.
 
 - [ ] **Proceed with release**
 
@@ -54,9 +55,8 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
 - [ ] **Promote release to fleets**.
   - [ ] [Deploy final release to `waku.sandbox` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-waku-sandbox)
   - [ ] Deploy final release to `waku.prod`
-  - [ ] Deploy final release to `status.staging`
-  - [ ] Deploy final release to `status.test` (soon to be `status.prod`)
+  - [ ] [Deploy final release to `status.staging` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-shards-staging/)
+  - [ ] [Deploy final release to `status.test` fleet](https://ci.infra.status.im/job/nim-waku/job/deploy-shards-test/) ([soon to be `status.prod`](https://github.com/status-im/infra-shards/issues/33))
 
-post release
-
-    Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.
+- [ ] **Post release**
+  - [ ] Submit a PR from the release branch to master. Important to commit the PR with "create a merge commit" option.

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -17,6 +17,8 @@ For detailed info on the release process refer to https://github.com/waku-org/nw
 
 All items below are to be completed by the owner of the given release.
 
+Note that `status.staging` refers to `shards.staging` fleet (rename is wip).
+
 - [ ] Create release branch
 - [ ] Assign release candidate tag to the release branch HEAD. e.g. v0.30.0-rc.0
 - [ ] Generate and edit releases notes in CHANGELOG.md

--- a/.github/ISSUE_TEMPLATE/prepare_release.md
+++ b/.github/ISSUE_TEMPLATE/prepare_release.md
@@ -23,6 +23,10 @@ All items below are to be completed by the owner of the given release.
 - [ ] _End user impact_: Summarize impact of changes on Status end users (can be a comment in this issue).
 - [ ] **Validate release candidate**
 
+- [ ] Automated testing
+  - [ ] Ensures js-waku tests are green against release candidate
+  - [ ] Ask Vac-QA and Vac-DST to perform available tests against release candidate
+
   - [ ] **On Waku fleets**
     - [ ] Lock `waku.test` fleet to release candidate version
     - [ ] Continuously stress `waku.test` fleet for a week (e.g. from `wakudev`)
@@ -40,10 +44,10 @@ All items below are to be completed by the owner of the given release.
       - [ ] Close one instance, send messages with second instance, reopen first instance and confirm messages sent while offline are retrieved from store
     - [ ] Perform checks based _end user impact_
     - [ ] Ask other (Waku and Status) CCs to point their instance to `status.staging` for a week and use the app as usual.
-    - [ ] Ask Status/QA to perform sanity checks (as described above) + checks based on _end user impact_
-    - [ ] Ask Status/QA or infra to run the automated Status e2e tests against `status.staging`
+    - [ ] Ask Status-QA to perform sanity checks (as described above) + checks based on _end user impact_
+    - [ ] Ask Status-QA or infra to run the automated Status e2e tests against `status.staging`
     - [ ] Get other CCs sign-off: they comment on this PR "used app for a week, no problem", or problem reported, resolved and new RC
-    - [ ] **Get Status/QA sign-off**. Ensuring that `status.test` update will not disturb ongoing activities.
+    - [ ] **Get Status-QA sign-off**. Ensuring that `status.test` update will not disturb ongoing activities.
 
 - [ ] **Proceed with release**
 


### PR DESCRIPTION
New detailed release process that involves more validation in Status app context.

Some decisions explanation (feel free to debate):

- Release isn't finalised until validated with Status
  - 2024 is focus on Status, it seems less costly to block release until checked in Status context than doing patch releases.
  - Problems introduced in latest release blocked Status QA (nwaku blocked node), we must avoid this in the future.
- Which means release process now takes 2 weeks:
  - 1st week testing release on Waku fleet
  - 2nd week testing release on Status fleet
-  Added task to create a summary of changes impact on Status users: needed to know what we check in the Status app beyond sanity check.

Also:
- not sure how we deploy on the various fleets: do we run jenkins ourselves or open an issue to infra?
- Once merged, I think we should delete https://www.notion.so/Release-Process-61234f335b904cd0943a5033ed8f42b4?pvs=4#4e249cfff5d24ea08f7b8087a286f5c6 and point to this template to avoid dupe/conflicting information.