### PR TITLE
fix:  waku sync timing

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -214,9 +214,9 @@ proc mountStoreSync*(
     storeSyncInterval = 300,
     storeSyncRelayJitter = 20,
 ): Future[Result[void, string]] {.async.} =
-  let idsChannel = newAsyncQueue[SyncID](100)
-  let wantsChannel = newAsyncQueue[(PeerId, WakuMessageHash)](100)
-  let needsChannel = newAsyncQueue[(PeerId, WakuMessageHash)](100)
+  let idsChannel = newAsyncQueue[SyncID](0)
+  let wantsChannel = newAsyncQueue[(PeerId, WakuMessageHash)](0)
+  let needsChannel = newAsyncQueue[(PeerId, WakuMessageHash)](0)
 
   var cluster: uint16
   var shards: seq[uint16]

--- a/waku/waku_store_sync/reconciliation.nim
+++ b/waku/waku_store_sync/reconciliation.nim
@@ -129,10 +129,10 @@ proc processRequest(
       sendPayload.shards = self.shards.toSeq()
 
       for hash in hashToSend:
-        await self.remoteNeedsTx.addLast((conn.peerId, hash))
+        self.remoteNeedsTx.addLastNoWait((conn.peerId, hash))
 
       for hash in hashToRecv:
-        await self.localWantstx.addLast((conn.peerId, hash))
+        self.localWantsTx.addLastNoWait((conn.peerId, hash))
 
       rawPayload = sendPayload.deltaEncode()
 


### PR DESCRIPTION
# Description
Because of the async nature of the waku sync code, missing messages were sent before the differences could be computed by the other node.

I removed some async parts of the code so that the reconciliation payload is always sent before anything else.

N.B. I also removed the limit on the queues because the async `addLast` was waiting on available space, that is no longer the case and could raise if no space.