### PR TITLE
chore: use distinct type for Light push status codes

### DIFF
--- a/tests/node/test_wakunode_lightpush.nim
+++ b/tests/node/test_wakunode_lightpush.nim
@@ -76,7 +76,7 @@ suite "Waku Lightpush - End To End":
       # Then the message is not relayed but not due to RLN
       assert publishResponse.isErr(), "We expect an error response"
 
-      assert (publishResponse.error.code == NO_PEERS_TO_RELAY),
+      assert (publishResponse.error.code == LightPushErrorCode.NO_PEERS_TO_RELAY),
         "incorrect error response"
 
   suite "Waku LightPush Validation Tests":
@@ -93,7 +93,7 @@ suite "Waku Lightpush - End To End":
 
       check:
         publishResponse.isErr()
-        publishResponse.error.code == INVALID_MESSAGE_ERROR
+        publishResponse.error.code == LightPushErrorCode.INVALID_MESSAGE
         publishResponse.error.desc ==
           some(fmt"Message size exceeded maximum of {DefaultMaxWakuMessageSize} bytes")
 
@@ -168,7 +168,7 @@ suite "RLN Proofs as a Lightpush Service":
 
       # Then the message is not relayed but not due to RLN
       assert publishResponse.isErr(), "We expect an error response"
-      check publishResponse.error.code == NO_PEERS_TO_RELAY
+      check publishResponse.error.code == LightPushErrorCode.NO_PEERS_TO_RELAY
 
 suite "Waku Lightpush message delivery":
   asyncTest "lightpush message flow succeed":

--- a/tests/waku_lightpush/test_client.nim
+++ b/tests/waku_lightpush/test_client.nim
@@ -43,7 +43,7 @@ suite "Waku Lightpush Client":
       let msgLen = message.encode().buffer.len
       if msgLen > int(DefaultMaxWakuMessageSize) + 64 * 1024:
         return lighpushErrorResult(
-          ErrorCode.PAYLOAD_TOO_LARGE, "length greater than maxMessageSize"
+          LightPushErrorCode.PAYLOAD_TOO_LARGE, "length greater than maxMessageSize"
         )
       handlerFuture.complete((pubsubTopic, message))
       # return that we published the message to 1 peer.
@@ -264,7 +264,7 @@ suite "Waku Lightpush Client":
       # Then the message is not received by the server
       check:
         publishResponse5.isErr()
-        publishResponse5.error.code == ErrorCode.PAYLOAD_TOO_LARGE
+        publishResponse5.error.code == LightPushErrorCode.PAYLOAD_TOO_LARGE
         (await handlerFuture.waitForResult()).isErr()
 
     asyncTest "Invalid Encoding Payload":
@@ -277,7 +277,7 @@ suite "Waku Lightpush Client":
       # And the error is returned
       check:
         publishResponse.requestId == "N/A"
-        publishResponse.statusCode == ErrorCode.BAD_REQUEST
+        publishResponse.statusCode == LightPushErrorCode.BAD_REQUEST
         publishResponse.statusDesc.isSome()
         scanf(publishResponse.statusDesc.get(), decodeRpcFailure)
 
@@ -290,7 +290,7 @@ suite "Waku Lightpush Client":
             peer: PeerId, pubsubTopic: PubsubTopic, message: WakuMessage
         ): Future[WakuLightPushResult] {.async.} =
           handlerFuture2.complete()
-          return lighpushErrorResult(ErrorCode.PAYLOAD_TOO_LARGE, handlerError)
+          return lighpushErrorResult(LightPushErrorCode.PAYLOAD_TOO_LARGE, handlerError)
 
       let
         serverSwitch2 = newTestSwitch()
@@ -306,7 +306,7 @@ suite "Waku Lightpush Client":
 
       # Then the response is negative
       check:
-        publishResponse.error.code == ErrorCode.PAYLOAD_TOO_LARGE
+        publishResponse.error.code == LightPushErrorCode.PAYLOAD_TOO_LARGE
         publishResponse.error.desc == some(handlerError)
         (await handlerFuture2.waitForResult()).isOk()
 
