### PR TITLE
test: revive three orphaned sharding suites

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -3,12 +3,7 @@
 import ./test_waku
 
 # Waku core test suite
-import
-  ./waku_core/test_namespaced_topics,
-  ./waku_core/test_time,
-  ./waku_core/test_message_digest,
-  ./waku_core/test_peers,
-  ./waku_core/test_published_address
+import ./waku_core/test_all
 
 # Waku archive test suite
 import
@@ -46,6 +41,7 @@ import ./waku_store_sync/test_all
 
 import
   ./node/test_all,
+  ./waku_enr/test_all,
   ./waku_filter_v2/test_all,
   ./waku_peer_exchange/test_all,
   ./waku_lightpush_legacy/test_all,

--- a/tests/node/test_all.nim
+++ b/tests/node/test_all.nim
@@ -8,4 +8,5 @@ import
   ./test_wakunode_store,
   ./test_wakunode_peer_manager,
   ./test_wakunode_health_monitor,
-  ./test_wakunode_restart
+  ./test_wakunode_restart,
+  ./test_wakunode_sharding

--- a/tests/node/test_wakunode_sharding.nim
+++ b/tests/node/test_wakunode_sharding.nim
@@ -3,12 +3,13 @@
 import results, std/[sequtils, tempfiles], testutils/unittests, chronos, chronicles
 
 import
-  std/[sequtils, tempfiles],
+  std/[sequtils, sets, tables, tempfiles],
   stew/byteutils,
   testutils/unittests,
   chronos,
   libp2p/switch,
-  libp2p/protocols/pubsub/pubsub
+  libp2p/protocols/pubsub/pubsub,
+  libp2p/protocols/pubsub/gossipsub
 
 import
   logos_delivery/waku/[
@@ -18,6 +19,7 @@ import
     common/paging,
     waku_core,
     waku_store/common,
+    waku_lightpush_legacy/protocol_metrics,
     node/peer_manager,
     waku_filter_v2/client,
   ],
@@ -25,11 +27,25 @@ import
   ../waku_archive/archive_utils,
   ../testlib/[assertions, common, wakucore, wakunode, testasync, futures, testutils]
 
-import waku_relay/protocol
+import logos_delivery/waku/waku_relay/protocol
 
 const
   listenIp = parseIpAddress("0.0.0.0")
   listenPort = Port(0)
+  # every shard id hardcoded below is the gen-zero derivation over 65536 shards
+  autoShardCount = 65536'u32
+
+proc waitForTopicPeer(
+    node: WakuNode, topic: PubsubTopic, peer: PeerId, timeout = 5.seconds
+) {.async.} =
+  ## Waits until node's gossipsub has learnt that peer subscribes to topic.
+  let deadline = Moment.now() + timeout
+  while Moment.now() < deadline:
+    for p in GossipSub(node.wakuRelay).gossipsub.getOrDefault(topic):
+      if p.peerId == peer:
+        return
+    await sleepAsync(10.milliseconds)
+  raiseAssert $peer & " never announced a subscription to " & topic
 
 suite "Sharding":
   var
@@ -45,6 +61,9 @@ suite "Sharding":
     client = newTestWakuNode(clientKey, listenIp, listenPort)
 
     await allFutures(server.mountRelay(), client.mountRelay())
+    for node in [server, client]:
+      node.mountAutoSharding(DefaultClusterId, autoShardCount).isOkOr:
+        raiseAssert "mountAutoSharding failed: " & error
     await allFutures(server.start(), client.start())
 
   asyncTeardown:
