### PR TITLE
fix: android support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - 'BearSSL.mk'
           - 'Nat.mk'
           - 'vendor/zerokit'
+          - 'config.nims'
           - 'scripts/**'
           - 'flake.nix'
           - 'flake.lock'
@@ -166,12 +167,12 @@ jobs:
         with:
           ndk-version: r27c
 
-      # Keyed on the rev scripts/build_rln_android.sh pins.
+      # Keyed on the script so a change of the pinned cross rev invalidates it.
       - name: Cache cross
         uses: actions/cache@v3
         with:
           path: ~/.cargo/bin/cross
-          key: ${{ runner.os }}-cross-55f84725
+          key: ${{ runner.os }}-cross-${{ hashFiles('scripts/build_rln_android.sh') }}
 
       - name: Cache nimble deps
         id: cache-nimbledeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           - 'nimble.lock'
           - 'logos_delivery.nimble'
           - 'Makefile'
+          - 'BearSSL.mk'
+          - 'Nat.mk'
+          - 'vendor/zerokit'
           - 'scripts/**'
           - 'flake.nix'
           - 'flake.lock'
@@ -128,6 +131,80 @@ jobs:
     uses: ./.github/workflows/windows-build.yml
     with:
       branch: ${{ github.ref }}
+
+  build-android:
+    needs: changes
+    if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # arm64 only: amd64 is blocked by a nim-lsquic android type mismatch,
+        # 32-bit ABIs by int overflows in nim-brokers and waku_store_sync.
+        target: [arm64]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    name: build-android-${{ matrix.target }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
+        run: |
+          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
+          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
+
+      - name: Setup Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+
+      # Keyed on the rev scripts/build_rln_android.sh pins.
+      - name: Cache cross
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cross
+          key: ${{ runner.os }}-cross-55f84725
+
+      - name: Cache nimble deps
+        id: cache-nimbledeps
+        uses: actions/cache@v3
+        with:
+          path: |
+            nimbledeps/
+            nimble.paths
+          # Separate key: the android build rewrites the nimbledeps archives
+          # with the NDK compiler, so never share the host jobs' cache.
+          key: ${{ runner.os }}-nimbledeps-android-${{ matrix.target }}-v2-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
+
+      - name: Install nimble deps
+        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
+        run: |
+          # nim's source tree checksums differently across platforms, so its
+          # locked checksum is unreliable. --useSystemNim uses the CI nim and
+          # skips that check, while still verifying every other locked dep.
+          nimble setup --localdeps -y --useSystemNim
+          touch nimbledeps/.nimble-setup
+
+      - name: Build liblogosdelivery for android-${{ matrix.target }}
+        # -j1: see the build job.
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: make V=1 -j1 liblogosdelivery-android-${{ matrix.target }}
+
+      - name: Upload android libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: liblogosdelivery-android-${{ matrix.target }}
+          path: build/android/
+          retention-days: 1
 
   test:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -543,37 +543,41 @@ ifndef ANDROID_NDK_HOME
 	$(error ANDROID_NDK_HOME is not set)
 endif
 
+# librln and the NDK-built nat-libs must exist before the nim link consumes
+# them. PORTABLE_NAT_MARCH is host-derived and invalid for the arm targets.
 build-liblogosdelivery-for-android-arch:
-ifneq ($(findstring /nix/store,$(LIBRLN_FILE)),)
 	mkdir -p $(CURDIR)/build/android/$(ABIDIR)/
-	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid
+ifneq ($(findstring /nix/store,$(LIBRLN_FILE)),)
+	cp -f $(LIBRLN_FILE) $(CURDIR)/build/android/$(ABIDIR)/
 else
+	git submodule update --init vendor/zerokit
 	./scripts/build_rln_android.sh $(CURDIR)/build $(LIBRLN_BUILDDIR) $(LIBRLN_VERSION) $(CROSS_TARGET) $(ABIDIR)
 endif
-	$(MAKE) rebuild-nat-libs-nimbledeps CC=$(ANDROID_TOOLCHAIN_DIR)/bin/$(ANDROID_COMPILER)
+	$(MAKE) rebuild-nat-libs-nimbledeps CC=$(ANDROID_TOOLCHAIN_DIR)/bin/$(ANDROID_COMPILER) PORTABLE_NAT_MARCH=
+	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid
 
 liblogosdelivery-android-arm64: ANDROID_ARCH=aarch64-linux-android
 liblogosdelivery-android-arm64: CPU=arm64
 liblogosdelivery-android-arm64: ABIDIR=arm64-v8a
-liblogosdelivery-android-arm64: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-arm64: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-amd64: ANDROID_ARCH=x86_64-linux-android
 liblogosdelivery-android-amd64: CPU=amd64
 liblogosdelivery-android-amd64: ABIDIR=x86_64
-liblogosdelivery-android-amd64: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-amd64: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-x86: ANDROID_ARCH=i686-linux-android
 liblogosdelivery-android-x86: CPU=i386
 liblogosdelivery-android-x86: ABIDIR=x86
-liblogosdelivery-android-x86: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-x86: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-arm: ANDROID_ARCH=armv7a-linux-androideabi
 liblogosdelivery-android-arm: CPU=arm
 liblogosdelivery-android-arm: ABIDIR=armeabi-v7a
-liblogosdelivery-android-arm: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-arm: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=armv7-linux-androideabi CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android:

--- a/Makefile
+++ b/Makefile
@@ -547,12 +547,8 @@ endif
 # them. PORTABLE_NAT_MARCH is host-derived and invalid for the arm targets.
 build-liblogosdelivery-for-android-arch:
 	mkdir -p $(CURDIR)/build/android/$(ABIDIR)/
-ifneq ($(findstring /nix/store,$(LIBRLN_FILE)),)
-	cp -f $(LIBRLN_FILE) $(CURDIR)/build/android/$(ABIDIR)/
-else
 	git submodule update --init vendor/zerokit
 	./scripts/build_rln_android.sh $(CURDIR)/build $(LIBRLN_BUILDDIR) $(LIBRLN_VERSION) $(CROSS_TARGET) $(ABIDIR)
-endif
 	$(MAKE) rebuild-nat-libs-nimbledeps CC=$(ANDROID_TOOLCHAIN_DIR)/bin/$(ANDROID_COMPILER) PORTABLE_NAT_MARCH=
 	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid
 

--- a/Makefile
+++ b/Makefile
@@ -531,37 +531,41 @@ ifndef ANDROID_NDK_HOME
 	$(error ANDROID_NDK_HOME is not set)
 endif
 
+# librln and the NDK-built nat-libs must exist before the nim link consumes
+# them. PORTABLE_NAT_MARCH is host-derived and invalid for the arm targets.
 build-liblogosdelivery-for-android-arch:
-ifneq ($(findstring /nix/store,$(LIBRLN_FILE)),)
 	mkdir -p $(CURDIR)/build/android/$(ABIDIR)/
-	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid
+ifneq ($(findstring /nix/store,$(LIBRLN_FILE)),)
+	cp -f $(LIBRLN_FILE) $(CURDIR)/build/android/$(ABIDIR)/
 else
+	git submodule update --init vendor/zerokit
 	./scripts/build_rln_android.sh $(CURDIR)/build $(LIBRLN_BUILDDIR) $(LIBRLN_VERSION) $(CROSS_TARGET) $(ABIDIR)
 endif
-	$(MAKE) rebuild-nat-libs-nimbledeps CC=$(ANDROID_TOOLCHAIN_DIR)/bin/$(ANDROID_COMPILER)
+	$(MAKE) rebuild-nat-libs-nimbledeps CC=$(ANDROID_TOOLCHAIN_DIR)/bin/$(ANDROID_COMPILER) PORTABLE_NAT_MARCH=
+	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid
 
 liblogosdelivery-android-arm64: ANDROID_ARCH=aarch64-linux-android
 liblogosdelivery-android-arm64: CPU=arm64
 liblogosdelivery-android-arm64: ABIDIR=arm64-v8a
-liblogosdelivery-android-arm64: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-arm64: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-amd64: ANDROID_ARCH=x86_64-linux-android
 liblogosdelivery-android-amd64: CPU=amd64
 liblogosdelivery-android-amd64: ABIDIR=x86_64
-liblogosdelivery-android-amd64: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-amd64: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-x86: ANDROID_ARCH=i686-linux-android
 liblogosdelivery-android-x86: CPU=i386
 liblogosdelivery-android-x86: ABIDIR=x86
-liblogosdelivery-android-x86: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-x86: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-arm: ANDROID_ARCH=armv7a-linux-androideabi
 liblogosdelivery-android-arm: CPU=arm
 liblogosdelivery-android-arm: ABIDIR=armeabi-v7a
-liblogosdelivery-android-arm: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-arm: | liblogosdelivery-android-precheck build deps build-deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=armv7-linux-androideabi CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android:

--- a/Nat.mk
+++ b/Nat.mk
@@ -28,6 +28,10 @@ else
   PORTABLE_NAT_MARCH :=
 endif
 
+# The vendored sub-makes are mtime-only and do not track the compiler, so a
+# CC change (host <-> Android NDK clang) must clean before rebuilding.
+NAT_CC_STAMP := $(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/.nat-libs-cc
+
 .PHONY: rebuild-nat-libs-nimbledeps
 
 rebuild-nat-libs-nimbledeps:
@@ -44,6 +48,10 @@ ifeq ($(OS), Windows_NT)
 		CFLAGS="-Wall -Wno-cpp -Os -fPIC -DWIN32 -DNATPMP_STATICLIB -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
 		libnatpmp.a $(HANDLE_OUTPUT)
 else
+	@if [ "`cat '$(NAT_CC_STAMP)' 2>/dev/null`" != "$(CC)" ]; then \
+		echo "nat-libs were built with a different CC — cleaning for rebuild"; \
+		find "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor" \( -name '*.o' -o -name '*.a' \) -delete; \
+	fi
 # Delete the archives that the nimble install hook of nat_traversal already
 # built before nimble copied the package into nimbledeps/pkgs2/.
 #
@@ -63,4 +71,5 @@ else
 	+ "$(MAKE)" CFLAGS="-Wall -Wno-cpp -Os -fPIC $(PORTABLE_NAT_MARCH) -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
 		-C "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/libnatpmp-upstream" \
 		CC=$(CC) libnatpmp.a $(HANDLE_OUTPUT)
+	@echo '$(CC)' > '$(NAT_CC_STAMP)'
 endif

--- a/Nat.mk
+++ b/Nat.mk
@@ -28,6 +28,10 @@ else
   PORTABLE_NAT_MARCH :=
 endif
 
+# The vendored sub-makes are mtime-only and do not track the compiler, so a
+# CC change (host <-> Android NDK clang) must clean before rebuilding.
+NAT_CC_STAMP := $(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/.nat-libs-cc
+
 .PHONY: rebuild-nat-libs-nimbledeps
 
 rebuild-nat-libs-nimbledeps:
@@ -44,9 +48,14 @@ ifeq ($(OS), Windows_NT)
 		CFLAGS="-Wall -Wno-cpp -Os -fPIC -DWIN32 -DNATPMP_STATICLIB -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
 		libnatpmp.a $(HANDLE_OUTPUT)
 else
+	@if [ "`cat '$(NAT_CC_STAMP)' 2>/dev/null`" != "$(CC)" ]; then \
+		echo "nat-libs were built with a different CC — cleaning for rebuild"; \
+		find "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor" \( -name '*.o' -o -name '*.a' \) -delete; \
+	fi
 	+ "$(MAKE)" -C "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/miniupnp/miniupnpc" \
 		CC=$(CC) CFLAGS="-Os -fPIC $(PORTABLE_NAT_MARCH)" build/libminiupnpc.a $(HANDLE_OUTPUT)
 	+ "$(MAKE)" CFLAGS="-Wall -Wno-cpp -Os -fPIC $(PORTABLE_NAT_MARCH) -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 $(CFLAGS)" \
 		-C "$(NAT_TRAVERSAL_NIMBLEDEPS_DIR)/vendor/libnatpmp-upstream" \
 		CC=$(CC) libnatpmp.a $(HANDLE_OUTPUT)
+	@echo '$(CC)' > '$(NAT_CC_STAMP)'
 endif

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -192,7 +192,7 @@ proc buildMobileAndroid(srcDir = ".", params = "") =
 
   # -Bsymbolic: see buildLibrary's dynamic branch (issue #4085).
   exec "nim c" & " --out:" & outDir &
-    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-Wl,-Bsymbolic --passL:-L" &
+    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll -d:discv5_protocol_id=d5waku --passL:-Wl,-Bsymbolic --passL:-L" &
     outdir & " --passL:-lrln --passL:-llog --cpu:" & cpu & " --nimMainPrefix:liblogosdelivery --os:android -d:androidNDK " & params &
     getNimParams() & " " & srcDir & "/liblogosdelivery.nim"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -32,9 +32,9 @@ requires "nim >= 2.2.4",
   "faststreams",
   # Networking & P2P
   "https://github.com/vacp2p/nim-libp2p.git#v2.0.0",
-  # pinned to the locked commit: a fresh resolve of "eth" takes nim-eth HEAD,
+  # 0.9.0 is the locked version; an unversioned "eth" resolves to nim-eth HEAD,
   # which no longer ships eth/p2p/discoveryv5/enr.
-  "https://github.com/status-im/nim-eth#d9135e6c3c5d6d819afdfb566aa8d958756b73a8",
+  "eth == 0.9.0",
   "nat_traversal",
   "dnsdisc",
   "dnsclient",

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -32,12 +32,15 @@ requires "nim >= 2.2.4",
   "faststreams",
   # Networking & P2P
   "https://github.com/vacp2p/nim-libp2p.git#v2.0.0",
-  "eth",
+  # pinned to the locked commit: a fresh resolve of "eth" takes nim-eth HEAD,
+  # which no longer ships eth/p2p/discoveryv5/enr.
+  "https://github.com/status-im/nim-eth#d9135e6c3c5d6d819afdfb566aa8d958756b73a8",
   "nat_traversal",
   "dnsdisc",
   "dnsclient",
   "httputils >= 0.4.1",
-  "websock >= 0.3.0",
+  # < 0.4.2: websock 0.4.2 requires chronos >= 4.4.0 (chronos is pinned < 4.4.0).
+  "websock >= 0.3.0 & < 0.4.2",
   # Cryptography
   "nimcrypto == 0.6.4", # 0.6.4 used in libp2p. Version 0.7.3 makes test to crash on Ubuntu.
   "secp256k1",
@@ -193,7 +196,7 @@ proc buildMobileAndroid(srcDir = ".", params = "") =
     mkDir outDir
 
   exec "nim c" & " --out:" & outDir &
-    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-L" &
+    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll -d:discv5_protocol_id=d5waku --passL:-L" &
     outdir & " --passL:-lrln --passL:-llog --cpu:" & cpu & " --nimMainPrefix:liblogosdelivery --os:android -d:androidNDK " & params &
     getNimParams() & " " & srcDir & "/liblogosdelivery.nim"
 

--- a/scripts/build_rln_android.sh
+++ b/scripts/build_rln_android.sh
@@ -12,16 +12,19 @@ abi=$5
 [[ -z "${android_arch}" ]]    && { echo "No android architecture specified";  exit 1; }
 [[ -z "${abi}" ]]             && { echo "No abi specified";                   exit 1; }
 
+set -e
+
 export RUSTFLAGS="-Ccodegen-units=1"
 
-rustup upgrade
-
-cargo install cross --git https://github.com/cross-rs/cross
+# cross compiles the Rust lib inside Docker images that bundle their own
+# Android toolchain; pinned so upstream changes cannot break this build.
+if ! command -v cross >/dev/null 2>&1; then
+  cargo install cross --git https://github.com/cross-rs/cross --rev 55f84725
+fi
 
 output_dir=`echo ${nwaku_build_dir}/android/${abi}`
 mkdir -p ${output_dir}
 pushd ${zerokit_dir}/rln
-cargo clean
 cross rustc --release --lib --target=${android_arch} --crate-type=cdylib
 cp ../target/${android_arch}/release/librln.so ${output_dir}/.
 popd


### PR DESCRIPTION
Part of logos-messaging/pm#468 · related: #3232

**Problem:** the Android build has been broken since the nimble migration (f5762af4) `make liblogosdelivery-android-<arch>` never produced a library, and no CI job existed to catch it.

**Fix:** repaired the build recipe (correct librln / nat-libs / nim link order, missing deps, discv5 protocol id) and added a `build-android` CI job (NDK r27c) so it stays green.

Verified: arm64 builds a working bionic `liblogosdelivery.so`. amd64 and x86 are blocked by upstream 32-bit/android bugs matrix grows once those land.