### PR TITLE
chore!: make sharding configuration explicit

### DIFF
--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -577,10 +577,11 @@ when isMainModule:
     conf.rlnRelayEthContractAddress = twnNetworkConf.rlnRelayEthContractAddress
     conf.rlnEpochSizeSec = twnNetworkConf.rlnEpochSizeSec
     conf.rlnRelayUserMessageLimit = twnNetworkConf.rlnRelayUserMessageLimit
-    conf.numShardsInNetwork = twnNetworkConf.numShardsInNetwork
+    conf.numShardsInNetwork = twnNetworkConf.shardingConf.numShardsInCluster
 
     if conf.shards.len == 0:
-      conf.shards = toSeq(uint16(0) .. uint16(twnNetworkConf.numShardsInNetwork - 1))
+      conf.shards =
+        toSeq(uint16(0) .. uint16(twnNetworkConf.shardingConf.numShardsInCluster - 1))
 
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)

--- a/apps/networkmonitor/networkmonitor.nim
+++ b/apps/networkmonitor/networkmonitor.nim
@@ -570,17 +570,17 @@ when isMainModule:
   info "cli flags", conf = conf
 
   if conf.clusterId == 1:
-    let twnClusterConf = ClusterConf.TheWakuNetworkConf()
+    let twnNetworkConf = NetworkConf.TheWakuNetworkConf()
 
-    conf.bootstrapNodes = twnClusterConf.discv5BootstrapNodes
-    conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
-    conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
-    conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
-    conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
-    conf.numShardsInNetwork = twnClusterConf.numShardsInNetwork
+    conf.bootstrapNodes = twnNetworkConf.discv5BootstrapNodes
+    conf.rlnRelayDynamic = twnNetworkConf.rlnRelayDynamic
+    conf.rlnRelayEthContractAddress = twnNetworkConf.rlnRelayEthContractAddress
+    conf.rlnEpochSizeSec = twnNetworkConf.rlnEpochSizeSec
+    conf.rlnRelayUserMessageLimit = twnNetworkConf.rlnRelayUserMessageLimit
+    conf.numShardsInNetwork = twnNetworkConf.numShardsInNetwork
 
     if conf.shards.len == 0:
-      conf.shards = toSeq(uint16(0) .. uint16(twnClusterConf.numShardsInNetwork - 1))
+      conf.shards = toSeq(uint16(0) .. uint16(twnNetworkConf.numShardsInNetwork - 1))
 
   if conf.logLevel != LogLevel.NONE:
     setLogLevel(conf.logLevel)

--- a/examples/wakustealthcommitments/node_spec.nim
+++ b/examples/wakustealthcommitments/node_spec.nim
@@ -24,26 +24,26 @@ proc setup*(): Waku =
 
   var conf = confRes.get()
 
-  let twnClusterConf = ClusterConf.TheWakuNetworkConf()
+  let twnNetworkConf = NetworkConf.TheWakuNetworkConf()
   if len(conf.shards) != 0:
-    conf.pubsubTopics = conf.shards.mapIt(twnClusterConf.pubsubTopics[it.uint16])
+    conf.pubsubTopics = conf.shards.mapIt(twnNetworkConf.pubsubTopics[it.uint16])
   else:
-    conf.pubsubTopics = twnClusterConf.pubsubTopics
+    conf.pubsubTopics = twnNetworkConf.pubsubTopics
 
   # Override configuration
-  conf.maxMessageSize = twnClusterConf.maxMessageSize
-  conf.clusterId = twnClusterConf.clusterId
-  conf.rlnRelayEthContractAddress = twnClusterConf.rlnRelayEthContractAddress
-  conf.rlnRelayDynamic = twnClusterConf.rlnRelayDynamic
-  conf.discv5Discovery = twnClusterConf.discv5Discovery
+  conf.maxMessageSize = twnNetworkConf.maxMessageSize
+  conf.clusterId = twnNetworkConf.clusterId
+  conf.rlnRelayEthContractAddress = twnNetworkConf.rlnRelayEthContractAddress
+  conf.rlnRelayDynamic = twnNetworkConf.rlnRelayDynamic
+  conf.discv5Discovery = twnNetworkConf.discv5Discovery
   conf.discv5BootstrapNodes =
-    conf.discv5BootstrapNodes & twnClusterConf.discv5BootstrapNodes
-  conf.rlnEpochSizeSec = twnClusterConf.rlnEpochSizeSec
-  conf.rlnRelayUserMessageLimit = twnClusterConf.rlnRelayUserMessageLimit
+    conf.discv5BootstrapNodes & twnNetworkConf.discv5BootstrapNodes
+  conf.rlnEpochSizeSec = twnNetworkConf.rlnEpochSizeSec
+  conf.rlnRelayUserMessageLimit = twnNetworkConf.rlnRelayUserMessageLimit
 
   # Only set rlnRelay to true if relay is configured
   if conf.relay:
-    conf.rlnRelay = twnClusterConf.rlnRelay
+    conf.rlnRelay = twnNetworkConf.rlnRelay
 
   debug "Starting node"
   var waku = Waku.new(conf).valueOr:

--- a/tests/factory/test_external_config.nim
+++ b/tests/factory/test_external_config.nim
@@ -48,7 +48,9 @@ suite "Waku config - apply preset":
       check rlnRelayConf.chainId == expectedConf.rlnRelayChainId
       check rlnRelayConf.epochSizeSec == expectedConf.rlnEpochSizeSec
       check rlnRelayConf.userMessageLimit == expectedConf.rlnRelayUserMessageLimit
-    check conf.numShardsInNetwork == expectedConf.numShardsInNetwork
+      check conf.shardingConf.kind == expectedConf.shardingConf.kind
+      check conf.shardingConf.numShardsInCluster ==
+        expectedConf.shardingConf.numShardsInCluster
     check conf.discv5Conf.isSome() == expectedConf.discv5Discovery
     if conf.discv5Conf.isSome():
       let discv5Conf = conf.discv5Conf.get()
@@ -68,7 +70,7 @@ suite "Waku config - apply preset":
 
     ## Then
     let conf = res.get()
-    check conf.shards.len == expectedConf.numShardsInNetwork.int
+    check conf.activeRelayShards.len == expectedConf.shardingConf.numShardsInCluster.int
 
   test "Subscribes to some valid shards in twn":
     ## Setup
@@ -84,9 +86,9 @@ suite "Waku config - apply preset":
 
     ## Then
     let conf = resConf.get()
-    assert conf.shards.len() == shards.len()
+    assert conf.activeRelayShards.len() == shards.len()
     for index, shard in shards:
-      assert shard in conf.shards
+      assert shard in conf.activeRelayShards
 
   test "Subscribes to invalid shards in twn":
     ## Setup
@@ -131,7 +133,9 @@ suite "Waku config - apply preset":
       check rlnRelayConf.chainId == expectedConf.rlnRelayChainId
       check rlnRelayConf.epochSizeSec == expectedConf.rlnEpochSizeSec
       check rlnRelayConf.userMessageLimit == expectedConf.rlnRelayUserMessageLimit
-    check conf.numShardsInNetwork == expectedConf.numShardsInNetwork
+      check conf.shardingConf.kind == expectedConf.shardingConf.kind
+      check conf.shardingConf.numShardsInCluster ==
+        expectedConf.shardingConf.numShardsInCluster
     check conf.discv5Conf.isSome() == expectedConf.discv5Discovery
     if conf.discv5Conf.isSome():
       let discv5Conf = conf.discv5Conf.get()
@@ -164,7 +168,7 @@ suite "Waku config - Shards":
 
     ## Given
     let shards: seq[uint16] = @[0, 2, 4]
-    let numShardsInNetwork = 5.uint32
+    let numShardsInNetwork = 5.uint16
     let wakuNodeConf = WakuNodeConf(
       cmd: noCommand, shards: shards, numShardsInNetwork: numShardsInNetwork
     )
@@ -183,7 +187,7 @@ suite "Waku config - Shards":
 
     ## Given
     let shards: seq[uint16] = @[0, 2, 5]
-    let numShardsInNetwork = 5.uint32
+    let numShardsInNetwork = 5.uint16
     let wakuNodeConf = WakuNodeConf(
       cmd: noCommand, shards: shards, numShardsInNetwork: numShardsInNetwork
     )

--- a/tests/factory/test_external_config.nim
+++ b/tests/factory/test_external_config.nim
@@ -20,7 +20,7 @@ import
 suite "Waku config - apply preset":
   test "Default preset is TWN":
     ## Setup
