### PR TITLE
chore: bump nim-lsquic v0.5.1 -> v0.5.6

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -67,7 +67,7 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.1.4"
 
-requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
+requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.6"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 

--- a/nimble.lock
+++ b/nimble.lock
@@ -476,8 +476,8 @@
       }
     },
     "lsquic": {
-      "version": "0.5.1",
-      "vcsRevision": "2f01046bf1d513de8b5f8296c3d8bec819ab0cb9",
+      "version": "0.5.6",
+      "vcsRevision": "b778d16d6f00b47249e2674c23f21aa26b711eb7",
       "url": "https://github.com/vacp2p/nim-lsquic",
       "downloadMethod": "git",
       "dependencies": [
@@ -491,7 +491,7 @@
         "boringssl"
       ],
       "checksums": {
-        "sha1": "959df1a9ac2a574d6fe30a4faf37c37b443e1cfb"
+        "sha1": "2676f1facb400ad3cfa1b338149d9c20fc5967c4"
       }
     },
     "secp256k1": {


### PR DESCRIPTION
## Description

Bumps the pinned nim-lsquic from v0.5.1 to v0.5.6 to pick up QUIC fixes released upstream.

## Changes

* bump nim-lsquic v0.5.1 -> v0.5.6

## Issue

Maintenance Y2026H2 #4043