### PR TITLE
feat(node-info): expose MaxMessageSize node info item

### DIFF
--- a/logos_delivery/waku/factory/waku_state_info.nim
+++ b/logos_delivery/waku/factory/waku_state_info.nim
@@ -5,13 +5,9 @@
 ## accessible through the debug API.
 
 import std/[tables, sequtils, strutils]
-import
-  metrics,
-  eth/p2p/discoveryv5/enr,
-  libp2p/peerid,
-  libp2p/protocols/pubsub/gossipsub,
-  stew/byteutils
+import metrics, eth/p2p/discoveryv5/enr, libp2p/peerid, stew/byteutils
 import logos_delivery/waku/[waku_node, net/bound_ports]
+import logos_delivery/waku/factory/waku_conf
 
 type
   NodeInfoId* {.pure.} = enum
@@ -26,6 +22,7 @@ type
 
   WakuStateInfo* {.requiresInit.} = object
     node: WakuNode
+    conf: WakuConf
 
 proc getAllPossibleInfoItemIds*(self: WakuStateInfo): seq[NodeInfoId] =
   ## Returns all possible options that can be queried to learn about the node's information.
@@ -59,13 +56,10 @@ proc getNodeInfoItem*(self: WakuStateInfo, infoItemId: NodeInfoId): string =
       return ""
     return self.node.wakuMix.pubKey.to0xHex()
   of NodeInfoId.MaxMessageSize:
-    ## Max message size (in bytes) accepted by the relay protocol.
-    ## Empty when the relay protocol is not mounted on this node.
-    if self.node.wakuRelay.isNil():
-      return ""
-    return $self.node.wakuRelay.maxMessageSize
+    ## Configured max message size (in bytes) for this node.
+    return $self.conf.maxMessageSizeBytes
   else:
     return "unknown info item id"
 
-proc init*(T: typedesc[WakuStateInfo], node: WakuNode): T =
-  return WakuStateInfo(node: node)
+proc init*(T: typedesc[WakuStateInfo], node: WakuNode, conf: WakuConf): T =
+  return WakuStateInfo(node: node, conf: conf)

--- a/logos_delivery/waku/factory/waku_state_info.nim
+++ b/logos_delivery/waku/factory/waku_state_info.nim
@@ -5,7 +5,12 @@
 ## accessible through the debug API.
 
 import std/[tables, sequtils, strutils]
-import metrics, eth/p2p/discoveryv5/enr, libp2p/peerid, stew/byteutils
+import
+  metrics,
+  eth/p2p/discoveryv5/enr,
+  libp2p/peerid,
+  libp2p/protocols/pubsub/gossipsub,
+  stew/byteutils
 import logos_delivery/waku/[waku_node, net/bound_ports]
 
 type
@@ -17,6 +22,7 @@ type
     MyPeerId
     MyBoundPorts
     MyMixPubKey
+    MaxMessageSize
 
   WakuStateInfo* {.requiresInit.} = object
     node: WakuNode
@@ -52,6 +58,12 @@ proc getNodeInfoItem*(self: WakuStateInfo, infoItemId: NodeInfoId): string =
     if self.node.wakuMix.isNil():
       return ""
     return self.node.wakuMix.pubKey.to0xHex()
+  of NodeInfoId.MaxMessageSize:
+    ## Max message size (in bytes) accepted by the relay protocol.
+    ## Empty when the relay protocol is not mounted on this node.
+    if self.node.wakuRelay.isNil():
+      return ""
+    return $self.node.wakuRelay.maxMessageSize
   else:
     return "unknown info item id"
 