-    let expectedConf = ClusterConf.TheWakuNetworkConf()
+    let expectedConf = NetworkConf.TheWakuNetworkConf()
 
     ## Given
     let preConfig = WakuNodeConf(
@@ -56,7 +56,7 @@ suite "Waku config - apply preset":
 
   test "Subscribes to all valid shards in twn":
     ## Setup
-    let expectedConf = ClusterConf.TheWakuNetworkConf()
+    let expectedConf = NetworkConf.TheWakuNetworkConf()
 
     ## Given
     let shards: seq[uint16] = @[0, 1, 2, 3, 4, 5, 6, 7]
@@ -72,7 +72,7 @@ suite "Waku config - apply preset":
 
   test "Subscribes to some valid shards in twn":
     ## Setup
-    let expectedConf = ClusterConf.TheWakuNetworkConf()
+    let expectedConf = NetworkConf.TheWakuNetworkConf()
 
     ## Given
     let shards: seq[uint16] = @[0, 4, 7]
@@ -103,7 +103,7 @@ suite "Waku config - apply preset":
 
   test "Apply TWN preset when cluster id = 1":
     ## Setup
-    let expectedConf = ClusterConf.TheWakuNetworkConf()
+    let expectedConf = NetworkConf.TheWakuNetworkConf()
 
     ## Given
     let preConfig = WakuNodeConf(

--- a/tests/factory/test_external_config.nim
+++ b/tests/factory/test_external_config.nim
@@ -70,7 +70,7 @@ suite "Waku config - apply preset":
 
     ## Then
     let conf = res.get()
-    check conf.activeRelayShards.len == expectedConf.shardingConf.numShardsInCluster.int
+    check conf.subscribeShards.len == expectedConf.shardingConf.numShardsInCluster.int
 
   test "Subscribes to some valid shards in twn":
     ## Setup
@@ -86,9 +86,9 @@ suite "Waku config - apply preset":
 
     ## Then
     let conf = resConf.get()
-    assert conf.activeRelayShards.len() == shards.len()
+    assert conf.subscribeShards.len() == shards.len()
     for index, shard in shards:
-      assert shard in conf.activeRelayShards
+      assert shard in conf.subscribeShards
 
   test "Subscribes to invalid shards in twn":
     ## Setup

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -38,8 +38,10 @@ suite "Waku Conf - build with cluster conf":
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
     check conf.clusterId == networkConf.clusterId
-    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
-    check conf.shards == expectedShards
+    check conf.shardingConf.kind == networkConf.shardingConf.kind
+    check conf.shardingConf.numShardsInCluster ==
+      networkConf.shardingConf.numShardsInCluster
+    check conf.activeRelayShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -78,8 +80,10 @@ suite "Waku Conf - build with cluster conf":
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
     check conf.clusterId == networkConf.clusterId
-    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
-    check conf.shards == expectedShards
+    check conf.shardingConf.kind == networkConf.shardingConf.kind
+    check conf.shardingConf.numShardsInCluster ==
+      networkConf.shardingConf.numShardsInCluster
+    check conf.activeRelayShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -108,8 +112,10 @@ suite "Waku Conf - build with cluster conf":
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
     check conf.clusterId == networkConf.clusterId
-    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
-    check conf.shards == expectedShards
+    check conf.shardingConf.kind == networkConf.shardingConf.kind
+    check conf.shardingConf.numShardsInCluster ==
+      networkConf.shardingConf.numShardsInCluster
+    check conf.activeRelayShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -124,7 +130,7 @@ suite "Waku Conf - build with cluster conf":
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
     builder.withNetworkConf(networkConf)
-    builder.withShards(shards)
+    builder.withActiveRelayShards(shards)
 
     ## When
     let resConf = builder.build()
@@ -135,8 +141,10 @@ suite "Waku Conf - build with cluster conf":
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
     check conf.clusterId == networkConf.clusterId
-    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
-    check conf.shards == shards
+    check conf.shardingConf.kind == networkConf.shardingConf.kind
+    check conf.shardingConf.numShardsInCluster ==
+      networkConf.shardingConf.numShardsInCluster
+    check conf.activeRelayShards == shards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -150,7 +158,7 @@ suite "Waku Conf - build with cluster conf":
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
     builder.withNetworkConf(networkConf)
-    builder.withShards(shards)
+    builder.withActiveRelayShards(shards)
 
     ## When
     let resConf = builder.build()
@@ -183,8 +191,10 @@ suite "Waku Conf - build with cluster conf":
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
     check conf.clusterId == networkConf.clusterId
-    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
-    check conf.shards == expectedShards
+    check conf.shardingConf.kind == networkConf.shardingConf.kind
+    check conf.shardingConf.numShardsInCluster ==
+      networkConf.shardingConf.numShardsInCluster
+    check conf.activeRelayShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.isSome == networkConf.discv5Discovery

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -41,7 +41,7 @@ suite "Waku Conf - build with cluster conf":
     check conf.shardingConf.kind == networkConf.shardingConf.kind
     check conf.shardingConf.numShardsInCluster ==
       networkConf.shardingConf.numShardsInCluster
-    check conf.activeRelayShards == expectedShards
+    check conf.subscribeShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -83,7 +83,7 @@ suite "Waku Conf - build with cluster conf":
     check conf.shardingConf.kind == networkConf.shardingConf.kind
     check conf.shardingConf.numShardsInCluster ==
       networkConf.shardingConf.numShardsInCluster
-    check conf.activeRelayShards == expectedShards
+    check conf.subscribeShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -115,7 +115,7 @@ suite "Waku Conf - build with cluster conf":
     check conf.shardingConf.kind == networkConf.shardingConf.kind
     check conf.shardingConf.numShardsInCluster ==
       networkConf.shardingConf.numShardsInCluster
-    check conf.activeRelayShards == expectedShards
+    check conf.subscribeShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -130,7 +130,7 @@ suite "Waku Conf - build with cluster conf":
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
     builder.withNetworkConf(networkConf)
-    builder.withActiveRelayShards(shards)
+    builder.withSubscribeShards(shards)
 
     ## When
     let resConf = builder.build()
@@ -144,7 +144,7 @@ suite "Waku Conf - build with cluster conf":
     check conf.shardingConf.kind == networkConf.shardingConf.kind
     check conf.shardingConf.numShardsInCluster ==
       networkConf.shardingConf.numShardsInCluster
-    check conf.activeRelayShards == shards
+    check conf.subscribeShards == shards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
@@ -158,7 +158,7 @@ suite "Waku Conf - build with cluster conf":
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
     builder.withNetworkConf(networkConf)
-    builder.withActiveRelayShards(shards)
+    builder.withSubscribeShards(shards)
 
     ## When
     let resConf = builder.build()
@@ -194,7 +194,7 @@ suite "Waku Conf - build with cluster conf":
     check conf.shardingConf.kind == networkConf.shardingConf.kind
     check conf.shardingConf.numShardsInCluster ==
       networkConf.shardingConf.numShardsInCluster
-    check conf.activeRelayShards == expectedShards
+    check conf.subscribeShards == expectedShards
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
     check conf.discv5Conf.isSome == networkConf.discv5Discovery

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -205,7 +205,7 @@ suite "Waku Conf - build with cluster conf":
 
       let rlnRelayConf = conf.rlnRelayConf.get()
       check rlnRelayConf.ethContractAddress.string ==
-        clusterConf.rlnRelayEthContractAddress
+        networkConf.rlnRelayEthContractAddress
       check rlnRelayConf.dynamic == networkConf.rlnRelayDynamic
       check rlnRelayConf.chainId == networkConf.rlnRelayChainId
       check rlnRelayConf.epochSizeSec == networkConf.rlnEpochSizeSec
@@ -274,8 +274,8 @@ suite "Waku Conf - extMultiaddrs":
     ## Then
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
-    check multiaddrs.len == conf.networkConf.extMultiAddrs.len
-    let resMultiaddrs = conf.networkConf.extMultiAddrs.map(
+    check multiaddrs.len == conf.endpointConf.extMultiAddrs.len
+    let resMultiaddrs = conf.endpointConf.extMultiAddrs.map(
       proc(m: MultiAddress): string =
         $m
     )

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -16,7 +16,7 @@ import
 suite "Waku Conf - build with cluster conf":
   test "Cluster Conf is passed and relay is enabled":
     ## Setup
-    let clusterConf = ClusterConf.TheWakuNetworkConf()
+    let networkConf = NetworkConf.TheWakuNetworkConf()
     var builder = WakuConfBuilder.init()
     builder.discv5Conf.withUdpPort(9000)
     builder.withRelayServiceRatio("50:50")
@@ -25,7 +25,7 @@ suite "Waku Conf - build with cluster conf":
 
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
-    builder.withClusterConf(clusterConf)
+    builder.withNetworkConf(networkConf)
     builder.withRelay(true)
     builder.rlnRelayConf.withTreePath("/tmp/test-tree-path")
 
@@ -37,27 +37,27 @@ suite "Waku Conf - build with cluster conf":
     ## Then
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
-    check conf.clusterId == clusterConf.clusterId
-    check conf.numShardsInNetwork == clusterConf.numShardsInNetwork
+    check conf.clusterId == networkConf.clusterId
+    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
     check conf.shards == expectedShards
     check conf.maxMessageSizeBytes ==
-      uint64(parseCorrectMsgSize(clusterConf.maxMessageSize))
-    check conf.discv5Conf.get().bootstrapNodes == clusterConf.discv5BootstrapNodes
+      uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
+    check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
 
-    if clusterConf.rlnRelay:
+    if networkConf.rlnRelay:
       assert conf.rlnRelayConf.isSome(), "RLN Relay conf is disabled"
 
       let rlnRelayConf = conf.rlnRelayConf.get()
       check rlnRelayConf.ethContractAddress.string ==
-        clusterConf.rlnRelayEthContractAddress
-      check rlnRelayConf.dynamic == clusterConf.rlnRelayDynamic
-      check rlnRelayConf.chainId == clusterConf.rlnRelayChainId
-      check rlnRelayConf.epochSizeSec == clusterConf.rlnEpochSizeSec
-      check rlnRelayConf.userMessageLimit == clusterConf.rlnRelayUserMessageLimit
+        networkConf.rlnRelayEthContractAddress
+      check rlnRelayConf.dynamic == networkConf.rlnRelayDynamic
+      check rlnRelayConf.chainId == networkConf.rlnRelayChainId
+      check rlnRelayConf.epochSizeSec == networkConf.rlnEpochSizeSec
+      check rlnRelayConf.userMessageLimit == networkConf.rlnRelayUserMessageLimit
 
   test "Cluster Conf is passed, but relay is disabled":
     ## Setup
-    let clusterConf = ClusterConf.TheWakuNetworkConf()
+    let networkConf = NetworkConf.TheWakuNetworkConf()
     var builder = WakuConfBuilder.init()
     builder.withRelayServiceRatio("50:50")
     builder.discv5Conf.withUdpPort(9000)
@@ -66,7 +66,7 @@ suite "Waku Conf - build with cluster conf":
 
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
-    builder.withClusterConf(clusterConf)
+    builder.withNetworkConf(networkConf)
     builder.withRelay(false)
 
     ## When
@@ -77,18 +77,18 @@ suite "Waku Conf - build with cluster conf":
     ## Then
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
-    check conf.clusterId == clusterConf.clusterId
-    check conf.numShardsInNetwork == clusterConf.numShardsInNetwork
+    check conf.clusterId == networkConf.clusterId
+    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
     check conf.shards == expectedShards
     check conf.maxMessageSizeBytes ==
-      uint64(parseCorrectMsgSize(clusterConf.maxMessageSize))
-    check conf.discv5Conf.get().bootstrapNodes == clusterConf.discv5BootstrapNodes
+      uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
+    check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
 
     assert conf.rlnRelayConf.isNone
 
   test "Cluster Conf is passed, but rln relay is disabled":
     ## Setup
-    let clusterConf = ClusterConf.TheWakuNetworkConf()
+    let networkConf = NetworkConf.TheWakuNetworkConf()
     var builder = WakuConfBuilder.init()
 
     let # Mount all shards in network
@@ -96,7 +96,7 @@ suite "Waku Conf - build with cluster conf":
 
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
-    builder.withClusterConf(clusterConf)
+    builder.withNetworkConf(networkConf)
     builder.rlnRelayConf.withEnabled(false)
 
     ## When
@@ -107,23 +107,23 @@ suite "Waku Conf - build with cluster conf":
     ## Then
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
-    check conf.clusterId == clusterConf.clusterId
-    check conf.numShardsInNetwork == clusterConf.numShardsInNetwork
+    check conf.clusterId == networkConf.clusterId
+    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
     check conf.shards == expectedShards
     check conf.maxMessageSizeBytes ==
-      uint64(parseCorrectMsgSize(clusterConf.maxMessageSize))
-    check conf.discv5Conf.get().bootstrapNodes == clusterConf.discv5BootstrapNodes
+      uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
+    check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
     assert conf.rlnRelayConf.isNone
 
   test "Cluster Conf is passed and valid shards are specified":
     ## Setup
-    let clusterConf = ClusterConf.TheWakuNetworkConf()
+    let networkConf = NetworkConf.TheWakuNetworkConf()
     var builder = WakuConfBuilder.init()
     let shards = @[2.uint16, 3.uint16]
 
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
-    builder.withClusterConf(clusterConf)
+    builder.withNetworkConf(networkConf)
     builder.withShards(shards)
 
     ## When
@@ -134,22 +134,22 @@ suite "Waku Conf - build with cluster conf":
     ## Then
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
-    check conf.clusterId == clusterConf.clusterId
-    check conf.numShardsInNetwork == clusterConf.numShardsInNetwork
+    check conf.clusterId == networkConf.clusterId
+    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
     check conf.shards == shards
     check conf.maxMessageSizeBytes ==
-      uint64(parseCorrectMsgSize(clusterConf.maxMessageSize))
-    check conf.discv5Conf.get().bootstrapNodes == clusterConf.discv5BootstrapNodes
+      uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
+    check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
 
   test "Cluster Conf is passed and invalid shards are specified":
     ## Setup
-    let clusterConf = ClusterConf.TheWakuNetworkConf()
+    let networkConf = NetworkConf.TheWakuNetworkConf()
     var builder = WakuConfBuilder.init()
     let shards = @[2.uint16, 10.uint16]
 
     ## Given
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
-    builder.withClusterConf(clusterConf)
+    builder.withNetworkConf(networkConf)
     builder.withShards(shards)
 
     ## When
@@ -160,7 +160,7 @@ suite "Waku Conf - build with cluster conf":
 
   test "Cluster Conf is passed and RLN contract is **not** overridden":
     ## Setup
-    let clusterConf = ClusterConf.TheWakuNetworkConf()
+    let networkConf = NetworkConf.TheWakuNetworkConf()
     var builder = WakuConfBuilder.init()
     builder.rlnRelayConf.withEthClientUrls(@["https://my_eth_rpc_url/"])
 
@@ -170,7 +170,7 @@ suite "Waku Conf - build with cluster conf":
 
     ## Given
     builder.rlnRelayConf.withEthContractAddress(contractAddress)
-    builder.withClusterConf(clusterConf)
+    builder.withNetworkConf(networkConf)
     builder.withRelay(true)
     builder.rlnRelayConf.withTreePath("/tmp/test")
 
@@ -182,24 +182,24 @@ suite "Waku Conf - build with cluster conf":
     ## Then
     let resValidate = conf.validate()
     assert resValidate.isOk(), $resValidate.error
-    check conf.clusterId == clusterConf.clusterId
-    check conf.numShardsInNetwork == clusterConf.numShardsInNetwork
+    check conf.clusterId == networkConf.clusterId
+    check conf.numShardsInNetwork == networkConf.numShardsInNetwork
     check conf.shards == expectedShards
     check conf.maxMessageSizeBytes ==
-      uint64(parseCorrectMsgSize(clusterConf.maxMessageSize))
-    check conf.discv5Conf.isSome == clusterConf.discv5Discovery
-    check conf.discv5Conf.get().bootstrapNodes == clusterConf.discv5BootstrapNodes
+      uint64(parseCorrectMsgSize(networkConf.maxMessageSize))
+    check conf.discv5Conf.isSome == networkConf.discv5Discovery
+    check conf.discv5Conf.get().bootstrapNodes == networkConf.discv5BootstrapNodes
 
-    if clusterConf.rlnRelay:
+    if networkConf.rlnRelay:
       assert conf.rlnRelayConf.isSome
 
       let rlnRelayConf = conf.rlnRelayConf.get()
       check rlnRelayConf.ethContractAddress.string ==
         clusterConf.rlnRelayEthContractAddress
-      check rlnRelayConf.dynamic == clusterConf.rlnRelayDynamic
-      check rlnRelayConf.chainId == clusterConf.rlnRelayChainId
-      check rlnRelayConf.epochSizeSec == clusterConf.rlnEpochSizeSec
-      check rlnRelayConf.userMessageLimit == clusterConf.rlnRelayUserMessageLimit
+      check rlnRelayConf.dynamic == networkConf.rlnRelayDynamic
+      check rlnRelayConf.chainId == networkConf.rlnRelayChainId
+      check rlnRelayConf.epochSizeSec == networkConf.rlnEpochSizeSec
+      check rlnRelayConf.userMessageLimit == networkConf.rlnRelayUserMessageLimit
 
 suite "Waku Conf - node key":
   test "Node key is generated":

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -420,7 +420,7 @@ procSuite "Peer Manager":
         parseIpAddress("0.0.0.0"),
         port,
         clusterId = 3,
-        activeRelayShards = @[uint16(0)],
+        subscribeShards = @[uint16(0)],
       )
 
       # same network
@@ -429,14 +429,14 @@ procSuite "Peer Manager":
         parseIpAddress("0.0.0.0"),
         port,
         clusterId = 4,
-        activeRelayShards = @[uint16(0)],
+        subscribeShards = @[uint16(0)],
       )
       node3 = newTestWakuNode(
         generateSecp256k1Key(),
         parseIpAddress("0.0.0.0"),
         port,
         clusterId = 4,
-        activeRelayShards = @[uint16(0)],
+        subscribeShards = @[uint16(0)],
       )
 
     node1.mountMetadata(3).expect("Mounted Waku Metadata")

--- a/tests/test_peer_manager.nim
+++ b/tests/test_peer_manager.nim
@@ -420,7 +420,7 @@ procSuite "Peer Manager":
         parseIpAddress("0.0.0.0"),
         port,
         clusterId = 3,
-        shards = @[uint16(0)],
+        activeRelayShards = @[uint16(0)],
       )
 
       # same network
