### PR TITLE
chore: install dig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL version="unknown"
 EXPOSE 30303 60000 8545
 
 # Referenced in the binary
-RUN apk add --no-cache libgcc pcre-dev libpq-dev
+RUN apk add --no-cache libgcc pcre-dev libpq-dev bind-tools
 
 # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
 RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3


### PR DESCRIPTION
Install `dig` to enable automatic detection of domain names to increase support of WSS.

See https://github.com/waku-org/nwaku-compose/pull/115