@@ -370,4 +370,4 @@ suite "Waku Lightpush Client":
 
       # Then the response is negative
       check not publishResponse.isOk()
-      check publishResponse.error.code == ErrorCode.NO_PEERS_TO_RELAY
+      check publishResponse.error.code == LightPushErrorCode.NO_PEERS_TO_RELAY

--- a/tests/waku_lightpush/test_client.nim
+++ b/tests/waku_lightpush/test_client.nim
@@ -42,8 +42,9 @@ suite "Waku Lightpush Client":
     ): Future[WakuLightPushResult] {.async.} =
       let msgLen = message.encode().buffer.len
       if msgLen > int(DefaultMaxWakuMessageSize) + 64 * 1024:
-        return
-          lighpushErrorResult(PAYLOAD_TOO_LARGE, "length greater than maxMessageSize")
+        return lighpushErrorResult(
+          ErrorCode.PAYLOAD_TOO_LARGE, "length greater than maxMessageSize"
+        )
       handlerFuture.complete((pubsubTopic, message))
       # return that we published the message to 1 peer.
       return ok(1)
@@ -263,7 +264,7 @@ suite "Waku Lightpush Client":
       # Then the message is not received by the server
       check:
         publishResponse5.isErr()
-        publishResponse5.error.code == PAYLOAD_TOO_LARGE
+        publishResponse5.error.code == ErrorCode.PAYLOAD_TOO_LARGE
         (await handlerFuture.waitForResult()).isErr()
 
     asyncTest "Invalid Encoding Payload":
@@ -276,7 +277,7 @@ suite "Waku Lightpush Client":
       # And the error is returned
       check:
         publishResponse.requestId == "N/A"
-        publishResponse.statusCode == LightpushStatusCode.BAD_REQUEST.uint32
+        publishResponse.statusCode == ErrorCode.BAD_REQUEST
         publishResponse.statusDesc.isSome()
         scanf(publishResponse.statusDesc.get(), decodeRpcFailure)
 
@@ -289,7 +290,7 @@ suite "Waku Lightpush Client":
             peer: PeerId, pubsubTopic: PubsubTopic, message: WakuMessage
         ): Future[WakuLightPushResult] {.async.} =
           handlerFuture2.complete()
-          return lighpushErrorResult(PAYLOAD_TOO_LARGE, handlerError)
+          return lighpushErrorResult(ErrorCode.PAYLOAD_TOO_LARGE, handlerError)
 
       let
         serverSwitch2 = newTestSwitch()
@@ -305,7 +306,7 @@ suite "Waku Lightpush Client":
 
       # Then the response is negative
       check:
-        publishResponse.error.code == PAYLOAD_TOO_LARGE
+        publishResponse.error.code == ErrorCode.PAYLOAD_TOO_LARGE
         publishResponse.error.desc == some(handlerError)
         (await handlerFuture2.waitForResult()).isOk()
 
@@ -369,4 +370,4 @@ suite "Waku Lightpush Client":
 
       # Then the response is negative
       check not publishResponse.isOk()
-      check publishResponse.error.code == LightpushStatusCode.NO_PEERS_TO_RELAY
+      check publishResponse.error.code == ErrorCode.NO_PEERS_TO_RELAY

--- a/tests/waku_lightpush/test_ratelimit.nim
+++ b/tests/waku_lightpush/test_ratelimit.nim
@@ -119,7 +119,7 @@ suite "Rate limited push service":
 
       check:
         requestRes.isErr()
-        requestRes.error.code == ErrorCode.TOO_MANY_REQUESTS
+        requestRes.error.code == LightPushErrorCode.TOO_MANY_REQUESTS
         requestRes.error.desc == some(TooManyRequestsMessage)
 
     for testCnt in 0 .. 2:

--- a/tests/waku_lightpush/test_ratelimit.nim
+++ b/tests/waku_lightpush/test_ratelimit.nim
@@ -119,7 +119,7 @@ suite "Rate limited push service":
 
       check:
         requestRes.isErr()
