### PR TITLE
fix: stop host OpenSSL from hijacking bundled BoringSSL in liblogosdelivery (#4085)

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -115,9 +115,15 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
       " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:on -d:discv5_protocol_id=d5waku " &
       getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
+    # -Bsymbolic binds the library's references to its own symbols at link
+    # time. Without it, a host process that already loads OpenSSL (e.g.
+    # Node.js) interposes our statically linked BoringSSL functions and data
+    # (ASN1_ITEM tables), and QUIC startup crashes in lsquic setupSSLContext
+    # (issue #4085).
+    let elfFlags = when defined(linux): "--passL:-Wl,-Bsymbolic " else: ""
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
+      elfFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
   buildLibrary libName & ".dll", folderName,
@@ -173,8 +179,9 @@ proc buildMobileAndroid(srcDir = ".", params = "") =
   if not dirExists outDir:
     mkDir outDir
 
+  # -Bsymbolic: see buildLibrary's dynamic branch (issue #4085).
   exec "nim c" & " --out:" & outDir &
-    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-L" &
+    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-Wl,-Bsymbolic --passL:-L" &
     outdir & " --passL:-lrln --passL:-llog --cpu:" & cpu & " --nimMainPrefix:liblogosdelivery --os:android -d:androidNDK " & params &
     getNimParams() & " " & srcDir & "/liblogosdelivery.nim"
 


### PR DESCRIPTION
Fixes #4085.

## Root cause

`liblogosdelivery.so` statically embeds BoringSSL, but exports all ~8,500 of its symbols with default visibility and calls them through interposable PLT/GOT entries. (nim-boringssl sets `-fvisibility=hidden` via `{.localPassC.}`, but on Nim 2.2.4 `localPassC` flags never reach `{.compile.}`'d C files, so the hiding is ineffective — verified empirically.)

When the host process already has OpenSSL in its global symbol scope — Node.js is the canonical case, since it exports its statically linked OpenSSL from the executable itself; `LD_PRELOAD=libssl.so.3` reproduces the same condition — every symbol name common to both libraries resolves to OpenSSL instead of our BoringSSL. The QUIC startup flow works right up to `SSL_CTX_set1_sigalgs_list`, which is the **first BoringSSL-only function** in the whole sequence (OpenSSL defines it as a macro over `SSL_CTX_ctrl`, so there is no such dynamic symbol to interpose). That function then reads an OpenSSL `SSL_CTX` using BoringSSL's struct layout, producing exactly the reported trace:

```
lsquic/context/context.nim(305) setupSSLContext
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

Reproduced locally byte-for-byte on linux/amd64 with the stock C API (`logosdelivery_create_node` with `{"mode":"Core","preset":"logos.test","messagingOverrides":{"quicSupport":true}}` + `start`) and system OpenSSL preloaded. Without OpenSSL in the process the same binary starts cleanly, which is why the crash only shows up in some host environments.

## Fix

Link the Linux and Android shared libraries with `-Wl,-Bsymbolic`, so the library's own references bind to its own definitions at link time and cannot be interposed by the host's OpenSSL.

Two subtleties:

- `buildLibrary` ignores its `params` argument (the chronicles flags passed by `buildLibDynamicLinux` are dead code), so the flag is added inside `buildLibrary`'s dynamic branch (Linux hosts only) and in `buildMobileAndroid`.
- `-Bsymbolic-functions` is **not** sufficient: with it, the SIGSEGV disappears but QUIC startup still fails with `Failed to generate certificate: -30` (`CERT_ERROR_PUBKEY_SET`), because BoringSSL's `ASN1_ITEM` template descriptors (`ASN1_INTEGER_it`, `X509_ALGOR_it`, …) are *data* symbols and still get interposed by OpenSSL's structurally different ones (confirmed with `LD_DEBUG=bindings`). Full `-Bsymbolic` binds data references too.

macOS is unaffected (two-level namespace prevents this class of interposition) and Windows PE has no flat-namespace interposition, so the flag is ELF-only.

## Verification

- Before: repro crashes with the exact #4085 trace under `LD_PRELOAD=libssl.so.3:libcrypto.so.3`; starts fine without preload.
- After: repro starts, runs, and stops cleanly both with and without OpenSSL preloaded; `readelf -d build/liblogosdelivery.so` shows `SYMBOLIC`, and `LD_DEBUG=bindings` shows no more cross-library bindings for BoringSSL symbols.
- `make testcommon` 42/42 OK, `make testwaku` 893 OK / 0 failed (13 skipped), `make testwakunode2` 38/38 OK (POSTGRES=1).

## Possible follow-up (not in this PR)

A linker version script exporting only `logosdelivery_*` would additionally stop the library from polluting host processes with BoringSSL symbols (the reverse interposition direction) and shrink the dynamic symbol table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)