@@ -429,14 +429,14 @@ procSuite "Peer Manager":
         parseIpAddress("0.0.0.0"),
         port,
         clusterId = 4,
-        shards = @[uint16(0)],
+        activeRelayShards = @[uint16(0)],
       )
       node3 = newTestWakuNode(
         generateSecp256k1Key(),
         parseIpAddress("0.0.0.0"),
         port,
         clusterId = 4,
-        shards = @[uint16(0)],
+        activeRelayShards = @[uint16(0)],
       )
 
     node1.mountMetadata(3).expect("Mounted Waku Metadata")

--- a/tests/test_waku_netconfig.nim
+++ b/tests/test_waku_netconfig.nim
@@ -18,8 +18,8 @@ suite "Waku NetConfig":
     let wakuFlags = defaultTestWakuFlags()
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extIp = none(IpAddress),
       extPort = none(Port),
       extMultiAddrs = @[],
@@ -46,7 +46,8 @@ suite "Waku NetConfig":
     let conf = defaultTestWakuConf()
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress, bindPort = conf.networkConf.p2pTcpPort
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
     )
 
     assert netConfigRes.isOk(), $netConfigRes.error
@@ -57,7 +58,9 @@ suite "Waku NetConfig":
       netConfig.announcedAddresses.len == 1 # Only bind address should be present
       netConfig.announcedAddresses[0] ==
         formatListenAddress(
-          ip4TcpEndPoint(conf.networkConf.p2pListenAddress, conf.networkConf.p2pTcpPort)
+          ip4TcpEndPoint(
+            conf.endpointConf.p2pListenAddress, conf.endpointConf.p2pTcpPort
+          )
         )
 
   asyncTest "AnnouncedAddresses contains external address if extIp/Port are provided":