-        requestRes.error.code == TOO_MANY_REQUESTS
+        requestRes.error.code == ErrorCode.TOO_MANY_REQUESTS
         requestRes.error.desc == some(TooManyRequestsMessage)
 
     for testCnt in 0 .. 2:

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -82,6 +82,8 @@ const clientId* = "Nimbus Waku v2 node"
 
 const WakuNodeVersionString* = "version / git commit hash: " & git_version
 
+const LightPushError = lightpush_protocol.ErrorCode
+
 # key and crypto modules different
 type
   # TODO: Move to application instance (e.g., `WakuNode2`)
@@ -1190,7 +1192,9 @@ proc lightpushPublish*(
 ): Future[lightpush_protocol.WakuLightPushResult] {.async.} =
   if node.wakuLightpushClient.isNil() and node.wakuLightPush.isNil():
     error "failed to publish message as lightpush not available"
-    return lighpushErrorResult(SERVICE_NOT_AVAILABLE, "Waku lightpush not available")
+    return lighpushErrorResult(
+      LightPushError.SERVICE_NOT_AVAILABLE, "Waku lightpush not available"
+    )
 
   let toPeer: RemotePeerInfo = peerOpt.valueOr:
     if not node.wakuLightPush.isNil():
@@ -1199,9 +1203,11 @@ proc lightpushPublish*(
       node.peerManager.selectPeer(WakuLightPushCodec).valueOr:
         let msg = "no suitable remote peers"
         error "failed to publish message", msg = msg
-        return lighpushErrorResult(NO_PEERS_TO_RELAY, msg)
+        return lighpushErrorResult(LightPushError.NO_PEERS_TO_RELAY, msg)
     else:
-      return lighpushErrorResult(NO_PEERS_TO_RELAY, "no suitable remote peers")
+      return lighpushErrorResult(
+        LightPushError.NO_PEERS_TO_RELAY, "no suitable remote peers"
+      )
 
   let pubsubForPublish = pubSubTopic.valueOr:
     if node.wakuAutoSharding.isNone():
@@ -1212,12 +1218,12 @@ proc lightpushPublish*(
     let parsedTopic = NsContentTopic.parse(message.contentTopic).valueOr:
       let msg = "Invalid content-topic:" & $error
       error "lightpush request handling error", error = msg
-      return lighpushErrorResult(INVALID_MESSAGE_ERROR, msg)
+      return lighpushErrorResult(LightPushError.INVALID_MESSAGE, msg)
 
     node.wakuAutoSharding.get().getShard(parsedTopic).valueOr:
       let msg = "Autosharding error: " & error
       error "lightpush publish error", error = msg
-      return lighpushErrorResult(INTERNAL_SERVER_ERROR, msg)
+      return lighpushErrorResult(LightPushError.INTERNAL_SERVER_ERROR, msg)
 
   return await lightpushPublishHandler(node, pubsubForPublish, message, toPeer)
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -82,8 +82,6 @@ const clientId* = "Nimbus Waku v2 node"
 
 const WakuNodeVersionString* = "version / git commit hash: " & git_version
 
-const LightPushError = lightpush_protocol.ErrorCode
-
 # key and crypto modules different
 type
   # TODO: Move to application instance (e.g., `WakuNode2`)
@@ -1193,7 +1191,7 @@ proc lightpushPublish*(
   if node.wakuLightpushClient.isNil() and node.wakuLightPush.isNil():
     error "failed to publish message as lightpush not available"
     return lighpushErrorResult(
-      LightPushError.SERVICE_NOT_AVAILABLE, "Waku lightpush not available"
+      LightPushErrorCode.SERVICE_NOT_AVAILABLE, "Waku lightpush not available"
     )
 
   let toPeer: RemotePeerInfo = peerOpt.valueOr:
@@ -1203,10 +1201,10 @@ proc lightpushPublish*(
       node.peerManager.selectPeer(WakuLightPushCodec).valueOr:
         let msg = "no suitable remote peers"
         error "failed to publish message", msg = msg
-        return lighpushErrorResult(LightPushError.NO_PEERS_TO_RELAY, msg)
+        return lighpushErrorResult(LightPushErrorCode.NO_PEERS_TO_RELAY, msg)
     else:
       return lighpushErrorResult(
-        LightPushError.NO_PEERS_TO_RELAY, "no suitable remote peers"
+        LightPushErrorCode.NO_PEERS_TO_RELAY, "no suitable remote peers"
       )
 
   let pubsubForPublish = pubSubTopic.valueOr:
@@ -1218,12 +1216,12 @@ proc lightpushPublish*(
     let parsedTopic = NsContentTopic.parse(message.contentTopic).valueOr:
       let msg = "Invalid content-topic:" & $error
       error "lightpush request handling error", error = msg
-      return lighpushErrorResult(LightPushError.INVALID_MESSAGE, msg)
+      return lighpushErrorResult(LightPushErrorCode.INVALID_MESSAGE, msg)
 
     node.wakuAutoSharding.get().getShard(parsedTopic).valueOr:
       let msg = "Autosharding error: " & error
       error "lightpush publish error", error = msg
-      return lighpushErrorResult(LightPushError.INTERNAL_SERVER_ERROR, msg)
+      return lighpushErrorResult(LightPushErrorCode.INTERNAL_SERVER_ERROR, msg)
 
   return await lightpushPublishHandler(node, pubsubForPublish, message, toPeer)
 

--- a/waku/node/waku_node.nim
+++ b/waku/node/waku_node.nim
@@ -1211,7 +1211,7 @@ proc lightpushPublish*(
     if node.wakuAutoSharding.isNone():
       let msg = "Pubsub topic must be specified when static sharding is enabled"
       error "lightpush publish error", error = msg
-      return lighpushErrorResult(INVALID_MESSAGE_ERROR, msg)
+      return lighpushErrorResult(LightPushErrorCode.INVALID_MESSAGE, msg)
 
     let parsedTopic = NsContentTopic.parse(message.contentTopic).valueOr:
       let msg = "Invalid content-topic:" & $error

--- a/waku/waku_api/rest/lightpush/handlers.nim
+++ b/waku/waku_api/rest/lightpush/handlers.nim
@@ -32,7 +32,7 @@ const NoPeerNoneFoundError = "No suitable service peer & none discovered"
 proc useSelfHostedLightPush(node: WakuNode): bool =
   return node.wakuLightPush != nil and node.wakuLightPushClient == nil
 
-proc convertErrorKindToHttpStatus(statusCode: LightpushStatusCode): HttpCode =
+proc convertErrorKindToHttpStatus(statusCode: LightPushStatusCode): HttpCode =
   ## Lightpush status codes are matching HTTP status codes by design
   return toHttpCode(statusCode.int).get(Http500)
 

--- a/waku/waku_lightpush/callbacks.nim
+++ b/waku/waku_lightpush/callbacks.nim
@@ -44,10 +44,10 @@ proc getRelayPushHandler*(
   ): Future[WakuLightPushResult] {.async.} =
     # append RLN proof
     let msgWithProof = checkAndGenerateRLNProof(rlnPeer, message).valueOr:
-      return lighpushErrorResult(OUT_OF_RLN_PROOF, error)
+      return lighpushErrorResult(ErrorCode.OUT_OF_RLN_PROOF, error)
 
     (await wakuRelay.validateMessage(pubSubTopic, msgWithProof)).isOkOr:
-      return lighpushErrorResult(INVALID_MESSAGE_ERROR, $error)
+      return lighpushErrorResult(ErrorCode.INVALID_MESSAGE, $error)
 
     let publishedResult = await wakuRelay.publish(pubsubTopic, msgWithProof)
 

--- a/waku/waku_lightpush/callbacks.nim
+++ b/waku/waku_lightpush/callbacks.nim
@@ -44,10 +44,10 @@ proc getRelayPushHandler*(
   ): Future[WakuLightPushResult] {.async.} =
     # append RLN proof
     let msgWithProof = checkAndGenerateRLNProof(rlnPeer, message).valueOr:
-      return lighpushErrorResult(ErrorCode.OUT_OF_RLN_PROOF, error)
+      return lighpushErrorResult(LightPushErrorCode.OUT_OF_RLN_PROOF, error)
 
     (await wakuRelay.validateMessage(pubSubTopic, msgWithProof)).isOkOr:
-      return lighpushErrorResult(ErrorCode.INVALID_MESSAGE, $error)
+      return lighpushErrorResult(LightPushErrorCode.INVALID_MESSAGE, $error)
 
     let publishedResult = await wakuRelay.publish(pubsubTopic, msgWithProof)
 

--- a/waku/waku_lightpush/common.nim
+++ b/waku/waku_lightpush/common.nim
@@ -5,18 +5,21 @@ import ../waku_core, ./rpc, ../waku_relay/protocol
 
 from ../waku_core/codecs import WakuLightPushCodec
 export WakuLightPushCodec
+export LightPushStatusCode
 
-type LightpushStatusCode* = enum
-  SUCCESS = uint32(200)
-  BAD_REQUEST = uint32(400)
-  PAYLOAD_TOO_LARGE = uint32(413)
-  INVALID_MESSAGE_ERROR = uint32(420)
-  UNSUPPORTED_PUBSUB_TOPIC = uint32(421)
-  TOO_MANY_REQUESTS = uint32(429)
-  INTERNAL_SERVER_ERROR = uint32(500)
-  SERVICE_NOT_AVAILABLE = uint32(503)
-  OUT_OF_RLN_PROOF = uint32(504)
-  NO_PEERS_TO_RELAY = uint32(505)
+const SuccessCode* = (SUCCESS: LightPushStatusCode(200))
+
+const ErrorCode* = (
+  BAD_REQUEST: LightPushStatusCode(400),
+  PAYLOAD_TOO_LARGE: LightPushStatusCode(413),
+  INVALID_MESSAGE: LightPushStatusCode(420),
+  UNSUPPORTED_PUBSUB_TOPIC: LightPushStatusCode(421),
+  TOO_MANY_REQUESTS: LightPushStatusCode(429),
+  INTERNAL_SERVER_ERROR: LightPushStatusCode(500),
+  SERVICE_NOT_AVAILABLE: LightPushStatusCode(503),
+  OUT_OF_RLN_PROOF: LightPushStatusCode(504),
+  NO_PEERS_TO_RELAY: LightPushStatusCode(505),
+)
 
 type ErrorStatus* = tuple[code: LightpushStatusCode, desc: Option[string]]
 type WakuLightPushResult* = Result[uint32, ErrorStatus]
@@ -28,7 +31,7 @@ type PushMessageHandler* = proc(
 const TooManyRequestsMessage* = "Request rejected due to too many requests"
 
 func isSuccess*(response: LightPushResponse): bool =
-  return response.statusCode == LightpushStatusCode.SUCCESS.uint32
+  return response.statusCode == SuccessCode.SUCCESS
 
 func toPushResult*(response: LightPushResponse): WakuLightPushResult =
   if isSuccess(response):
@@ -40,13 +43,13 @@ func lightpushSuccessResult*(relayPeerCount: uint32): WakuLightPushResult =
   return ok(relayPeerCount)
 
 func lightpushResultInternalError*(msg: string): WakuLightPushResult =
-  return err((LightpushStatusCode.INTERNAL_SERVER_ERROR, some(msg)))
+  return err((ErrorCode.INTERNAL_SERVER_ERROR, some(msg)))
 
 func lightpushResultBadRequest*(msg: string): WakuLightPushResult =
-  return err((LightpushStatusCode.BAD_REQUEST, some(msg)))
+  return err((ErrorCode.BAD_REQUEST, some(msg)))
 
 func lightpushResultServiceUnavailable*(msg: string): WakuLightPushResult =
-  return err((LightpushStatusCode.SERVICE_NOT_AVAILABLE, some(msg)))
+  return err((ErrorCode.SERVICE_NOT_AVAILABLE, some(msg)))
 
 func lighpushErrorResult*(
     statusCode: LightpushStatusCode, desc: Option[string]
@@ -63,24 +66,16 @@ func mapPubishingErrorToPushResult*(
 ): WakuLightPushResult =
   case publishOutcome
   of NoTopicSpecified:
-    return err(
-      (LightpushStatusCode.INVALID_MESSAGE_ERROR, some("Empty topic, skipping publish"))
-    )
+    return err((ErrorCode.INVALID_MESSAGE, some("Empty topic, skipping publish")))
   of DuplicateMessage:
-    return err(
-      (LightpushStatusCode.INVALID_MESSAGE_ERROR, some("Dropping already-seen message"))
-    )
+    return err((ErrorCode.INVALID_MESSAGE, some("Dropping already-seen message")))
   of NoPeersToPublish:
-    return err(
-      (
-        LightpushStatusCode.NO_PEERS_TO_RELAY,
-        some("No peers for topic, skipping publish"),
-      )
-    )
+    return
+      err((ErrorCode.NO_PEERS_TO_RELAY, some("No peers for topic, skipping publish")))
   of CannotGenerateMessageId:
     return err(
       (
-        LightpushStatusCode.INTERNAL_SERVER_ERROR,
+        ErrorCode.INTERNAL_SERVER_ERROR,
         some("Error generating message id, skipping publish"),
       )
     )

--- a/waku/waku_lightpush/protocol.nim
+++ b/waku/waku_lightpush/protocol.nim
@@ -36,7 +36,7 @@ proc handleRequest(
       let msg = "Pubsub topic must be specified when static sharding is enabled"
       error "lightpush request handling error", error = msg
       return WakuLightPushResult.err(
-        (code: LightpushStatusCode.INVALID_MESSAGE_ERROR, desc: some(msg))
+        (code: LightPushErrorCode.INVALID_MESSAGE, desc: some(msg))
       )
 
     let parsedTopic = NsContentTopic.parse(pushRequest.message.contentTopic).valueOr:

--- a/waku/waku_lightpush/rpc.nim
+++ b/waku/waku_lightpush/rpc.nim
@@ -3,6 +3,10 @@
 import std/options
 import ../waku_core
 
+type LightPushStatusCode* = distinct uint32
+proc `==`*(a, b: LightPushStatusCode): bool {.borrow.}
+proc `$`*(code: LightPushStatusCode): string {.borrow.}
+
 type
   LightpushRequest* = object
     requestId*: string
@@ -11,6 +15,6 @@ type
 
   LightPushResponse* = object
     requestId*: string
-    statusCode*: uint32
+    statusCode*: LightPushStatusCode
     statusDesc*: Option[string]
     relayPeerCount*: Option[uint32]

--- a/waku/waku_lightpush/rpc_codec.nim
+++ b/waku/waku_lightpush/rpc_codec.nim
@@ -43,7 +43,7 @@ proc encode*(rpc: LightPushResponse): ProtoBuffer =
   var pb = initProtoBuffer()
 
   pb.write3(1, rpc.requestId)
-  pb.write3(10, rpc.statusCode)
+  pb.write3(10, rpc.statusCode.uint32)
   pb.write3(11, rpc.statusDesc)
   pb.write3(12, rpc.relayPeerCount)
   pb.finish3()
@@ -64,7 +64,7 @@ proc decode*(T: type LightPushResponse, buffer: seq[byte]): ProtobufResult[T] =
   if not ?pb.getField(10, statusCode):
     return err(ProtobufError.missingRequiredField("status_code"))
   else:
-    rpc.statusCode = statusCode
+    rpc.statusCode = statusCode.LightPushStatusCode
 
   var statusDesc: string
   if not ?pb.getField(11, statusDesc):


### PR DESCRIPTION
# Description

Use a distinct type for light push status codes, so that we don't need to cast to uint32 in several places.

# Changes

<!-- List of detailed changes -->

- [x] Create a `distinct` type for Light Push status codes

<!--
## How to test

1.
1.
1.

-->


<!--