@@ -59,6 +78,8 @@ suite "Sharding":
         clientHandler = client.subscribeCompletionHandler(topic)
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(topic, server.switch.peerInfo.peerId)
+      await server.waitForTopicPeer(topic, client.switch.peerInfo.peerId)
 
       # When the client publishes a message in the subscribed topic
       discard await client.publish(
@@ -101,9 +122,9 @@ suite "Sharding":
         serverHandler = server.subscribeCompletionHandler(topic1)
         clientHandler = client.subscribeCompletionHandler(topic2)
 
-      # await sleepAsync(FUTURE_TIMEOUT)
-
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(topic1, server.switch.peerInfo.peerId)
+      await server.waitForTopicPeer(topic2, client.switch.peerInfo.peerId)
 
       # When a message is published in the server's subscribed topic
       discard await client.publish(
@@ -146,6 +167,8 @@ suite "Sharding":
         clientHandler = client.subscribeToContentTopicWithHandler(contentTopicFull)
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(pubsubTopic, server.switch.peerInfo.peerId)
+      await server.waitForTopicPeer(pubsubTopic, client.switch.peerInfo.peerId)
 
       # When the client publishes a message
       discard await client.publish(
@@ -180,7 +203,6 @@ suite "Sharding":
       let
         contentTopic1 = "/toychat/2/huilong/proto"
         shard1 = "/waku/2/rs/0/58355"
-        shard12 = RelayShard.parse(contentTopic1)
           # Automatically generated from the contentTopic above
         contentTopic2 = "/0/toychat2/2/huilong/proto"
         shard2 = "/waku/2/rs/0/23286"
@@ -191,6 +213,8 @@ suite "Sharding":
         clientHandler = client.subscribeToContentTopicWithHandler(contentTopic2)
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(shard1, server.switch.peerInfo.peerId)
+      await server.waitForTopicPeer(shard2, client.switch.peerInfo.peerId)
 
       # When the server publishes a message in the server's subscribed topic
       discard await server.publish(
@@ -229,8 +253,8 @@ suite "Sharding":
           serverHandler = server.subscribeCompletionHandler(pubsubTopic)
           clientHandler = client.subscribeCompletionHandler(pubsubTopic)
 
-        await sleepAsync(FUTURE_TIMEOUT)
         await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+        await client.waitForTopicPeer(pubsubTopic, server.switch.peerInfo.peerId)
 
         # When the client publishes a message
         discard await client.publish(
@@ -280,13 +304,14 @@ suite "Sharding":
       asyncTest "lightpush":
         # Given a connected server and client subscribed to the same pubsub topic
         client.mountLegacyLightPushClient()
-        check (await server.mountLightpush()).isOk()
+        check (await server.mountLegacyLightPush()).isOk()
 
         let
           topic = "/waku/2/rs/0/1"
           clientHandler = client.subscribeCompletionHandler(topic)
 
         await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+        await server.waitForTopicPeer(topic, client.switch.peerInfo.peerId)
 
         # When a peer publishes a message (the client, for testing easeness)
         let
@@ -310,8 +335,9 @@ suite "Sharding":
           serverHandler = server.subscribeToContentTopicWithHandler(contentTopicShort)
           clientHandler = client.subscribeToContentTopicWithHandler(contentTopicFull)
 
-        await sleepAsync(FUTURE_TIMEOUT)
         await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+        await client.waitForTopicPeer(pubsubTopic, server.switch.peerInfo.peerId)
+        await server.waitForTopicPeer(pubsubTopic, client.switch.peerInfo.peerId)
 
         # When the client publishes a message
         discard await client.publish(
@@ -400,10 +426,43 @@ suite "Sharding":
         assertResultOk(pushHandlerResult2)
         check pushHandlerResult2.get() == (pubsubTopic, msg2)
 
+      asyncTest "filter (shard deduced from content topic)":
+        # Given a connected server and client, and a subscription without a pubsub topic
+        await client.mountFilterClient()
+        await server.mountFilter()
+
+        let pushHandlerFuture = newFuture[(string, WakuMessage)]()
+        proc messagePushHandler(
+            pubsubTopic: PubsubTopic, message: WakuMessage
+        ): Future[void] {.async, closure, gcsafe.} =
+          pushHandlerFuture.complete((pubsubTopic, message))
+
+        client.wakuFilterClient.registerPushHandler(messagePushHandler)
+        let
+          contentTopic = "/toychat/2/huilong/proto"
+          pubsubTopic = "/waku/2/rs/0/58355"
+          subscribeResponse = await client.filterSubscribe(
+            Opt.none(PubsubTopic),
+            @[contentTopic],
+            server.switch.peerInfo.toRemotePeerInfo(),
+          )
+
+        assertResultOk(subscribeResponse)
+        await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+
+        # When the server pushes a message on the shard that content topic maps to
+        let msg = WakuMessage(payload: "message1".toBytes(), contentTopic: contentTopic)
+        await server.filterHandleMessage(pubsubTopic, msg)
+
+        # Then the client receives it, so the subscription landed on that shard
+        let pushHandlerResult = await pushHandlerFuture.waitForResult(FUTURE_TIMEOUT)
+        assertResultOk(pushHandlerResult)
+        check pushHandlerResult.get() == (pubsubTopic, msg)
+
       asyncTest "lightpush (automatic sharding filtering)":
         # Given a connected server and client using the same content topic (with two different formats)
         client.mountLegacyLightPushClient()
-        check (await server.mountLightpush()).isOk()
+        check (await server.mountLegacyLightPush()).isOk()
 
         let
           contentTopicShort = "/toychat/2/huilong/proto"
@@ -412,6 +471,7 @@ suite "Sharding":
           clientHandler = client.subscribeToContentTopicWithHandler(contentTopicShort)
 
         await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+        await server.waitForTopicPeer(pubsubTopic, client.switch.peerInfo.peerId)
 
         # When a peer publishes a message (the client, for testing easeness)
         let
@@ -425,6 +485,7 @@ suite "Sharding":
         let clientResult = await clientHandler.waitForResult(FUTURE_TIMEOUT)
         assertResultOk(clientResult)
 
+      # store matches content topics as literal strings, so the two forms never meet
       xasyncTest "store (automatic sharding filtering)":
         # Given one archive with two sets of messages using the same content topic (with two different formats)
         let
@@ -447,7 +508,7 @@ suite "Sharding":
         let mountArchiveResult = server.mountArchive(archiveDriver)
         assertResultOk(mountArchiveResult)
 
-        waitFor server.mountStore()
+        await server.mountStore()
         client.mountStoreClient()
 
         # Given one query for each content topic format
@@ -492,8 +553,9 @@ suite "Sharding":
           serverHandler = server.subscribeToContentTopicWithHandler(contentTopic1)
           clientHandler = client.subscribeToContentTopicWithHandler(contentTopic2)
 
-        await sleepAsync(FUTURE_TIMEOUT)
         await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+        await client.waitForTopicPeer(pubsubTopic1, server.switch.peerInfo.peerId)
+        await server.waitForTopicPeer(pubsubTopic2, client.switch.peerInfo.peerId)
 
         # When the client publishes a message in the client's subscribed topic
         discard await client.publish(
@@ -563,7 +625,7 @@ suite "Sharding":
       asyncTest "lightpush - exclusion (automatic sharding filtering)":
         # Given a connected server and client using different content topics
         client.mountLegacyLightPushClient()
-        check (await server.mountLightpush()).isOk()
+        check (await server.mountLegacyLightPush()).isOk()
 
         let
           contentTopic1 = "/toychat/2/huilong/proto"
@@ -575,6 +637,7 @@ suite "Sharding":
           clientHandler = client.subscribeToContentTopicWithHandler(contentTopic1)
 
         await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+        await server.waitForTopicPeer(pubsubTopic1, client.switch.peerInfo.peerId)
 
         # When a peer publishes a message in the server's subscribed topic (the client, for testing easeness)
         let
@@ -583,9 +646,11 @@ suite "Sharding":
             Opt.some(pubsubTopic2), msg, server.switch.peerInfo.toRemotePeerInfo()
           )
 
-        # Then the client does not receive the message
+        # Then the server finds no peer on that shard and the client gets nothing
         let clientResult = await clientHandler.waitForResult(FUTURE_TIMEOUT)
-        check clientResult.isErr()
+        check:
+          lightpublishRespnse.error == protocol_metrics.notPublishedAnyPeer
+          clientResult.isErr()
 
       asyncTest "store - exclusion (automatic sharding filtering)":
         # Given one archive with two sets of messages using different content topics
@@ -612,7 +677,7 @@ suite "Sharding":
         let mountArchiveResult = server.mountArchive(archiveDriver)
         assertResultOk(mountArchiveResult)
 
-        waitFor server.mountStore()
+        await server.mountStore()
         client.mountStoreClient()
 
         # Given one query for each content topic
@@ -656,6 +721,8 @@ suite "Sharding":
         clientHandler2 = client.subscribeCompletionHandler(topic2)
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(topic1, server.switch.peerInfo.peerId)
+      await client.waitForTopicPeer(topic2, server.switch.peerInfo.peerId)
 
       # When the client publishes a message in the topic1
       discard await client.publish(
@@ -702,6 +769,8 @@ suite "Sharding":
         clientHandler2 = client.subscribeToContentTopicWithHandler(contentTopic2)
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(pubsubTopic1, server.switch.peerInfo.peerId)
+      await client.waitForTopicPeer(pubsubTopic2, server.switch.peerInfo.peerId)
 
       # When the client publishes a message in contentTopic1
       discard await client.publish(
@@ -755,6 +824,8 @@ suite "Sharding":
         clientHandler4 = client.subscribeToContentTopicWithHandler(contentTopic4)
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      for topic in [pubsubTopic1, pubsubTopic2, pubsubTopic3, pubsubTopic4]:
+        await client.waitForTopicPeer(topic, server.switch.peerInfo.peerId)
 
       # When the client publishes a message in the topic1
       discard await client.publish(
@@ -859,22 +930,24 @@ suite "Sharding":
         clientHandler = client.subscribeCompletionHandler("/waku/2/rs/0/0")
 
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer("/waku/2/rs/0/0", server.switch.peerInfo.peerId)
 
       # When the client publishes a message in the topic
-      discard await client.publish(
+      let publishResult = await client.publish(
         Opt.some(topic),
         WakuMessage(payload: "message1".toBytes(), contentTopic: contentTopic),
       )
 
-      # Then the server and client don't receive the message
+      # Then the publish is rejected, and neither node receives the message
       check:
+        publishResult.isErr()
         (await serverHandler.waitForResult(FUTURE_TIMEOUT)).isErr()
         (await clientHandler.waitForResult(FUTURE_TIMEOUT)).isErr()
 
     asyncTest "Waku LightPush Sharding (Static Sharding)":
       # Given a connected server and client using two different pubsub topics
       client.mountLegacyLightPushClient()
-      check (await server.mountLightpush()).isOk()
+      check (await server.mountLegacyLightPush()).isOk()
 
       # Given a connected server and client subscribed to multiple pubsub topics
       let
@@ -886,9 +959,9 @@ suite "Sharding":
         clientHandler1 = client.subscribeCompletionHandler(topic1)
         clientHandler2 = client.subscribeCompletionHandler(topic2)
 
-      await sleepAsync(FUTURE_TIMEOUT)
-
       await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await server.waitForTopicPeer(topic1, client.switch.peerInfo.peerId)
+      await server.waitForTopicPeer(topic2, client.switch.peerInfo.peerId)
 
       # When a peer publishes a message (the client, for testing easeness) in topic1
       let
@@ -1002,7 +1075,7 @@ suite "Sharding":
       let mountArchiveResult = server.mountArchive(archiveDriver)
       assertResultOk(mountArchiveResult)
 
-      waitFor server.mountStore()
+      await server.mountStore()
       client.mountStoreClient()
 
       # Given one query for each pubsub topic

--- a/tests/waku_core/test_all.nim
+++ b/tests/waku_core/test_all.nim
@@ -5,5 +5,6 @@ import
   ./test_namespaced_topics,
   ./test_peers,
   ./test_published_address,
-  ./test_sharding,
-  ./test_time
+  ./test_time,
+  ./topics/test_pubsub_topic,
+  ./topics/test_sharding

--- a/tests/waku_core/topics/test_sharding.nim
+++ b/tests/waku_core/topics/test_sharding.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import results, std/tables, testutils/unittests
 
 import logos_delivery/waku/waku_core/topics, ../../testlib/[wakucore, tables, testutils]
@@ -7,7 +9,6 @@ const ClusterId = 1
 
 suite "Autosharding":
   const
-    pubsubTopic04 = "/waku/2/rs/0/4"
     pubsubTopic13 = "/waku/2/rs/1/3"
     contentTopicShort = "/toychat/2/huilong/proto"
     contentTopicFull = "/0/toychat/2/huilong/proto"
@@ -15,10 +16,8 @@ suite "Autosharding":
     contentTopicFull2 = "/0/toychat2/2/huilong/proto"
     contentTopicShort3 = "/toychat/2/huilong/proto2"
     contentTopicFull3 = "/0/toychat/2/huilong/proto2"
-    contentTopicShort4 = "/toychat/4/huilong/proto2"
     contentTopicFull4 = "/0/toychat/4/huilong/proto2"
     contentTopicFull5 = "/1/toychat/2/huilong/proto"
-    contentTopicFull6 = "/1/toychat2/2/huilong/proto"
     contentTopicInvalid = "/1/toychat/2/huilong/proto"
 
   suite "getGenZeroShard":
@@ -71,7 +70,7 @@ suite "Autosharding":
         Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
 
       # When we get a shard from a topic without generation
-      let shard = sharding.getShard(contentTopicShort)
+      let shard = sharding.getShard(NsContentTopic.parse(contentTopicShort).value())
 
       # Then the generated shard is valid
       check:
@@ -81,7 +80,7 @@ suite "Autosharding":
       let sharding =
         Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
       # When we get a shard from a gen0 topic
-      let shard = sharding.getShard(contentTopicFull)
+      let shard = sharding.getShard(NsContentTopic.parse(contentTopicFull).value())
 
       # Then the generated shard is valid
       check:
@@ -91,7 +90,7 @@ suite "Autosharding":
       let sharding =
         Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
       # When we get a shard from ain invalid content topic
-      let shard = sharding.getShard(contentTopicInvalid)
+      let shard = sharding.getShard(NsContentTopic.parse(contentTopicInvalid).value())
 
       # Then the generated shard is valid
       check:
@@ -136,73 +135,51 @@ suite "Autosharding":
 
       # Then the generated shard is valid
       check:
-        shard.error() == "invalid format: topic must start with slash"
+        shard.error() == "invalid format: content-topic 'invalid' must start with slash"
 
-  suite "parseSharding":
+  suite "getShardsFromContentTopics":
     test "contentTopics is ContentTopic":
       let sharding =
         Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
       # When calling with contentTopic as string
-      let topicMap = sharding.parseSharding(Opt.some(pubsubTopic04), contentTopicShort)
-
-      # Then the topicMap is valid
-      check:
-        topicMap.value() == {pubsubTopic04: @[contentTopicShort]}
-
-    test "contentTopics is seq[ContentTopic]":
-      let sharding =
-        Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
-      # When calling with contentTopic as string seq
-      let topicMap = sharding.parseSharding(
-        Opt.some(pubsubTopic04), @[contentTopicShort, "/0/foo/1/bar/proto"]
-      )
-
-      # Then the topicMap is valid
-      check:
-        topicMap.value() == {pubsubTopic04: @[contentTopicShort, "/0/foo/1/bar/proto"]}
-
-    test "pubsubTopic is none":
-      let sharding =
-        Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
-      # When calling with pubsubTopic as none
-      let topicMap = sharding.parseSharding(Opt.none(PubsubTopic), contentTopicShort)
+      let topicMap = sharding.getShardsFromContentTopics(contentTopicShort)
 
       # Then the topicMap is valid
       check:
         topicMap.value() == {pubsubTopic13: @[contentTopicShort]}
 
+    test "contentTopics is seq[ContentTopic]":
+      let sharding =
+        Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
+      # When calling with contentTopic as string seq
+      let topicMap =
+        sharding.getShardsFromContentTopics(@[contentTopicShort, contentTopicShort3])
+
+      # Then the topicMap is valid
+      check:
+        topicMap.value() == {pubsubTopic13: @[contentTopicShort, contentTopicShort3]}
+
     test "content parse error":
       let sharding =
         Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
-      # When calling with pubsubTopic as none with invalid content
-      let topicMap = sharding.parseSharding(Opt.none(PubsubTopic), "invalid")
+      # When calling with an invalid content topic
+      let topicMap = sharding.getShardsFromContentTopics("invalid")
 
       # Then the topicMap is valid
       check:
         topicMap.error() ==
-          "Cannot parse content topic: invalid format: topic must start with slash"
+          "Cannot parse content topic: invalid format: content-topic 'invalid' must start with slash"
 
-    test "pubsubTopic parse error":
+    test "shard deduction error":
       let sharding =
         Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
-      # When calling with pubsubTopic as none with invalid content
-      let topicMap = sharding.parseSharding(Opt.some("invalid"), contentTopicShort)
+      # When calling with a content topic that cannot be autosharded
+      let topicMap = sharding.getShardsFromContentTopics(contentTopicInvalid)
 
       # Then the topicMap is valid
       check:
         topicMap.error() ==
-          "Cannot parse pubsub topic: invalid format: must start with /waku/2"
-
-    test "pubsubTopic getShard error":
-      let sharding =
-        Sharding(clusterId: ClusterId, shardCountGenZero: GenerationZeroShardsCount)
-      # When calling with pubsubTopic as none with invalid content
-      let topicMap = sharding.parseSharding(Opt.none(PubsubTopic), contentTopicInvalid)
-
-      # Then the topicMap is valid
-      check:
-        topicMap.error() ==
-          "Cannot autoshard content topic: Generation > 0 are not supported yet"
+          "Cannot deduce shard from content topic: Generation > 0 are not supported yet"
 
     xtest "catchable error on add to topicMap":
       # TODO: Trigger a CatchableError or mock

--- a/tests/waku_enr/test_all.nim
+++ b/tests/waku_enr/test_all.nim
@@ -1,1 +1,3 @@
+{.used.}
+
 import ./test_sharding

--- a/tests/waku_enr/test_sharding.nim
+++ b/tests/waku_enr/test_sharding.nim
@@ -1,6 +1,7 @@
 {.used.}
 
 import
+  std/sequtils,
   results,
   chronos,
   testutils/unittests,
@@ -8,7 +9,8 @@ import
   eth/keys as eth_keys
 
 import
-  logos_delivery/waku/[waku_enr, discovery/waku_discv5, waku_core, common/enr],
+  logos_delivery/waku/
+    [waku_enr, discovery/waku_discv5, waku_core, common/enr, net/auto_port],
   ../testlib/wakucore,
   ../waku_discv5/utils,
   ./utils
@@ -41,8 +43,7 @@ suite "Sharding":
       assert shardedRes.isOk(), shardedRes.error
       assert shardedRes.value.isSome()
       assert shardedRes.value.get() == shardsTopics, $shardedRes.value.get()
-      assert namedRes.isOk(), namedRes.error
-      assert namedRes.value.isNone(), $namedRes.value
+      assert namedRes.isErr(), $namedRes.value
       assert gibberishRes.isErr(), $gibberishRes.value
       assert emptyRes.isOk(), emptyRes.error
       assert emptyRes.value.isNone(), $emptyRes.value
@@ -58,43 +59,73 @@ suite "Sharding":
         bindIp = "0.0.0.0"
         extIp = "127.0.0.1"
         tcpPort = 61500u16
-        udpPort = 9000u16
-
-      let record = newTestEnrRecord(
-        privKey = privKey, extIp = extIp, tcpPort = tcpPort, udpPort = udpPort
-      )
 
       let queue = newAsyncEventQueue[SubscriptionEvent](30)
 
-      let node = newTestDiscv5(
-        privKey = privKey,
-        bindIp = bindIp,
-        tcpPort = tcpPort,
-        udpPort = udpPort,
-        record = record,
-        queue = queue,
-      )
+      proc attempt(
+          p: Port
+      ): Future[Result[WakuDiscoveryV5, string]] {.async: (raises: []).} =
+        let node =
+          try:
+            let record = newTestEnrRecord(
+              privKey = privKey, extIp = extIp, tcpPort = tcpPort, udpPort = uint16(p)
+            )
+            newTestDiscv5(
+              privKey = privKey,
+              bindIp = bindIp,
+              tcpPort = tcpPort,
+              udpPort = uint16(p),
+              record = record,
+              queue = queue,
+            )
+          except CatchableError as e:
+            return err("could not build discv5 node: " & e.msg)
+        (await node.start()).isOkOr:
+          return err(error)
+        ok(node)
 
-      let res = await node.start()
-      assert res.isOk(), res.error
+      let node = (await tryWithAutoPort[WakuDiscoveryV5](Port(0), attempt)).valueOr:
+        raiseAssert "could not start discv5 node: " & error
+
+      proc waitForShards(
+          shards: seq[string], present: bool, timeout = 5.seconds
+      ) {.async.} =
+        ## Waits until the ENR agrees with the emitted subscription events.
+        let deadline = Moment.now() + timeout
+        while Moment.now() < deadline:
+          if shards.allIt(node.protocol.localNode.record.containsShard(it) == present):
+            return
+          await sleepAsync(10.milliseconds)
+        raiseAssert "ENR never reached containsShard == " & $present & " for " & $shards
+
+      proc waitForEnrUpdate(previous: uint64, timeout = 5.seconds) {.async.} =
+        ## Waits for the next ENR revision, for events that leave the shards alone.
+        let deadline = Moment.now() + timeout
+        while Moment.now() < deadline:
+          if node.protocol.localNode.record.seqNum > previous:
+            return
+          await sleepAsync(10.milliseconds)
+        raiseAssert "ENR was never revised past seqNum " & $previous
 
       ## Then
       queue.emit((kind: PubsubSub, topic: shard1))
       queue.emit((kind: PubsubSub, topic: shard2))
       queue.emit((kind: PubsubSub, topic: shard3))
 
-      await sleepAsync(1.seconds)
+      await waitForShards(@[shard1, shard2, shard3], true)
 
       check:
         node.protocol.localNode.record.containsShard(shard1) == true
         node.protocol.localNode.record.containsShard(shard2) == true
         node.protocol.localNode.record.containsShard(shard3) == true
 
+      let seqNumBeforeResubscribe = node.protocol.localNode.record.seqNum
+
       queue.emit((kind: PubsubSub, topic: shard1))
       queue.emit((kind: PubsubSub, topic: shard2))
       queue.emit((kind: PubsubSub, topic: shard3))
 
-      await sleepAsync(1.seconds)
+      await waitForEnrUpdate(seqNumBeforeResubscribe)
 
       check:
         node.protocol.localNode.record.containsShard(shard1) == true
@@ -104,7 +135,7 @@ suite "Sharding":
       queue.emit((kind: PubsubUnsub, topic: shard1))
       queue.emit((kind: PubsubUnsub, topic: shard2))
 
-      await sleepAsync(1.seconds)
+      await waitForShards(@[shard1, shard2], false)
 
       check:
         node.protocol.localNode.record.containsShard(shard1) == false

--- a/tests/waku_relay/utils.nim
+++ b/tests/waku_relay/utils.nim
@@ -43,12 +43,10 @@ proc subscribeToContentTopicWithHandler*(
   proc relayHandler(
       topic: PubsubTopic, msg: WakuMessage
   ): Future[void] {.async, gcsafe.} =
-    if topic == topic:
-      completionFut.complete(true)
+    completionFut.complete(true)
 
   (node.subscribe((kind: ContentSub, topic: contentTopic), relayHandler)).isOkOr:
-    error "Failed to subscribe to content topic", error
-    completionFut.complete(true)
+    raiseAssert "Failed to subscribe to content topic " & contentTopic & ": " & error
   return completionFut
 
 proc subscribeCompletionHandler*(node: WakuNode, pubsubTopic: string): Future[bool] =


### PR DESCRIPTION
Three Nim sharding suites had never run — nothing imports them from an entry
point CI builds, so refactors passed them by. This wires them in and fixes what
had rotted. No product defect was found: every failure was a stale test
expectation.

- **`tests/node/test_wakunode_sharding.nim`** (added in #2603, May 2024) did not
  compile — line 28 was a bare `import waku_relay/protocol`. Once compiling:
  8 OK / 13 FAILED, from three test-side causes. Publish raced the peer's
  SUBSCRIBE, so 24 `waitForTopicPeer` calls now wait for the announcement (four
  sites had a fixed `sleepAsync`, the rest had no wait at all). Autosharding was
  never mounted, so 18 content-topic subscriptions failed. And #3279 renamed the
  lightpush client call in this file but not the server one, leaving a legacy
  client talking to a v3 server — Nim's style-insensitive identifiers hid it.
- **`tests/waku_core/topics/test_sharding.nim`** called `parseSharding`, removed
  in #3468. Of the two tests naming its pubsub-topic override, one duplicated a
  case the port already covers and one described a path production never took;
  the rest port to `getShardsFromContentTopics`. What no test covered is the
  opposite branch — deducing the shard when no pubsub topic is given, reachable
  in production through the REST filter handler — so it gets a node-level test.
- **`tests/waku_enr/test_sharding.nim`** asserted `ok(none)` for named sharding,
  deprecated in #2723; it is `isErr()` now. Since the file is about to run in CI
  for the first time, its discv5 node stops binding a hardcoded UDP port (it
  uses `tryWithAutoPort`, as `tests/waku_discv5` does) and its three one-second
  sleeps became polls: 3.0s -> 0.04s.

Three checks could not fail and now can: `subscribeToContentTopicWithHandler`
completed its future with `true` when the subscription **failed** (that is how
the delivery assertion in `lightpush (automatic sharding filtering)` passed
while nothing was delivered); `Protocol with Unconfigured PubSub Topic Fails`
discarded the publish result; and `lightpush - exclusion` asserted only that
nothing arrived, which also holds when lightpush is broken end to end.

Wired in through the per-directory `test_all` aggregates, replacing five direct
imports in `all_tests_waku`. That also revives
`waku_core/topics/test_pubsub_topic.nim` and two aggregators: 24 test files were
unreachable before this commit, 18 after.

Run locally on macOS — CI has never built these files before:

    test_wakunode_sharding   8 OK / 13 FAILED  ->  22 OK / 0 FAILED / 1 SKIPPED
    waku_core/topics         did not compile   ->  14 OK / 1 SKIPPED
    waku_enr                 3 OK /  1 FAILED  ->   4 OK
    all_tests_waku           955 tests, 940 OK, 0 FAILED, 15 SKIPPED