### PR TITLE
feat: change latency buckets

### DIFF
--- a/apps/networkmonitor/networkmonitor_metrics.nim
+++ b/apps/networkmonitor/networkmonitor_metrics.nim
@@ -38,7 +38,7 @@ declarePublicGauge networkmonitor_peer_user_agents,
 declarePublicHistogram networkmonitor_peer_ping,
   "Histogram tracking ping durations for discovered peers",
   buckets =
-    [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 2000.0, Inf]
+    [10.0, 20.0, 50.0, 100.0, 200.0, 300.0, 500.0, 800.0, 1000.0, 2000.0, Inf]
 
 declarePublicGauge networkmonitor_peer_count,
   "Number of discovered peers", labels = ["connected"]

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -55,7 +55,7 @@ import
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
 declarePublicHistogram waku_histogram_message_size,
   "message size histogram in kB",
-  buckets = [0.0, 5.0, 15.0, 50.0, 75.0, 100.0, 125.0, 150.0, 300.0, 700.0, 1000.0, Inf]
+  buckets = [0.0, 1.0, 3.0, 5.0, 15.0, 50.0, 75.0, 100.0, 125.0, 150.0, 500.0, 700.0, 1000.0, Inf]
 
 declarePublicGauge waku_version,
   "Waku version info (in git describe format)", ["version"]


### PR DESCRIPTION
~70% of observed values are under 100ms so usefult to split it further.

Less than 10% of observed values are above 400ms so no need to have that much precision.