### PR TITLE
feat: add status.prod network preset (cluster 16, RLN off)

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -40,8 +40,17 @@ void *logosdelivery_create_node(
 ```
 
 Configuration uses flat field names matching `WakuNodeConf` in `tools/confutils/cli_args.nim`.
-Use `"preset"` to select a network preset (e.g., `"twn"`, `"logos.dev"`) which auto-configures
-entry nodes, cluster ID, sharding, and other network-specific settings.
+Use `"preset"` to select a network preset (e.g., `"twn"`, `"logos.dev"`, `"status.prod"`) which
+auto-configures entry nodes, cluster ID, sharding, and other network-specific settings.
+
+Available presets:
+
+| Preset | Cluster ID | RLN | Sharding | Network |
+| --- | --- | --- | --- | --- |
+| `twn` | 1 | on | auto (8 shards) | The Waku Network |
+| `logos.dev` | 2 | off | auto (8 shards) | Logos Dev Network |
+| `logos.test` | 2 | off | auto (8 shards) | Logos Test Network |
+| `status.prod` | 16 | off | auto (1 shard) | Status Production Network |
 
 #### `logosdelivery_start_node`
 Starts the node.

--- a/logos_delivery/waku/factory/networks_config.nim
+++ b/logos_delivery/waku/factory/networks_config.nim
@@ -123,6 +123,39 @@ proc LogosTestConf*(T: type NetworkPresetConf): NetworkPresetConf =
     ],
   )
 
+# cluster-id=16 (Status Production Network)
+# Cluster configuration for the `status.prod` network that Status runs on.
+# RLN is disabled. Starting from the logos-delivery integration, status.prod
+# defaults to auto-sharding with a single shard (numShardsInCluster = 1).
+# Bootstrap is done through the status.prod DNS discovery enrtree plus the
+# fleet boot nodes.
+# Source: https://fleets.waku.org/ and each host's `/config.toml`.
+proc StatusProdConf*(T: type NetworkPresetConf): NetworkPresetConf =
+  const ZeroChainId = 0'u256
+  return NetworkPresetConf(
+    maxMessageSize: "1024KiB",
+    clusterId: 16,
+    rlnRelay: false,
+    rlnRelayEthContractAddress: "",
+    rlnRelayDynamic: false,
+    rlnRelayChainId: ZeroChainId,
+    rlnEpochSizeSec: 0,
+    rlnRelayUserMessageLimit: 0,
+    shardingConf: ShardingConf(kind: AutoSharding, numShardsInCluster: 1),
+    enableKadDiscovery: false,
+    kadBootstrapNodes: @[],
+    mix: false,
+    p2pReliability: false,
+    discv5Discovery: true,
+    discv5BootstrapNodes: @[],
+    entryNodes: @[
+      "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im",
+      "/dns4/boot-01.do-ams3.status.prod.status.im/tcp/30303/p2p/16Uiu2HAmAR24Mbb6VuzoyUiGx42UenDkshENVDj4qnmmbabLvo31",
+      "/dns4/boot-01.gc-us-central1-a.status.prod.status.im/tcp/30303/p2p/16Uiu2HAm8mUZ18tBWPXDQsaF7PbCKYA35z7WB2xNZH2EVq1qS8LJ",
+      "/dns4/boot-01.ac-cn-hongkong-c.status.prod.status.im/tcp/30303/p2p/16Uiu2HAmGwcE8v7gmJNEWFtZtojYpPMTHy2jBLL6xRk33qgDxFWX",
+    ],
+  )
+
 proc validateShards*(
     shardingConf: ShardingConf, shards: seq[uint16]
 ): Result[void, string] =

--- a/tests/api/test_node_conf.nim
+++ b/tests/api/test_node_conf.nim
@@ -241,6 +241,25 @@ suite "WakuNodeConf - preset integration":
     check:
       wakuConf.clusterId == 2
 
+  test "StatusProd preset applies StatusProdConf":
+    ## Given
+    var conf = defaultWakuNodeConf().valueOr:
+      raiseAssert error
+    conf.preset = "status.prod"
+
+    ## When
+    let wakuConfRes = conf.toWakuConf()
+
+    ## Then
+    require wakuConfRes.isOk()
+    let wakuConf = wakuConfRes.get()
+    require wakuConf.validate().isOk()
+    check:
+      wakuConf.clusterId == 16
+      wakuConf.shardingConf.kind == AutoSharding
+      wakuConf.shardingConf.numShardsInCluster == 1
+      wakuConf.rlnRelayConf.isNone()
+
   test "Invalid preset returns error":
     ## Given
     var conf = defaultWakuNodeConf().valueOr:

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -175,7 +175,7 @@ type WakuNodeConf* = object
 
     preset* {.
       desc:
-        "Network preset to use. 'twn' is The RLN-protected Waku Network (cluster 1). 'logos.dev' is the Logos Dev Network (cluster 2). 'logos.test' is the Logos Test Network (cluster 2). Overrides other values.",
+        "Network preset to use. 'twn' is The RLN-protected Waku Network (cluster 1). 'logos.dev' is the Logos Dev Network (cluster 2). 'logos.test' is the Logos Test Network (cluster 2). 'status.prod' is the Status Production Network (cluster 16, RLN off, auto-sharding with 1 shard). Overrides other values.",
       defaultValue: "",
       name: "preset"
     .}: string
@@ -1001,6 +1001,8 @@ proc toNetworkPresetConf(
     ok(some(NetworkPresetConf.LogosDevConf()))
   of "logos.test", "logostest":
     ok(some(NetworkPresetConf.LogosTestConf()))
+  of "status.prod", "statusprod":
+    ok(some(NetworkPresetConf.StatusProdConf()))
   else:
     err("Invalid --preset value passed: " & lcPreset)
 


### PR DESCRIPTION
## Summary

Adds a `status.prod` network preset usable from the Messaging API and CLI (`--preset=status.prod`), targeting the live `status.prod` network that Status runs on.

Closes #3906

## Preset values

| Field | Value |
| --- | --- |
| Cluster ID | 16 |
| RLN | disabled |
| Sharding | auto-sharding, 1 shard (`numShardsInCluster = 1`) — the new default for `status.prod` from the logos-delivery integration |
| Max message size | 1024KiB |
| Bootstrap | status.prod DNS-discovery enrtree + the three fleet boot nodes |

Config sourced from <https://fleets.waku.org/> and each host's `/config.toml` (e.g. `http://boot-01.do-ams3.status.prod.status.im/config.toml`).

## Changes

- `logos_delivery/waku/factory/networks_config.nim` — new `StatusProdConf` preset.
- `tools/confutils/cli_args.nim` — `--preset=status.prod` / `statusprod` mapping + help text.
- `tests/api/test_node_conf.nim` — preset integration test (cluster 16, auto-sharding/1 shard, RLN off, `validate()` ok).
- `library/README.md` — documented preset table.

## Notes / not yet verified

- Not compiled locally — no Nim toolchain was available in the authoring environment, so the suite (`make test tests/api/test_node_conf.nim`) and `nph` formatting still need a CI/local run. The code mirrors the existing `LogosDevConf` / `LogosTestConf` presets structurally.
- Acceptance criterion "interop with current status.prod clients verified" needs a live connectivity check (`createNode` with the preset against the live network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)