### PR TITLE
chore: lock in nph version and add pre-commit hook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -174,3 +174,8 @@
 	path = vendor/negentropy
 	url = https://github.com/waku-org/negentropy.git
 	branch = master
+[submodule "vendor/nph"]
+	ignore = untracked
+	branch = master
+	path = vendor/nph
+	url = https://github.com/arnetheduck/nph.git

--- a/Makefile
+++ b/Makefile
@@ -245,11 +245,21 @@ networkmonitor: | build deps librln
 ############
 ## Format ##
 ############
-.PHONY: build-nph clean-nph
+.PHONY: build-nph clean-nph install-nph
 
 build-nph:
 ifeq ("$(wildcard $(NPH))","")
 	$(ENV_SCRIPT) nim c vendor/nph/src/nph.nim
+endif
+
+GIT_PRE_COMMIT_HOOK := .git/hooks/pre-commit
+
+install-nph: build-nph
+ifeq ("$(wildcard $(GIT_PRE_COMMIT_HOOK))","")
+	cp ./scripts/git_pre_commit_format.sh $(GIT_PRE_COMMIT_HOOK)
+else
+	echo "$(GIT_PRE_COMMIT_HOOK) already present, will NOT override"
+	exit 1
 endif
 
 nph/%: build-nph

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 EXCLUDED_NIM_PACKAGES := vendor/nim-dnsdisc/vendor
 LINK_PCRE := 0
 LOG_LEVEL := TRACE
-
+NPH := vendor/nph/src/nph
+FORMAT_MSG := "\\x1B[95mFormatting:\\x1B[39m"
 # we don't want an error here, so we can handle things later, in the ".DEFAULT" target
 -include $(BUILD_SYSTEM_DIR)/makefiles/variables.mk
 
@@ -98,7 +99,7 @@ ifeq (, $(shell which cargo))
 endif
 
 anvil: rustup
-ifeq (, $(shell which anvil))
+ifeq (, $(shell which anvil 2> /dev/null))
 # Install Anvil if it's not installed
 	./scripts/install_anvil.sh
 endif
@@ -241,6 +242,24 @@ networkmonitor: | build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim networkmonitor $(NIM_PARAMS) waku.nims
 
+############
+## Format ##
+############
+.PHONY: build-nph clean-nph
+
+build-nph:
+ifeq ("$(wildcard $(NPH))","")
+	$(ENV_SCRIPT) nim c vendor/nph/src/nph.nim
+endif
+
+nph/%: build-nph
+	echo -e $(FORMAT_MSG) "nph/$*" && \
+		$(NPH) $*
+
+clean-nph:
+	rm -f $(NPH)
+
+clean: | clean-nph
 
 ###################
 ## Documentation ##

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ Binary will be created as `<path to your test file.nim>.bin` under the `build` d
 make test/tests/common/test_enr_builder.nim
 ```
 
+## Formatting
+
+Nim files are expected to be formatted using the [`nph`](https://github.com/arnetheduck/nph) version present in `vendor/nph`.
+
+You can easily format file with the `make nph/<relative path to nim> file` command.
+For example:
+
+```
+make nph/waku/waku_core.nim
+```
+
+A convenient git hook is provided to automatically format file at commit time.
+Run the following command to install it:
+
+```shell
+make install-nph
+```
+
 ### Examples
 
 Examples can be found in the examples folder.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ If you encounter difficulties building the project on WSL, consider placing the 
 #### Nim Runtime
 This repository is bundled with a Nim runtime that includes the necessary dependencies for the project.
 
-Before you can utilise the runtime you'll need to build the project, as detailed in a previous section. This will generate a `vendor` directory containing various dependencies, including the `nimbus-build-system` which has the bundled nim runtime.
+Before you can utilise the runtime you'll need to build the project, as detailed in a previous section.
+This will generate a `vendor` directory containing various dependencies, including the `nimbus-build-system` which has the bundled nim runtime.
 
 After successfully building the project, you may bring the bundled runtime into scope by running:
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The nwaku repository implements Waku, and provides tools related to it.
 - Examples of Waku usage.
 - Various tests of above.
 
-For more details see the [source code](waku/v2/README.md)
+For more details see the [source code](waku/README.md)
 
 ## How to Build & Run
 

--- a/scripts/git_pre_commit_format.sh
+++ b/scripts/git_pre_commit_format.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Running pre-commit hook"
+
+# Regexp for grep to only choose some file extensions for formatting
+exts="\.\(nim\|nims\)$"
+
+# Build nph lazily
+make build-nph || (1>&2 echo "failed to build nph. Pre-commit formatting will not be done."; exit 0)
+
+# Format staged files
+git diff --cached --name-only --diff-filter=ACMR | grep "$exts" | while read file; do
+  echo "Formatting $file"
+  make nph/"$file"
+  git add "$file"
+done


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->

- Lock in `nph` version to `v0.5.1` by bringing it as a submodule
- Add convenient make tasks to build and run `nph`
- Add convenient make task to install hook that will format nim files at commit time.
