### PR TITLE
fix: filter out ephemeral msg from waku sync

### DIFF
--- a/waku/waku_archive/archive.nim
+++ b/waku/waku_archive/archive.nim
@@ -132,6 +132,9 @@ proc syncMessageIngress*(
     pubsubTopic: PubsubTopic,
     msg: WakuMessage,
 ): Future[Result[void, string]] {.async.} =
+  if msg.ephemeral:
+    return err("ephemeral message, will not store")
+
   let msgHashHex = msgHash.to0xHex()
 
   trace "handling message in syncMessageIngress",

--- a/waku/waku_store_sync/reconciliation.nim
+++ b/waku/waku_store_sync/reconciliation.nim
@@ -68,6 +68,9 @@ type SyncReconciliation* = ref object of LPProtocol
 proc messageIngress*(
     self: SyncReconciliation, pubsubTopic: PubsubTopic, msg: WakuMessage
 ) =
+  if msg.ephemeral:
+    return
+
   let msgHash = computeMessageHash(pubsubTopic, msg)
 
   let id = SyncID(time: msg.timestamp, hash: msgHash)
@@ -78,6 +81,9 @@ proc messageIngress*(
 proc messageIngress*(
     self: SyncReconciliation, msgHash: WakuMessageHash, msg: WakuMessage
 ) =
+  if msg.ephemeral:
+    return
+
   let id = SyncID(time: msg.timestamp, hash: msgHash)
 
   self.storage.insert(id).isOkOr:

--- a/waku/waku_store_sync/transfer.nim
+++ b/waku/waku_store_sync/transfer.nim
@@ -118,6 +118,10 @@ proc needsReceiverLoop(self: SyncTransfer) {.async.} =
       error "failed to query archive", error = error
       continue
 
+    if response.messages.len < 1:
+      error "failed to fetch message from db"
+      continue
+
     let msg =
       WakuMessageAndTopic(pubsub: response.topics[0], message: response.messages[0])
 


### PR DESCRIPTION
## Description
Ephemeral messages were not being filtered out and caused problem when they were not present to be fetched from the db.

Thanks to @Ivansete-status for noticing this bug.

## Issue
- https://github.com/waku-org/nwaku/issues/3236