@@ -67,8 +70,8 @@ suite "Waku NetConfig":
       extPort = Port(1234)
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extIp = some(extIp),
       extPort = some(extPort),
     )
@@ -88,8 +91,8 @@ suite "Waku NetConfig":
       extPort = Port(1234)
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       dns4DomainName = some(dns4DomainName),
       extPort = some(extPort),
     )
@@ -110,8 +113,8 @@ suite "Waku NetConfig":
       extMultiAddrs = @[ip4TcpEndPoint(extIp, extPort)]
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extMultiAddrs = extMultiAddrs,
     )
 
@@ -131,8 +134,8 @@ suite "Waku NetConfig":
       extPort = Port(1234)
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       dns4DomainName = some(dns4DomainName),
       extIp = some(extIp),
       extPort = some(extPort),
@@ -152,8 +155,8 @@ suite "Waku NetConfig":
       wssEnabled = false
 
     var netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       wsEnabled = true,
       wssEnabled = wssEnabled,
     )
@@ -165,8 +168,9 @@ suite "Waku NetConfig":
     check:
       netConfig.announcedAddresses.len == 2 # Bind address + wsHostAddress
       netConfig.announcedAddresses[1] == (
-        ip4TcpEndPoint(conf.networkConf.p2pListenAddress, conf.webSocketConf.get().port) &
-        wsFlag(wssEnabled)
+        ip4TcpEndPoint(
+          conf.endpointConf.p2pListenAddress, conf.webSocketConf.get().port
+        ) & wsFlag(wssEnabled)
       )
 
     ## Now try the same for the case of wssEnabled = true
@@ -174,8 +178,8 @@ suite "Waku NetConfig":
     wssEnabled = true
 
     netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       wsEnabled = true,
       wssEnabled = wssEnabled,
     )
@@ -187,8 +191,9 @@ suite "Waku NetConfig":
     check:
       netConfig.announcedAddresses.len == 2 # Bind address + wsHostAddress
       netConfig.announcedAddresses[1] == (
-        ip4TcpEndPoint(conf.networkConf.p2pListenAddress, conf.websocketConf.get().port) &
-        wsFlag(wssEnabled)
+        ip4TcpEndPoint(
+          conf.endpointConf.p2pListenAddress, conf.websocketConf.get().port
+        ) & wsFlag(wssEnabled)
       )
 
   asyncTest "Announced WebSocket address contains external IP if provided":
@@ -199,8 +204,8 @@ suite "Waku NetConfig":
       wssEnabled = false
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extIp = some(extIp),
       extPort = some(extPort),
       wsEnabled = true,
@@ -224,8 +229,8 @@ suite "Waku NetConfig":
       wssEnabled = false
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       dns4DomainName = some(dns4DomainName),
       extPort = some(extPort),
       wsEnabled = true,
@@ -252,8 +257,8 @@ suite "Waku NetConfig":
       wssEnabled = false
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       dns4DomainName = some(dns4DomainName),
       extIp = some(extIp),
       extPort = some(extPort),
@@ -277,7 +282,8 @@ suite "Waku NetConfig":
     let conf = defaultTestWakuConf()
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress, bindPort = conf.networkConf.p2pTcpPort
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
     )
 
     assert netConfigRes.isOk(), $netConfigRes.error
@@ -285,8 +291,8 @@ suite "Waku NetConfig":
     let netConfig = netConfigRes.get()
 
     check:
-      netConfig.enrIp.get() == conf.networkConf.p2pListenAddress
-      netConfig.enrPort.get() == conf.networkConf.p2pTcpPort
+      netConfig.enrIp.get() == conf.endpointConf.p2pListenAddress
+      netConfig.enrPort.get() == conf.endpointConf.p2pTcpPort
 
   asyncTest "ENR is set with extIp/Port if provided":
     let
@@ -295,8 +301,8 @@ suite "Waku NetConfig":
       extPort = Port(1234)
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extIp = some(extIp),
       extPort = some(extPort),
     )
@@ -316,8 +322,8 @@ suite "Waku NetConfig":
       extPort = Port(1234)
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       dns4DomainName = some(dns4DomainName),
       extPort = some(extPort),
     )
@@ -339,8 +345,8 @@ suite "Waku NetConfig":
       extMultiAddrs = @[(ip4TcpEndPoint(extAddIp, extAddPort) & wsFlag(wssEnabled))]
 
     var netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extMultiAddrs = extMultiAddrs,
       wsEnabled = wsEnabled,
     )
@@ -358,8 +364,8 @@ suite "Waku NetConfig":
     extMultiAddrs = @[(ip4TcpEndPoint(extAddIp, extAddPort) & wsFlag(wssEnabled))]
 
     netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extMultiAddrs = extMultiAddrs,
       wssEnabled = wssEnabled,
     )
@@ -380,8 +386,8 @@ suite "Waku NetConfig":
       extMultiAddrs = @[ip4TcpEndPoint(extAddIp, extAddPort)]
 
     let netConfigRes = NetConfig.init(
-      bindIp = conf.networkConf.p2pListenAddress,
-      bindPort = conf.networkConf.p2pTcpPort,
+      bindIp = conf.endpointConf.p2pListenAddress,
+      bindPort = conf.endpointConf.p2pTcpPort,
       extMultiAddrs = extMultiAddrs,
       extMultiAddrsOnly = true,
     )

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -72,7 +72,7 @@ proc newTestWakuNode*(
     agentString = none(string),
     peerStoreCapacity = none(int),
     clusterId = DefaultClusterId,
-    shards = @[DefaultShardId],
+    activeRelayShards = @[DefaultShardId],
 ): WakuNode =
   var resolvedExtIp = extIp
 
