### PR TITLE
wip: remove more pubsubtopic usage

### DIFF
--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -521,7 +521,7 @@ proc mountFilterClient*(node: WakuNode) {.async: (raises: []).} =
 
 proc filterSubscribe*(
     node: WakuNode,
-    pubsubTopic: Option[PubsubTopic],
+    shard: Option[RelayShard],
     contentTopics: ContentTopic | seq[ContentTopic],
     peer: RemotePeerInfo | string,
 ): Future[FilterSubscribeResult] {.async: (raises: []).} =
@@ -603,6 +603,15 @@ proc filterSubscribe*(
 
     # return the last error or ok
     return subRes
+
+# proc filterSubscribe* {.deprecated: "Pass a shard instead of a pubsubtopic".} (
+#     node: WakuNode,
+#     pubsubTopic: Option[PubsubTopic],
+#     contentTopics: ContentTopic | seq[ContentTopic],
+#     peer: RemotePeerInfo | string,
+# ): Future[FilterSubscribeResult] {.async: (raises: []).} =
+
+#   echo "TODO"
 
 proc filterUnsubscribe*(
     node: WakuNode,

--- a/waku/waku_core/message/digest.nim
+++ b/waku/waku_core/message/digest.nim
@@ -59,6 +59,9 @@ proc computeMessageHash*(pubsubTopic: PubsubTopic, msg: WakuMessage): WakuMessag
 
   return ctx.finish() # Computes the hash
 
+proc computeMessageHash*(shard: RelayShard, msg: WakuMessage): WakuMessageHash =
+  return computeMessageHash(shard.toPubsubTopic(), msg)
+
 proc cmp*(x, y: WakuMessageHash): int =
   if x < y:
     return -1

--- a/waku/waku_filter_v2/rpc.nim
+++ b/waku/waku_filter_v2/rpc.nim
@@ -28,6 +28,11 @@ type
 
 # Convenience functions
 
+proc init*(
+    T: type MessagePush, shard: RelayShard, wakuMessage: WakuMessage
+): MessagePush =
+  MessagePush(wakuMessage: wakuMessage, pubsubTopic: shard.toPubsubTopic())
+
 proc ping*(T: type FilterSubscribeRequest, requestId: string): T =
   FilterSubscribeRequest(requestId: requestId, filterSubscribeType: SUBSCRIBER_PING)
 

--- a/waku/waku_filter_v2/subscriptions.nim
+++ b/waku/waku_filter_v2/subscriptions.nim
@@ -19,8 +19,8 @@ const
   MessageCacheTTL* = 2.minutes
 
 type
-  # a single filter criterion is fully defined by a pubsub topic and content topic
-  FilterCriterion* = tuple[pubsubTopic: PubsubTopic, contentTopic: ContentTopic]
+  # a single filter criterion is fully defined by a shard and content topic
+  FilterCriterion* = tuple[shard: RelayShard, contentTopic: ContentTopic]
 
   FilterCriteria* = HashSet[FilterCriterion] # a sequence of filter criteria
 
@@ -74,9 +74,9 @@ proc getPeerSubscriptions*(
   return subscribedContentTopics
 
 proc findSubscribedPeers*(
-    s: FilterSubscriptions, pubsubTopic: PubsubTopic, contentTopic: ContentTopic
+    s: FilterSubscriptions, shard: RelayShard, contentTopic: ContentTopic
 ): seq[PeerID] =
-  let filterCriterion: FilterCriterion = (pubsubTopic, contentTopic)
+  let filterCriterion: FilterCriterion = (shard, contentTopic)
 
   var foundPeers: seq[PeerID] = @[]
   # only peers subscribed to criteria and with legit subscription is counted


### PR DESCRIPTION
# Description

Remove more pubsub topic usage mid code.

I actually realize I should start with relay instead.

The main reason is that pubsub topic are not strongly typed, so there is always doubt on whether it can match a shard/cluster.

The intent would be to only have pubsub topic near the wire, and use shards every where.

Ultimately, we could even remove pubsub topic from the wire.

Let me know how you feel on the concept before I spend more time on it.

# Changes

<!-- List of detailed changes -->

- [ ] ...
- [ ] ...

<!--
## How to test

1.
1.
1.

-->


<!--
## Issue

closes #
-->