### PR TITLE
feat(conf): default --entry-layer to kernel

### DIFF
--- a/apps/logos_delivery_node/logosdeliverynode.nim
+++ b/apps/logos_delivery_node/logosdeliverynode.nim
@@ -44,8 +44,9 @@ when isMainModule:
     quit(QuitFailure)
   of noCommand:
     # `LogosDelivery` derives the per-layer config from `WakuNodeConf` itself
-    # (it runs `toWakuConf` internally), then builds the full stack bottom-up:
+    # (it runs `toWakuConf` internally), then builds the layers bottom-up:
     #   Waku <- MessagingClient <- ReliableChannelManager
+    # How far up it goes is set by `--entry-layer` (default `kernel`: Waku only).
     var node = (waitFor LogosDelivery.new(wakuNodeConf)).valueOr:
       error "LogosDelivery initialization failed", error = error
       quit(QuitFailure)

--- a/examples/api_example/api_example.nim
+++ b/examples/api_example/api_example.nim
@@ -63,6 +63,9 @@ when isMainModule:
     echo "Failed to create default config: ", error
     quit(QuitFailure)
 
+  # The CLI default is kernel-only; this example drives the messaging API.
+  conf.entryLayer = EntryLayer.channels
+
   if args.ethRpcEndpoint == "":
     # Create a basic configuration for the Waku node
     # No RLN as we don't have an ETH RPC Endpoint

--- a/logos_delivery/api/conf/logos_delivery_conf.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf.nim
@@ -26,15 +26,21 @@ proc init*(
     messagingOverrides: MessagingClientConf,
     channelsOverrides: ReliableChannelManagerConf,
 ): ConfResult[LogosDeliveryConf] =
-  ## Structured (preset + overrides) entry. Only `messaging` / `channels` layers
-  ## reach here; the `kernel` layer uses `init(kernelConf)` (raw, mode ignored).
+  ## Structured (preset + overrides) entry: `mode` and `preset` shape the kernel
+  ## conf for every layer, `kernel` included - it just yields no upper layers.
+  ## `init(kernelConf)` is the raw entry that takes a caller's config as-is.
   let merged = merge(?resolvePreset(preset), messagingOverrides)
   var kernelConf = ?toWakuNodeConf(merged, mode)
   kernelConf.preset = preset
+  kernelConf.entryLayer = entryLayer
   return ok(
     LogosDeliveryConf(
       kernelConf: KernelConf(kernelConf),
-      messagingConf: Opt.some(merged),
+      messagingConf:
+        if entryLayer != EntryLayer.kernel:
+          Opt.some(merged)
+        else:
+          Opt.none(MessagingClientConf),
       channelsConf:
         if entryLayer == EntryLayer.channels:
           Opt.some(channelsOverrides)

--- a/logos_delivery/api/conf/logos_delivery_conf.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf.nim
@@ -31,6 +31,7 @@ proc init*(
   let merged = merge(?resolvePreset(preset), messagingOverrides)
   var kernelConf = ?toWakuNodeConf(merged, mode)
   kernelConf.preset = preset
+  kernelConf.entryLayer = entryLayer
   return ok(
     LogosDeliveryConf(
       kernelConf: KernelConf(kernelConf),

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -89,6 +89,9 @@ proc toWakuNodeConf*(
   # `LogosDelivery.new(WakuNodeConf)` re-application is idempotent instead of
   # clobbering these flags with the field's default (`Core`).
   conf.mode = mode
+  # Derived from a `MessagingClientConf`, so never kernel-only: don't inherit the
+  # CLI default. `LogosDeliveryConf.init` overwrites this with the caller's layer.
+  conf.entryLayer = EntryLayer.channels
 
   if self.store.isSome():
     conf.store = self.store.get()

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -84,6 +84,9 @@ proc toWakuNodeConf*(
   # `LogosDelivery.new(WakuNodeConf)` re-application is idempotent instead of
   # clobbering these flags with the field's default (`Core`).
   conf.mode = mode
+  # Derived from a `MessagingClientConf`, so never kernel-only: don't inherit the
+  # CLI default. `LogosDeliveryConf.init` overwrites this with the caller's layer.
+  conf.entryLayer = EntryLayer.channels
 
   if self.store.isSome():
     conf.store = self.store.get()

--- a/logos_delivery/logos_delivery.nim
+++ b/logos_delivery/logos_delivery.nim
@@ -170,8 +170,8 @@ proc new*(
     appCallbacks: AppCallbacks = nil,
 ): Future[Result[LogosDelivery, string]] {.async.} =
   ## Messaging entry point (app dev). Builds the stack from preset, mode and
-  ## overrides; `entryLayer` selects messaging vs channels (use `new(kernelConf)`
-  ## for a kernel-only node).
+  ## overrides; `entryLayer` selects how far up the stack to go. `kernel` mounts
+  ## no upper layers but still applies mode/preset.
   let conf = LogosDeliveryConf.init(
     entryLayer = entryLayer,
     mode = mode,

--- a/tests/wakunode2/test_cli_args.nim
+++ b/tests/wakunode2/test_cli_args.nim
@@ -54,6 +54,13 @@ suite "Waku external config - default values":
     let conf = res.get()
     check conf.subscribeShards == defaultSubscribeShards
 
+  test "Default entry layer is kernel":
+    ## Given
+    let preConfig = defaultWakuNodeConf().get()
+
+    ## Then
+    check preConfig.entryLayer == EntryLayer.kernel
+
 suite "Waku external config - apply preset":
   test "Preset is TWN":
     ## Setup

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -172,7 +172,7 @@ type WakuNodeConf* = object
     entryLayer* {.
       desc:
         "Top API layer to run: kernel (transport only), messaging, or channels (messaging + reliable channels).",
-      defaultValue: EntryLayer.channels,
+      defaultValue: EntryLayer.kernel,
       name: "entry-layer"
     .}: EntryLayer
 


### PR DESCRIPTION
## Description

Flips the `--entry-layer` default from `channels` to `kernel`, so the node runs
transport-only unless asked otherwise. `--entry-layer=channels` restores the old
behaviour.

Protocol flags are unchanged — the individual CLI defaults already match what
`applyMode(Core)` was setting. Gone by default: messaging client, reliable
channel manager, messaging REST endpoints.

Only the CLI default moves; `LogosDelivery.new` and `parseLogosDeliveryConf`
still default to `channels`.

## Changes

- `cli_args`: `entryLayer` defaults to `kernel`.
- `messaging_conf`: `toWakuNodeConf` pins `entryLayer = channels`, so a conf
  derived from a `MessagingClientConf` doesn't inherit the new CLI default.
- `api_example` opts into `channels`; test for the new default.