@@ -86,7 +86,7 @@ proc newTestWakuNode*(
   var conf = defaultTestWakuConf()
 
   conf.clusterId = clusterId
-  conf.shards = shards
+  conf.activeRelayShards = activeRelayShards
 
   if dns4DomainName.isSome() and extIp.isNone():
     # If there's an error resolving the IP, an exception is thrown and test fails
@@ -114,7 +114,7 @@ proc newTestWakuNode*(
   var enrBuilder = EnrBuilder.init(nodeKey)
 
   enrBuilder.withWakuRelaySharding(
-    RelayShards(clusterId: conf.clusterId, shardIds: conf.shards)
+    RelayShards(clusterId: conf.clusterId, shardIds: conf.activeRelayShards)
   ).isOkOr:
     raise newException(Defect, "Invalid record: " & $error)
 

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -37,7 +37,7 @@ proc defaultTestWakuConfBuilder*(): WakuConfBuilder =
   builder.withRelayServiceRatio("60:40")
   builder.withMaxMessageSize("1024 KiB")
   builder.withClusterId(DefaultClusterId)
-  builder.withShards(@[DefaultShardId])
+  builder.withActiveRelayShards(@[DefaultShardId])
   builder.withRelay(true)
   builder.withRendezvous(true)
   builder.storeServiceConf.withDbMigration(false)

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -37,7 +37,7 @@ proc defaultTestWakuConfBuilder*(): WakuConfBuilder =
   builder.withRelayServiceRatio("60:40")
   builder.withMaxMessageSize("1024 KiB")
   builder.withClusterId(DefaultClusterId)
-  builder.withActiveRelayShards(@[DefaultShardId])
+  builder.withSubscribeShards(@[DefaultShardId])
   builder.withRelay(true)
   builder.withRendezvous(true)
   builder.storeServiceConf.withDbMigration(false)
@@ -72,7 +72,7 @@ proc newTestWakuNode*(
     agentString = none(string),
     peerStoreCapacity = none(int),
     clusterId = DefaultClusterId,
-    activeRelayShards = @[DefaultShardId],
+    subscribeShards = @[DefaultShardId],
 ): WakuNode =
   var resolvedExtIp = extIp
 
@@ -86,7 +86,7 @@ proc newTestWakuNode*(
   var conf = defaultTestWakuConf()
 
   conf.clusterId = clusterId
-  conf.activeRelayShards = activeRelayShards
+  conf.subscribeShards = subscribeShards
 
   if dns4DomainName.isSome() and extIp.isNone():
     # If there's an error resolving the IP, an exception is thrown and test fails
@@ -114,7 +114,7 @@ proc newTestWakuNode*(
   var enrBuilder = EnrBuilder.init(nodeKey)
 
   enrBuilder.withWakuRelaySharding(
-    RelayShards(clusterId: conf.clusterId, shardIds: conf.activeRelayShards)
+    RelayShards(clusterId: conf.clusterId, shardIds: conf.subscribeShards)
   ).isOkOr:
     raise newException(Defect, "Invalid record: " & $error)
 

--- a/tests/waku_discv5/test_waku_discv5.nim
+++ b/tests/waku_discv5/test_waku_discv5.nim
@@ -503,7 +503,7 @@ suite "Waku Discovery v5":
         waku.dynamicBootstrapNodes,
         waku.rng,
         waku.conf.nodeKey,
-        waku.conf.networkConf.p2pListenAddress,
+        waku.conf.endpointConf.p2pListenAddress,
         waku.conf.portsShift,
       )
 
@@ -534,7 +534,7 @@ suite "Waku Discovery v5":
         waku.dynamicBootstrapNodes,
         waku.rng,
         waku.conf.nodeKey,
-        waku.conf.networkConf.p2pListenAddress,
+        waku.conf.endpointConf.p2pListenAddress,
         waku.conf.portsShift,
       )
 

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -19,8 +19,9 @@ proc newTestWakuLightpushNode*(
   let
     peerManager = PeerManager.new(switch)
     wakuAutoSharding = Sharding(clusterId: 1, shardCountGenZero: 8)
-    proto =
-      WakuLightPush.new(peerManager, rng, handler, wakuAutoSharding, rateLimitSetting)
+    proto = WakuLightPush.new(
+      peerManager, rng, handler, some(wakuAutoSharding), rateLimitSetting
+    )
 
   await proto.start()
   switch.mount(proto)

--- a/tests/waku_lightpush/lightpush_utils.nim
+++ b/tests/waku_lightpush/lightpush_utils.nim
@@ -18,8 +18,9 @@ proc newTestWakuLightpushNode*(
 ): Future[WakuLightPush] {.async.} =
   let
     peerManager = PeerManager.new(switch)
-    wakuSharding = Sharding(clusterId: 1, shardCountGenZero: 8)
-    proto = WakuLightPush.new(peerManager, rng, handler, wakuSharding, rateLimitSetting)
+    wakuAutoSharding = Sharding(clusterId: 1, shardCountGenZero: 8)
+    proto =
+      WakuLightPush.new(peerManager, rng, handler, wakuAutoSharding, rateLimitSetting)
 
   await proto.start()
   switch.mount(proto)

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -657,7 +657,7 @@ suite "WakuNode - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
-    require node.mountSharding(1, 1).isOk
+    require node.mountAutoSharding(1, 1).isOk
 
     ## Given
     let
@@ -670,11 +670,11 @@ suite "WakuNode - Relay":
       ): Future[void] {.gcsafe, raises: [Defect].} =
         discard pubsubTopic
         discard message
-    assert shard == node.wakuSharding.getShard(contentTopicA).expect("Valid Topic"),
+    assert shard == node.wakuAutoSharding.getShard(contentTopicA).expect("Valid Topic"),
       "topic must use the same shard"
-    assert shard == node.wakuSharding.getShard(contentTopicB).expect("Valid Topic"),
+    assert shard == node.wakuAutoSharding.getShard(contentTopicB).expect("Valid Topic"),
       "topic must use the same shard"
-    assert shard == node.wakuSharding.getShard(contentTopicC).expect("Valid Topic"),
+    assert shard == node.wakuAutoSharding.getShard(contentTopicC).expect("Valid Topic"),
       "topic must use the same shard"
 
     ## When

--- a/tests/waku_relay/test_wakunode_relay.nim
+++ b/tests/waku_relay/test_wakunode_relay.nim
@@ -670,11 +670,14 @@ suite "WakuNode - Relay":
       ): Future[void] {.gcsafe, raises: [Defect].} =
         discard pubsubTopic
         discard message
-    assert shard == node.wakuAutoSharding.getShard(contentTopicA).expect("Valid Topic"),
+    assert shard ==
+      node.wakuAutoSharding.get().getShard(contentTopicA).expect("Valid Topic"),
       "topic must use the same shard"
-    assert shard == node.wakuAutoSharding.getShard(contentTopicB).expect("Valid Topic"),
+    assert shard ==
+      node.wakuAutoSharding.get().getShard(contentTopicB).expect("Valid Topic"),
       "topic must use the same shard"
-    assert shard == node.wakuAutoSharding.getShard(contentTopicC).expect("Valid Topic"),
+    assert shard ==
+      node.wakuAutoSharding.get().getShard(contentTopicC).expect("Valid Topic"),
       "topic must use the same shard"
 
     ## When

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -65,7 +65,7 @@ suite "Wakunode2 - Waku initialization":
   test "app properly handles dynamic port configuration":
     ## Given
     var conf = defaultTestWakuConf()
-    conf.networkConf.p2pTcpPort = Port(0)
+    conf.endpointConf.p2pTcpPort = Port(0)
 
     ## When
     var waku = Waku.new(conf).valueOr:

--- a/tests/wakunode_rest/test_rest_admin.nim
+++ b/tests/wakunode_rest/test_rest_admin.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[sequtils, strformat, net],
+  std/[sequtils, net],
   testutils/unittests,
   presto,
   presto/client as presto_client,
@@ -42,6 +42,14 @@ suite "Waku v2 Rest API - Admin":
     node2 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(60602))
     node3 = newTestWakuNode(generateSecp256k1Key(), getPrimaryIPAddr(), Port(60604))
 
+    let clusterId = 1.uint16
+    node1.mountMetadata(clusterId).isOkOr:
+      assert false, "Failed to mount metadata: " & $error
+    node2.mountMetadata(clusterId).isOkOr:
+      assert false, "Failed to mount metadata: " & $error
+    node3.mountMetadata(clusterId).isOkOr:
+      assert false, "Failed to mount metadata: " & $error
+
     await allFutures(node1.start(), node2.start(), node3.start())
     await allFutures(
       node1.mountRelay(),
@@ -56,7 +64,7 @@ suite "Waku v2 Rest API - Admin":
     ): Future[void] {.async, gcsafe.} =
       await sleepAsync(0.milliseconds)
 
