### PR TITLE
expire kademlia entries

### DIFF
--- a/waku/discovery/waku_kademlia.nim
+++ b/waku/discovery/waku_kademlia.nim
@@ -54,7 +54,9 @@ proc new*(
     switch,
     bootstrapNodes = params.bootstrapNodes,
     config = KadDHTConfig.new(
-      validator = kad_types.ExtEntryValidator(), selector = kad_types.ExtEntrySelector()
+      validator = kad_types.ExtEntryValidator(),
+      selector = kad_types.ExtEntrySelector(),
+      purgeStaleEntries = true,
     ),
     codec = ExtendedKademliaDiscoveryCodec,
   )


### PR DESCRIPTION
## Description
Noticing issues where entries are stale in kad-DHT which was causing connection issues while testing with new fleet. 

## Changes
Forcing kademlia to expiry stale entries on bucket-refresh-interval.

## Issue
Refer discussion [here](https://discord.com/channels/973324189794697286/1474397159108513834/1476517595686371412)
closes #