--- a/logos_delivery/waku/waku.nim
+++ b/logos_delivery/waku/waku.nim
@@ -235,7 +235,7 @@ proc new*(
     return err("Failed setting up app callbacks: " & $error)
 
   var waku = Waku(
-    stateInfo: WakuStateInfo.init(node),
+    stateInfo: WakuStateInfo.init(node, wakuConf),
     conf: wakuConf,
     rng: rng,
     key: wakuConf.nodeKey,

--- a/tests/node/test_wakunode_health_monitor.nim
+++ b/tests/node/test_wakunode_health_monitor.nim
@@ -235,7 +235,9 @@ suite "Health Monitor - events":
     # `waku.node` is read on the messaging path; `conf`/`stateInfo` are supplied
     # solely to satisfy Waku's {.requiresInit.} fields.
     let waku = Waku(
-      node: nodeA, conf: defaultTestWakuConf(), stateInfo: WakuStateInfo.init(nodeA)
+      node: nodeA,
+      conf: defaultTestWakuConf(),
+      stateInfo: WakuStateInfo.init(nodeA, defaultTestWakuConf()),
     )
     let ds = MessagingClient
       .new(MessagingClientConf(useP2PReliability: false), waku)
@@ -346,7 +348,9 @@ suite "Health Monitor - events":
     # `waku.node` is read on the messaging path; `conf`/`stateInfo` are supplied
     # solely to satisfy Waku's {.requiresInit.} fields.
     let waku = Waku(
-      node: nodeA, conf: defaultTestWakuConf(), stateInfo: WakuStateInfo.init(nodeA)
+      node: nodeA,
+      conf: defaultTestWakuConf(),
+      stateInfo: WakuStateInfo.init(nodeA, defaultTestWakuConf()),
     )
     let ds = MessagingClient
       .new(MessagingClientConf(useP2PReliability: false), waku)

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -33,12 +33,6 @@ suite "Wakunode2 - Waku":
 
     let waku = (waitFor Waku.new(conf)).valueOr:
       raiseAssert error
-    defer:
-      (waitFor waku.stop()).isOkOr:
-        raiseAssert error
-
-    (waitFor waku.start()).isOkOr:
-      raiseAssert error
 
     ## When
     let maxMessageSize = waku.stateInfo.getNodeInfoItem(NodeInfoId.MaxMessageSize)

--- a/tests/wakunode2/test_app.nim
+++ b/tests/wakunode2/test_app.nim
@@ -27,6 +27,26 @@ suite "Wakunode2 - Waku":
     check:
       version == git_version
 
+  test "max message size should be reported from node info":
+    ## Given
+    let conf = defaultTestWakuConf()
+
+    let waku = (waitFor Waku.new(conf)).valueOr:
+      raiseAssert error
+    defer:
+      (waitFor waku.stop()).isOkOr:
+        raiseAssert error
+
+    (waitFor waku.start()).isOkOr:
+      raiseAssert error
+
+    ## When
+    let maxMessageSize = waku.stateInfo.getNodeInfoItem(NodeInfoId.MaxMessageSize)
+
+    ## Then
+    check:
+      maxMessageSize == $conf.maxMessageSizeBytes
+
 suite "Wakunode2 - Waku initialization":
   test "peer persistence setup should be successfully mounted":
     ## Given


### PR DESCRIPTION
Part of https://github.com/logos-messaging/pm/issues/380

## Summary

Enables querying the node's configured **max message size** through the node info surface (`WakuStateInfo` / `NodeInfoId`), which is consumed by both the debug API and the FFI (`get_node_info` / `get_available_node_info_ids`).

- Adds a `MaxMessageSize` value to the `NodeInfoId` enum.
- `getNodeInfoItem` returns the node's configured `maxMessageSizeBytes` as a string.
- The item is automatically included in `getAllPossibleInfoItemIds` (it iterates the enum), so it's discoverable over the FFI without further changes.

## Design note: source of the value

The value is read from the **node config** (`conf.maxMessageSizeBytes`), not from the relay. `conf.maxMessageSizeBytes` is applied at runtime only via `mountRelay` (the relay holds a copy), so reading off the relay would report an empty string on relay-disabled (light) nodes. Sourcing from the config makes the item always available and reflects the node's configured limit directly.

To support this, `WakuStateInfo` now holds the `WakuConf` it reports on; `WakuStateInfo.init` takes it as an argument. This also gives future config-derived node-info items a place to read from. Updated call sites:
- `logos_delivery/waku/waku.nim` (passes the resolved `wakuConf`)
- `tests/node/test_wakunode_health_monitor.nim` (2 direct constructions)

## Testing

Added a unit test in `tests/wakunode2/test_app.nim` asserting the reported value equals the configured `maxMessageSizeBytes`.

> Note: I was unable to compile/run the suite in this environment because the vendored libp2p submodules were not checked out (a full Nix build takes 30–45 min per the repo docs). The change follows the established `NodeInfoId` patterns. Please rely on CI to validate the build/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)