### PR TITLE
fix(tests): prevent race condition in postgres driver tests

### DIFF
--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -23,6 +23,8 @@ suite "Postgres driver":
 
     driver = PostgresDriver(driverRes.get())
 
+    (await driver.waitForPartition()).expect("Test has no DB partition")
+
   asyncTeardown:
     let resetRes = await driver.reset()
     if resetRes.isErr():

--- a/tests/waku_archive/test_driver_postgres_query.nim
+++ b/tests/waku_archive/test_driver_postgres_query.nim
@@ -38,6 +38,8 @@ suite "Postgres driver - queries":
 
     driver = PostgresDriver(driverRes.get())
 
+    (await driver.waitForPartition()).expect("Test has no DB partition")
+
   asyncTeardown:
     let resetRes = await driver.reset()
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1425,7 +1425,6 @@ proc containsAnyPartition*(self: PostgresDriver): bool =
 proc waitForPartition*(
     self: PostgresDriver, timeout = chronos.seconds(5)
 ): Future[ArchiveDriverResult[void]] {.async.} =
-
   let pollInterval = chronos.milliseconds(100)
   var elapsed = chronos.milliseconds(0)
 

--- a/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1422,6 +1422,22 @@ proc removeOldestPartition(
 proc containsAnyPartition*(self: PostgresDriver): bool =
   return not self.partitionMngr.isEmpty()
 
+proc waitForPartition*(
+    self: PostgresDriver, timeout = chronos.seconds(5)
+): Future[ArchiveDriverResult[void]] {.async.} =
+
+  let pollInterval = chronos.milliseconds(100)
+  var elapsed = chronos.milliseconds(0)
+
+  while elapsed < timeout:
+    if self.containsAnyPartition():
+      return ok()
+
+    await sleepAsync(pollInterval)
+    elapsed += pollInterval
+
+  return err("PostgresDriver.waitForPartition() timed out after " & $timeout)
+
 method decreaseDatabaseSize*(
     driver: PostgresDriver, targetSizeInBytes: int64, forceRemoval: bool = false
 ): Future[ArchiveDriverResult[void]] {.async.} =


### PR DESCRIPTION
## Description

Messaging tests (such as tests/waku_archive/test_driver_postgres_query.nim) can temporarily fail if a new partition in the DB is not created in time. This is unlikely to happen when running the test suite, but it can happen (the insert can jump ahead of the partition creation by a few milliseconds).

## Changes

* Add `PostgresDriver.waitForPartition()` which waits for a partition to be available for a given timeout period 
* Call `waitForPartition` in the archive test suite and wait for a partition to be created before starting each messaging test

## Issue

Maintenance Y2026H1 https://github.com/logos-messaging/logos-messaging-nim/issues/3686