-    let shard = RelayShard(clusterId: 1, shardId: 0)
+    let shard = RelayShard(clusterId: clusterId, shardId: 0)
     node1.subscribe((kind: PubsubSub, topic: $shard), simpleHandler).isOkOr:
       assert false, "Failed to subscribe to topic: " & $error
     node2.subscribe((kind: PubsubSub, topic: $shard), simpleHandler).isOkOr:

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -346,6 +346,7 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
+    require node.mountAutoSharding(1, 8).isOk
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
@@ -404,6 +405,7 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
+    require node.mountAutoSharding(1, 8).isOk
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")
@@ -469,6 +471,8 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
+    require node.mountAutoSharding(1, 8).isOk
+
     let wakuRlnConfig = WakuRlnConfig(
       dynamic: false,
       credIndex: some(1.uint),
@@ -528,6 +532,8 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
+    require node.mountAutoSharding(1, 8).isOk
+
     let wakuRlnConfig = WakuRlnConfig(
       dynamic: false,
       credIndex: some(1.uint),
@@ -641,6 +647,8 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
+    require node.mountAutoSharding(1, 8).isOk
+
     let wakuRlnConfig = WakuRlnConfig(
       dynamic: false,
       credIndex: some(1.uint),

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -296,7 +296,7 @@ suite "Waku v2 Rest API - Relay":
     await node.start()
     (await node.mountRelay()).isOkOr:
       assert false, "Failed to mount relay"
-    require node.mountSharding(1, 8).isOk
+    require node.mountAutoSharding(1, 8).isOk
 
     var restPort = Port(0)
     let restAddress = parseIpAddress("0.0.0.0")

--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -61,7 +61,7 @@ type WakuConfBuilder* = object
   clusterId: Option[uint16]
   shardingConf: Option[ShardingConfKind]
   numShardsInCluster: Option[uint16]
-  activeRelayShards: Option[seq[uint16]]
+  subscribeShards: Option[seq[uint16]]
   protectedShards: Option[seq[ProtectedShard]]
   contentTopics: Option[seq[string]]
 
@@ -151,8 +151,8 @@ proc withShardingConf*(b: var WakuConfBuilder, shardingConf: ShardingConfKind) =
 proc withNumShardsInCluster*(b: var WakuConfBuilder, numShardsInCluster: uint16) =
   b.numShardsInCluster = some(numShardsInCluster)
 
-proc withActiveRelayShards*(b: var WakuConfBuilder, shards: seq[uint16]) =
-  b.activeRelayShards = some(shards)
+proc withSubscribeShards*(b: var WakuConfBuilder, shards: seq[uint16]) =
+  b.subscribeShards = some(shards)
 
 proc withProtectedShards*(
     b: var WakuConfBuilder, protectedShards: seq[ProtectedShard]
@@ -445,9 +445,9 @@ proc build*(
       warn("No sharding conf specified, defaulting to static")
       ShardingConf(kind: StaticSharding)
 
-  let activeRelayShards =
-    if builder.activeRelayShards.isSome():
-      builder.activeRelayShards.get()
+  let subscribeShards =
+    if builder.subscribeShards.isSome():
+      builder.subscribeShards.get()
     else:
       case shardingConf.kind
       of AutoSharding:
@@ -617,7 +617,7 @@ proc build*(
     clusterId: clusterId,
     shardingConf: shardingConf,
     contentTopics: contentTopics,
-    activeRelayShards: activeRelayShards,
+    subscribeShards: subscribeShards,
     protectedShards: protectedShards,
     relay: relay,
     lightPush: lightPush,

--- a/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/waku/factory/conf_builder/waku_conf_builder.nim
@@ -601,7 +601,7 @@ proc build*(
     logLevel: logLevel,
     logFormat: logFormat,
     # TODO: Separate builders
-    networkConf: NetworkConfig(
+    endpointConf: EndpointConf(
       natStrategy: natStrategy,
       p2pTcpPort: p2pTcpPort,
       dns4DomainName: dns4DomainName,

--- a/waku/factory/conf_builder/web_socket_conf_builder.nim
+++ b/waku/factory/conf_builder/web_socket_conf_builder.nim
@@ -1,5 +1,4 @@
 import chronicles, std/[net, options], results
-import ../networks_config
 import waku/factory/waku_conf
 
 logScope:

--- a/waku/factory/conf_builder/web_socket_conf_builder.nim
+++ b/waku/factory/conf_builder/web_socket_conf_builder.nim
@@ -1,5 +1,6 @@
 import chronicles, std/[net, options], results
 import ../networks_config
+import waku/factory/waku_conf
 
 logScope:
   topics = "waku conf builder websocket"

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -858,9 +858,9 @@ proc toKeystoreGeneratorConf*(n: WakuNodeConf): RlnKeystoreGeneratorConf =
 proc toInspectRlnDbConf*(n: WakuNodeConf): InspectRlnDbConf =
   return InspectRlnDbConf(treePath: n.treePath)
 
-proc toClusterConf(
+proc toNetworkConf(
     preset: string, clusterId: Option[uint16]
-): ConfResult[Option[ClusterConf]] =
+): ConfResult[Option[NetworkConf]] =
   var lcPreset = toLowerAscii(preset)
   if clusterId.isSome() and clusterId.get() == 1:
     warn(
@@ -870,9 +870,9 @@ proc toClusterConf(
 
   case lcPreset
   of "":
-    ok(none(ClusterConf))
+    ok(none(NetworkConf))
   of "twn":
-    ok(some(ClusterConf.TheWakuNetworkConf()))
+    ok(some(NetworkConf.TheWakuNetworkConf()))
   else:
     err("Invalid --preset value passed: " & lcPreset)
 
@@ -909,11 +909,11 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   b.withProtectedShards(n.protectedShards)
   b.withClusterId(n.clusterId)
 
-  let clusterConf = toClusterConf(n.preset, some(n.clusterId)).valueOr:
+  let networkConf = toNetworkConf(n.preset, some(n.clusterId)).valueOr:
     return err("Error determining cluster from preset: " & $error)
 
-  if clusterConf.isSome():
-    b.withClusterConf(clusterConf.get())
+  if networkConf.isSome():
+    b.withNetworkConf(networkConf.get())
 
   b.withAgentString(n.agentString)
 

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -950,9 +950,9 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
 
   if n.numShardsInNetwork != 0:
     b.withNumShardsInCluster(n.numShardsInNetwork)
-    b.withShardingConf(Auto)
+    b.withShardingConf(AutoSharding)
   else:
-    b.withShardingConf(Static)
+    b.withShardingConf(StaticSharding)
 
   b.withActiveRelayShards(n.shards)
   b.withContentTopics(n.contentTopics)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -950,7 +950,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   if n.numShardsInNetwork != 0:
     b.withNumShardsInCluster(n.numShardsInNetwork)
 
-  b.withShards(n.shards)
+  b.withActiveRelayShards(n.shards)
   b.withContentTopics(n.contentTopics)
 
   b.storeServiceConf.withEnabled(n.store)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -314,29 +314,16 @@ hence would have reachability issues.""",
       name: "staticnode"
     .}: seq[string]
 
-    # TODO: This is trying to do too much, this should only be used for autosharding, which itself should be configurable
-    # If numShardsInNetwork is not set, we use the number of shards configured as numShardsInNetwork
     numShardsInNetwork* {.
       desc:
         "Enables autosharding and set number of shards in the cluster, set to `0` to use static sharding",
-      defaultValue: 0,
+      defaultValue: 1,
       name: "num-shards-in-network"
     .}: uint16
 
     shards* {.
       desc:
-        "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated.",
-      defaultValue:
-        @[
-          uint16(0),
-          uint16(1),
-          uint16(2),
-          uint16(3),
-          uint16(4),
-          uint16(5),
-          uint16(6),
-          uint16(7),
-        ],
+        "Shards index to subscribe to [0..NUM_SHARDS_IN_NETWORK-1]. Argument may be repeated. Subscribes to all shards by default in auto-sharding, no shard for static sharding",
       name: "shard"
     .}: seq[uint16]
 
@@ -954,7 +941,11 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   else:
     b.withShardingConf(StaticSharding)
 
-  b.withSubscribeShards(n.shards)
+  # It is not possible to pass an empty sequence on the CLI
+  # If this is empty, it means the user did not specify any shards
+  if n.shards.len != 0:
+    b.withSubscribeShards(n.shards)
+
   b.withContentTopics(n.contentTopics)
 
   b.storeServiceConf.withEnabled(n.store)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -954,7 +954,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   else:
     b.withShardingConf(StaticSharding)
 
-  b.withActiveRelayShards(n.shards)
+  b.withSubscribeShards(n.shards)
   b.withContentTopics(n.contentTopics)
 
   b.storeServiceConf.withEnabled(n.store)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -317,10 +317,11 @@ hence would have reachability issues.""",
     # TODO: This is trying to do too much, this should only be used for autosharding, which itself should be configurable
     # If numShardsInNetwork is not set, we use the number of shards configured as numShardsInNetwork
     numShardsInNetwork* {.
-      desc: "Number of shards in the network",
+      desc:
+        "Enables autosharding and set number of shards in the cluster, set to `0` to use static sharding",
       defaultValue: 0,
       name: "num-shards-in-network"
-    .}: uint32
+    .}: uint16
 
     shards* {.
       desc:
@@ -949,6 +950,9 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
 
   if n.numShardsInNetwork != 0:
     b.withNumShardsInCluster(n.numShardsInNetwork)
+    b.withShardingConf(Auto)
+  else:
+    b.withShardingConf(Static)
 
   b.withActiveRelayShards(n.shards)
   b.withContentTopics(n.contentTopics)

--- a/waku/factory/external_config.nim
+++ b/waku/factory/external_config.nim
@@ -948,7 +948,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
   b.withStaticNodes(n.staticNodes)
 
   if n.numShardsInNetwork != 0:
-    b.withNumShardsInNetwork(n.numShardsInNetwork)
+    b.withNumShardsInCluster(n.numShardsInNetwork)
 
   b.withShards(n.shards)
   b.withContentTopics(n.contentTopics)

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -64,7 +64,7 @@ proc dnsResolve*(
 # TODO: Reduce number of parameters, can be done once the same is done on Netconfig.init
 proc networkConfiguration*(
     clusterId: uint16,
-    conf: NetworkConfig,
+    conf: EndpointConf,
     discv5Conf: Option[Discv5Conf],
     webSocketConf: Option[WebSocketConf],
     wakuFlags: CapabilitiesBitfield,

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -29,7 +29,7 @@ proc enrConfiguration*(
   enrBuilder.withMultiaddrs(netConfig.enrMultiaddrs)
 
   enrBuilder.withWakuRelaySharding(
-    RelayShards(clusterId: conf.clusterId, shardIds: conf.shards)
+    RelayShards(clusterId: conf.clusterId, shardIds: conf.activeRelayShards)
   ).isOkOr:
     return err("could not initialize ENR with shards")
 
@@ -143,11 +143,3 @@ proc networkConfiguration*(
   )
 
   return netConfigRes
-
-# TODO: numShardsInNetwork should be mandatory with autosharding, and unneeded otherwise
-proc getNumShardsInNetwork*(conf: WakuConf): uint32 =
-  if conf.numShardsInNetwork != 0:
-    return conf.numShardsInNetwork
-  # If conf.numShardsInNetwork is not set, use 1024 - the maximum possible as per the static sharding spec
-  # https://github.com/waku-org/specs/blob/master/standards/core/relay-sharding.md#static-sharding
-  return uint32(MaxShardIndex + 1)

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -23,7 +23,7 @@ proc enrConfiguration*(
   enrBuilder.withMultiaddrs(netConfig.enrMultiaddrs)
 
   enrBuilder.withWakuRelaySharding(
-    RelayShards(clusterId: conf.clusterId, shardIds: conf.activeRelayShards)
+    RelayShards(clusterId: conf.clusterId, shardIds: conf.subscribeShards)
   ).isOkOr:
     return err("could not initialize ENR with shards")
 

--- a/waku/factory/internal_config.nim
+++ b/waku/factory/internal_config.nim
@@ -6,13 +6,7 @@ import
   libp2p/nameresolving/dnsresolver,
   std/[options, sequtils, net],
   results
-import
-  ../common/utils/nat,
-  ../node/net_config,
-  ../waku_enr,
-  ../waku_core,
-  ./waku_conf,
-  ./networks_config
+import ../common/utils/nat, ../node/net_config, ../waku_enr, ../waku_core, ./waku_conf
 
 proc enrConfiguration*(
     conf: WakuConf, netConfig: NetConfig

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -7,14 +7,14 @@ logScope:
 
 type
   ShardingConfKind* = enum
-    Auto
-    Static
+    AutoSharding
+    StaticSharding
 
   ShardingConf* = object
     case kind*: ShardingConfKind
-    of Auto:
+    of AutoSharding:
       numShardsInCluster*: uint16
-    of Static:
+    of StaticSharding:
       discard
 
 type NetworkConf* = object
@@ -44,7 +44,7 @@ proc TheWakuNetworkConf*(T: type NetworkConf): NetworkConf =
     rlnRelayChainId: RelayChainId,
     rlnEpochSizeSec: 600,
     rlnRelayUserMessageLimit: 100,
-    shardingConf: ShardingConf(kind: Auto, numShardsInCluster: 8),
+    shardingConf: ShardingConf(kind: AutoSharding, numShardsInCluster: 8),
     discv5Discovery: true,
     discv5BootstrapNodes:
       @[
@@ -58,9 +58,9 @@ proc validateShards*(
     shardingConf: ShardingConf, shards: seq[uint16]
 ): Result[void, string] =
   case shardingConf.kind
-  of Static:
+  of StaticSharding:
     return ok()
-  of Auto:
+  of AutoSharding:
     let numShardsInCluster = shardingConf.numShardsInCluster
     for shard in shards:
       if shard >= numShardsInCluster:

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import chronicles, results, stint, std/[nativesockets, options]
+import chronicles, results, stint
 
 logScope:
   topics = "waku networks conf"

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -10,9 +10,7 @@ type WebSocketConf* = object
   port*: Port
   secureConf*: Option[WebSocketSecureConf]
 
-# TODO: Rename this type to match file name
-
-type ClusterConf* = object
+type NetworkConf* = object
   maxMessageSize*: string # TODO: static convert to a uint64
   clusterId*: uint16
   rlnRelay*: bool
@@ -29,9 +27,9 @@ type ClusterConf* = object
 # cluster-id=1 (aka The Waku Network)
 # Cluster configuration corresponding to The Waku Network. Note that it
 # overrides existing cli configuration
-proc TheWakuNetworkConf*(T: type ClusterConf): ClusterConf =
+proc TheWakuNetworkConf*(T: type NetworkConf): NetworkConf =
   const RelayChainId = 59141'u256
-  return ClusterConf(
+  return NetworkConf(
     maxMessageSize: "150KiB",
     clusterId: 1,
     rlnRelay: true,

--- a/waku/factory/networks_config.nim
+++ b/waku/factory/networks_config.nim
@@ -1,14 +1,21 @@
 {.push raises: [].}
 
-import stint, std/[nativesockets, options]
+import chronicles, results, stint, std/[nativesockets, options]
 
-type WebSocketSecureConf* {.requiresInit.} = object
-  keyPath*: string
-  certPath*: string
+logScope:
+  topics = "waku networks conf"
 
-type WebSocketConf* = object
-  port*: Port
-  secureConf*: Option[WebSocketSecureConf]
+type
+  ShardingConfKind* = enum
+    Auto
+    Static
+
+  ShardingConf* = object
+    case kind*: ShardingConfKind
+    of Auto:
+      numShardsInCluster*: uint16
+    of Static:
+      discard
 
 type NetworkConf* = object
   maxMessageSize*: string # TODO: static convert to a uint64
@@ -19,8 +26,7 @@ type NetworkConf* = object
   rlnRelayDynamic*: bool
   rlnEpochSizeSec*: uint64
   rlnRelayUserMessageLimit*: uint64
-  # TODO: should be uint16 like the `shards` parameter
-  numShardsInNetwork*: uint32
+  shardingConf*: ShardingConf
   discv5Discovery*: bool
   discv5BootstrapNodes*: seq[string]
 
@@ -38,7 +44,7 @@ proc TheWakuNetworkConf*(T: type NetworkConf): NetworkConf =
     rlnRelayChainId: RelayChainId,
     rlnEpochSizeSec: 600,
     rlnRelayUserMessageLimit: 100,
-    numShardsInNetwork: 8,
+    shardingConf: ShardingConf(kind: Auto, numShardsInCluster: 8),
     discv5Discovery: true,
     discv5BootstrapNodes:
       @[
@@ -47,3 +53,21 @@ proc TheWakuNetworkConf*(T: type NetworkConf): NetworkConf =
         "enr:-QEkuEBfEzJm_kigJ2HoSS_RBFJYhKHocGdkhhBr6jSUAWjLdFPp6Pj1l4yiTQp7TGHyu1kC6FyaU573VN8klLsEm-XuAYJpZIJ2NIJpcIQI2SVcim11bHRpYWRkcnO4bgA0Ni9ub2RlLTAxLmFjLWNuLWhvbmdrb25nLWMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwA2Ni9ub2RlLTAxLmFjLWNuLWhvbmdrb25nLWMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQOwsS69tgD7u1K50r5-qG5hweuTwa0W26aYPnvivpNlrYN0Y3CCdl-DdWRwgiMohXdha3UyDw",
       ],
   )
+
+proc validateShards*(
+    shardingConf: ShardingConf, shards: seq[uint16]
+): Result[void, string] =
+  case shardingConf.kind
+  of Static:
+    return ok()
+  of Auto:
+    let numShardsInCluster = shardingConf.numShardsInCluster
+    for shard in shards:
+      if shard >= numShardsInCluster:
+        let msg =
+          "validateShards invalid shard: " & $shard & " when numShardsInCluster: " &
+          $numShardsInCluster
+        error "validateShards failed", error = msg
+        return err(msg)
+
+  return ok()

--- a/waku/factory/node_factory.nim
+++ b/waku/factory/node_factory.nim
@@ -301,7 +301,7 @@ proc setupProtocols(
   debug "Shards created from content topics",
     contentTopics = conf.contentTopics, shards = autoShards
 
-  let confShards = conf.activeRelayShards.mapIt(
+  let confShards = conf.subscribeShards.mapIt(
     RelayShard(clusterId: conf.clusterId, shardId: uint16(it))
   )
   let shards = confShards & autoShards
@@ -319,7 +319,7 @@ proc setupProtocols(
     # Add validation keys to protected topics
     var subscribedProtectedShards: seq[ProtectedShard]
     for shardKey in conf.protectedShards:
-      if shardKey.shard notin conf.activeRelayShards:
+      if shardKey.shard notin conf.subscribeShards:
         warn "protected shard not in subscribed shards, skipping adding validator",
           protectedShard = shardKey.shard, subscribedShards = shards
         continue

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -249,14 +249,14 @@ proc getRunningNetConfig(waku: ptr Waku): Result[NetConfig, string] =
     return err("Could not retrieve ports: " & error)
 
   if tcpPort.isSome():
-    conf.networkConf.p2pTcpPort = tcpPort.get()
+    conf.endpointConf.p2pTcpPort = tcpPort.get()
 
   if websocketPort.isSome() and conf.webSocketConf.isSome():
     conf.webSocketConf.get().port = websocketPort.get()
 
   # Rebuild NetConfig with bound port values
-  let netConf = networkConfiguration(
-    conf.clusterId, conf.networkConf, conf.discv5Conf, conf.webSocketConf,
+  let netConf = endpointConfiguration(
+    conf.clusterId, conf.endpointConf, conf.discv5Conf, conf.webSocketConf,
     conf.wakuFlags, conf.dnsAddrsNameServers, conf.portsShift, clientId,
   ).valueOr:
     return err("Could not update NetConfig: " & error)
@@ -306,7 +306,7 @@ proc updateAddressInENR(waku: ptr Waku): Result[void, string] =
 
 proc updateWaku(waku: ptr Waku): Result[void, string] =
   let conf = waku[].conf
-  if conf.networkConf.p2pTcpPort == Port(0) or
+  if conf.endpointConf.p2pTcpPort == Port(0) or
       (conf.websocketConf.isSome() and conf.websocketConf.get.port == Port(0)):
     updateEnr(waku).isOkOr:
       return err("error calling updateEnr: " & $error)
@@ -389,7 +389,7 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async.} =
       waku.dynamicBootstrapNodes,
       waku.rng,
       conf.nodeKey,
-      conf.networkConf.p2pListenAddress,
+      conf.endpointConf.p2pListenAddress,
       conf.portsShift,
     )
 

--- a/waku/factory/waku.nim
+++ b/waku/factory/waku.nim
@@ -130,7 +130,7 @@ proc setupAppCallbacks(
     let autoShards = node.getAutoshards(conf.contentTopics).valueOr:
       return err("Could not get autoshards: " & error)
 
-    let confShards = conf.activeRelayShards.mapIt(
+    let confShards = conf.subscribeShards.mapIt(
       RelayShard(clusterId: conf.clusterId, shardId: uint16(it))
     )
     let shards = confShards & autoShards
@@ -414,7 +414,7 @@ proc startWaku*(waku: ptr Waku): Future[Result[void, string]] {.async.} =
       conf.relay,
       conf.lightPush,
       conf.clusterId,
-      conf.activeRelayShards,
+      conf.subscribeShards,
       conf.contentTopics,
     ).isOkOr:
       return err ("Starting protocols support REST server failed: " & $error)

--- a/waku/factory/waku_conf.nim
+++ b/waku/factory/waku_conf.nim
@@ -76,7 +76,7 @@ type WakuConf* {.requiresInit.} = ref object
   nodeKey*: crypto.PrivateKey
 
   clusterId*: uint16
-  activeRelayShards*: seq[uint16]
+  subscribeShards*: seq[uint16]
   protectedShards*: seq[ProtectedShard]
 
   shardingConf*: ShardingConf
@@ -149,7 +149,7 @@ proc logConf*(conf: WakuConf) =
 
   info "Configuration. Network", cluster = conf.clusterId
 
-  for shard in conf.activeRelayShards:
+  for shard in conf.subscribeShards:
     info "Configuration. Active Relay Shards", shard = shard
 
   if conf.discv5Conf.isSome():
@@ -226,6 +226,6 @@ proc validateNoEmptyStrings(wakuConf: WakuConf): Result[void, string] =
 
 proc validate*(wakuConf: WakuConf): Result[void, string] =
   ?wakuConf.validateNodeKey()
-  ?wakuConf.shardingConf.validateShards(wakuConf.activeRelayShards)
+  ?wakuConf.shardingConf.validateShards(wakuConf.subscribeShards)
   ?wakuConf.validateNoEmptyStrings()
   return ok()

--- a/waku/factory/waku_conf.nim
+++ b/waku/factory/waku_conf.nim
@@ -50,7 +50,7 @@ type FilterServiceConf* {.requiresInit.} = object
   subscriptionTimeout*: uint16
   maxCriteria*: uint32
 
-type NetworkConfig* = object # TODO: make enum
+type EndpointConf* = object # TODO: make enum
   natStrategy*: string
   p2pTcpPort*: Port
   dns4DomainName*: Option[string]
@@ -95,7 +95,7 @@ type WakuConf* {.requiresInit.} = ref object
 
   portsShift*: uint16
   dnsAddrsNameServers*: seq[IpAddress]
-  networkConf*: NetworkConfig
+  endpointConf*: EndpointConf
   wakuFlags*: CapabilitiesBitfield
 
   # TODO: could probably make it a `PeerRemoteInfo`
@@ -183,8 +183,8 @@ proc validateShards(wakuConf: WakuConf): Result[void, string] =
   return ok()
 
 proc validateNoEmptyStrings(wakuConf: WakuConf): Result[void, string] =
-  if wakuConf.networkConf.dns4DomainName.isSome() and
-      isEmptyOrWhiteSpace(wakuConf.networkConf.dns4DomainName.get().string):
+  if wakuConf.endpointConf.dns4DomainName.isSome() and
+      isEmptyOrWhiteSpace(wakuConf.endpointConf.dns4DomainName.get().string):
     return err("dns4-domain-name is an empty string, set it to none(string) instead")
 
   if isEmptyOrWhiteSpace(wakuConf.relayServiceRatio):

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -329,9 +329,9 @@ proc subscribe*(
             return err("Autosharding error: " & error)
         ($shard, some(subscription.topic))
       else:
-        let msg =
+        return err(
           "Static sharding is used, relay subscriptions must specify a pubsub topic"
-        return err("Cannot proceed with content topic subscription")
+        )
     of PubsubSub:
       (subscription.topic, none(ContentTopic))
     else:
@@ -364,9 +364,9 @@ proc unsubscribe*(
             return err("Autosharding error: " & error)
         ($shard, some(subscription.topic))
       else:
-        let msg =
+        return err(
           "Static sharding is used, relay subscriptions must specify a pubsub topic"
-        return err("Cannot proceed with content topic subscription")
+        )
     of PubsubUnsub:
       (subscription.topic, none(ContentTopic))
     else:

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -241,6 +241,11 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
     let shard = shardId.valueOr:
       return RestApiResponse.badRequest(fmt("Invalid shardId: {error}"))
 
+    if node.wakuMetadata.isNil():
+      return RestApiResponse.serviceUnavailable(
+        "Error: Metadata Protocol is not mounted to the node"
+      )
+
     if node.wakuRelay.isNil():
       return RestApiResponse.serviceUnavailable(
         "Error: Relay Protocol is not mounted to the node"
@@ -285,6 +290,11 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
   ) -> RestApiResponse:
     let shard = shardId.valueOr:
       return RestApiResponse.badRequest(fmt("Invalid shardId: {error}"))
+
+    if node.wakuMetadata.isNil():
+      return RestApiResponse.serviceUnavailable(
+        "Error: Metadata Protocol is not mounted to the node"
+      )
 
     if node.wakuRelay.isNil():
       return RestApiResponse.serviceUnavailable(

--- a/waku/waku_api/rest/admin/handlers.nim
+++ b/waku/waku_api/rest/admin/handlers.nim
@@ -246,8 +246,10 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
         "Error: Relay Protocol is not mounted to the node"
       )
 
-    let topic =
-      toPubsubTopic(RelayShard(clusterId: node.wakuSharding.clusterId, shardId: shard))
+    # TODO: clusterId and shards should be uint16 across all codebase and probably be defined as a type
+    let topic = toPubsubTopic(
+      RelayShard(clusterId: node.wakuMetadata.clusterId.uint16, shardId: shard)
+    )
     let pubsubPeers =
       node.wakuRelay.getConnectedPubSubPeers(topic).get(initHashSet[PubSubPeer](0))
     let relayPeer = PeersOfShard(
@@ -289,8 +291,9 @@ proc installAdminV1GetPeersHandler(router: var RestRouter, node: WakuNode) =
         "Error: Relay Protocol is not mounted to the node"
       )
 
-    let topic =
-      toPubsubTopic(RelayShard(clusterId: node.wakuSharding.clusterId, shardId: shard))
+    let topic = toPubsubTopic(
+      RelayShard(clusterId: node.wakuMetadata.clusterId.uint16, shardId: shard)
+    )
     let peers =
       node.wakuRelay.getPubSubPeersInMesh(topic).get(initHashSet[PubSubPeer](0))
     let relayPeer = PeersOfShard(

--- a/waku/waku_core/topics/content_topic.nim
+++ b/waku/waku_core/topics/content_topic.nim
@@ -122,6 +122,18 @@ proc parse*(
       "Invalid content topic structure. Expected either /<application>/<version>/<topic-name>/<encoding> or /<gen>/<application>/<version>/<topic-name>/<encoding>"
     return err(ParsingError.invalidFormat(errMsg))
 
+proc parse*(
+    T: type NsContentTopic, topics: seq[ContentTopic]
+): ParsingResult[seq[NsContentTopic]] =
+  var result: seq[NsContentTopic] = @[]
+  for contentTopic in topics:
+    let res = NsContentTopic.parse(contentTopic)
+    if res.isErr():
+      let error: ParsingError = res.error
+      return ParsingResult[seq[NsContentTopic]].err(error)
+    result.add(res.value)
+  return ParsingResult[seq[NsContentTopic]].ok(result)
+
 # Content topic compatibility
 
 converter toContentTopic*(topic: NsContentTopic): ContentTopic =

--- a/waku/waku_core/topics/content_topic.nim
+++ b/waku/waku_core/topics/content_topic.nim
@@ -125,14 +125,14 @@ proc parse*(
 proc parse*(
     T: type NsContentTopic, topics: seq[ContentTopic]
 ): ParsingResult[seq[NsContentTopic]] =
-  var result: seq[NsContentTopic] = @[]
+  var res: seq[NsContentTopic] = @[]
   for contentTopic in topics:
-    let res = NsContentTopic.parse(contentTopic)
-    if res.isErr():
-      let error: ParsingError = res.error
+    let parseRes = NsContentTopic.parse(contentTopic)
+    if parseRes.isErr():
+      let error: ParsingError = parseRes.error
       return ParsingResult[seq[NsContentTopic]].err(error)
-    result.add(res.value)
-  return ParsingResult[seq[NsContentTopic]].ok(result)
+    res.add(parseRes.value)
+  return ParsingResult[seq[NsContentTopic]].ok(res)
 
 # Content topic compatibility
 

--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -69,13 +69,8 @@ proc getShardsFromContentTopics*(
 
   var topicMap = initTable[RelayShard, seq[NsContentTopic]]()
   for content in nsContentTopics:
-    let shardsRes = s.getShard(content)
-
-    let shard =
-      if shardsRes.isErr():
-        return err("Cannot deduce shard from content topic: " & $shardsRes.error)
-      else:
-        shardsRes.get()
+    let shard = s.getShard(content).valueOr:
+      return err("Cannot deduce shard from content topic: " & $error)
 
     if not topicMap.hasKey(shard):
       topicMap[shard] = @[]

--- a/waku/waku_core/topics/sharding.nim
+++ b/waku/waku_core/topics/sharding.nim
@@ -8,6 +8,7 @@ import nimcrypto, std/options, std/tables, stew/endians2, results, stew/byteutil
 
 import ./content_topic, ./pubsub_topic
 
+# TODO: this is autosharding, not just "sharding"
 type Sharding* = object
   clusterId*: uint16
   # TODO: generations could be stored in a table here
@@ -50,6 +51,7 @@ proc getShard*(s: Sharding, topic: ContentTopic): Result[RelayShard, string] =
 
   ok(shard)
 
+# TODO: Can be simplified by putting shards as first class citizen
 proc parseSharding*(
     s: Sharding,
     pubsubTopic: Option[PubsubTopic],

--- a/waku/waku_metadata/protocol.nim
+++ b/waku/waku_metadata/protocol.nim
@@ -29,7 +29,7 @@ proc respond(
     m: WakuMetadata, conn: Connection
 ): Future[Result[void, string]] {.async, gcsafe.} =
   let response =
-    WakuMetadataResponse(clusterId: some(m.clusterId), shards: toSeq(m.shards))
+    WakuMetadataResponse(clusterId: some(m.clusterId.uint32), shards: toSeq(m.shards))
 
   let res = catch:
     await conn.writeLP(response.encode().buffer)


### PR DESCRIPTION
# Description

Make it explicit that the node can either be configured with _auto sharding_ or _static sharding_. Treat static sharding as an happy path (prev. was implicit error or do-nothing-happy).
Make it clear that without auto-sharding, pubsub topics can't be derived from content topics.

Do so by improving the internal node configuration and make it clear that there are two options, and that the _number of shards in the network_ is only needed for auto sharding.

Also proceed with a number of naming improvement, as per https://github.com/waku-org/specs/pull/65/

- Cluster Conf is actually a (Waku) network conf - as previously mentioned by @ivansete-status in other pr
- tcp/ip "network" conf is renamed to "endpoint conf" to avoid name clashing

Some refactoring done along the way.

# Changes

<!-- List of detailed changes -->

- [x] Auto sharding is enabled by default, with `1` shard in network
- [x] new `shards` (or `subscribeShards`) defaults:
  - auto sharding: all shards
  - static sharding: no shards (because we cannot guess the shard numbers)
- [x] cluster conf renamed to network conf
- [x] sharding conf is made explicit static vs auto, number of shards in network is only useful for autosharding
- [x] conf `shards` is actually the shards we want relay to subscribe too, so rename accordingly
- [x] use `uint16` for cluster id and shard id more (but not totally) consistently across the code base.
- [x] move `WebSocketConf` to the right place 

# Follow-up changes

- probably remove `activeRelayShards` in config, in favour of having `wakunode2` just automatically subscribe to the shards passed on the CLI
- Number of TODOs left in code
- define a proper type for cluster id and shard ids

<!--
## How to test

1.
1.
1.

-->


## Issue

- https://github.com/waku-org/nwaku/issues/3349
- https://github.com/waku-org/nwaku/issues/3493