### PR TITLE
test: revive eight more orphaned suites

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -30,11 +30,7 @@ when os == "Linux" and
     ./wakunode_rest/test_all
 
 # Waku store test suite
-import
-  ./waku_store/test_client,
-  ./waku_store/test_rpc_codec,
-  ./waku_store/test_waku_store,
-  ./waku_store/test_wakunode_store
+import ./waku_store/test_all
 
 # Waku store sync suite
 import ./waku_store_sync/test_all
@@ -54,6 +50,8 @@ import
   ./test_wakunode,
   ./test_peer_store_extended,
   ./test_message_cache,
+  ./test_utils_compat,
+  ./test_waku_protobufs,
   ./test_peer_manager,
   ./test_peer_storage,
   ./test_waku_keepalive,

--- a/tests/node/peer_manager/peer_store/test_all.nim
+++ b/tests/node/peer_manager/peer_store/test_all.nim
@@ -1,0 +1,3 @@
+{.used.}
+
+import ./test_peer_storage, ./test_waku_peer_storage

--- a/tests/node/peer_manager/peer_store/test_peer_storage.nim
+++ b/tests/node/peer_manager/peer_store/test_peer_storage.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import results, testutils/unittests
 
 import

--- a/tests/node/peer_manager/peer_store/test_waku_peer_storage.nim
+++ b/tests/node/peer_manager/peer_store/test_waku_peer_storage.nim
@@ -1,5 +1,7 @@
+{.used.}
+
 import
-  std/[nativesockets, sequtils],
+  std/[nativesockets, net, sequtils],
   testutils/unittests,
   libp2p/[multiaddress, peerid],
   libp2p/crypto/crypto,
@@ -82,7 +84,6 @@ suite "Protobuf Serialisation":
         encodedRemotePeerInfo.buffer == expectedBuffer
         encodedRemotePeerInfo.offset == 152
         encodedRemotePeerInfo.length == 0
-        encodedRemotePeerInfo.maxSize == 4194304
 
   suite "decode":
     test "simple":

--- a/tests/node/peer_manager/test_all.nim
+++ b/tests/node/peer_manager/test_all.nim
@@ -1,0 +1,3 @@
+{.used.}
+
+import ./test_peer_manager, ./peer_store/test_all

--- a/tests/node/peer_manager/test_peer_manager.nim
+++ b/tests/node/peer_manager/test_peer_manager.nim
@@ -1,20 +1,22 @@
+{.used.}
+
 import results, chronicles, std/[tables, strutils], chronos, testutils/unittests
 
 import
-  logos_delivery/waku/node/waku_node,
+  logos_delivery/waku/waku_node,
   logos_delivery/waku/waku_core,
   ../../waku_lightpush/[lightpush_utils],
   ../../testlib/[wakucore, wakunode, futures, testasync],
   logos_delivery/waku/node/peer_manager/peer_manager
 
 suite "Peer Manager":
-  suite "onPeerMetadata":
+  suite "refreshPeerMetadata":
     var
       listenPort {.threadvar.}: Port
       listenAddress {.threadvar.}: IpAddress
       serverKey {.threadvar.}: PrivateKey
       clientKey {.threadvar.}: PrivateKey
-      clusterId {.threadvar.}: uint64
+      clusterId {.threadvar.}: uint16
 
     asyncSetup:
       listenPort = Port(0)
@@ -24,13 +26,21 @@ suite "Peer Manager":
       clusterId = 1
 
     asyncTest "light client is not disconnected":
-      # Given two nodes with the same shardId
+      # Given two nodes with different shardIds
       let
         server = newTestWakuNode(
-          serverKey, listenAddress, listenPort, clusterId = clusterId, shards = @[0]
+          serverKey,
+          listenAddress,
+          listenPort,
+          clusterId = clusterId,
+          subscribeShards = @[0'u16],
         )
         client = newTestWakuNode(
-          clientKey, listenAddress, listenPort, clusterId = clusterId, shards = @[1]
+          clientKey,
+          listenAddress,
+          listenPort,
+          clusterId = clusterId,
+          subscribeShards = @[1'u16],
         )
 
       # And both mount metadata and filter
@@ -50,7 +60,7 @@ suite "Peer Manager":
       await client.connectToNodes(@[serverRemotePeerInfo])
       await sleepAsync(FUTURE_TIMEOUT)
 
-      # When making an operation that triggers onPeerMetadata
+      # When the client issues a filter request
       discard await client.filterSubscribe(
         Opt.some("/waku/2/rs/0/0"), "waku/lightpush/1", serverRemotePeerInfo
       )
@@ -64,15 +74,23 @@ suite "Peer Manager":
       # Given two nodes with the same shardId
       let
         server = newTestWakuNode(
-          serverKey, listenAddress, listenPort, clusterId = clusterId, shards = @[0]
+          serverKey,
+          listenAddress,
+          listenPort,
+          clusterId = clusterId,
+          subscribeShards = @[0'u16],
         )
         client = newTestWakuNode(
-          clientKey, listenAddress, listenPort, clusterId = clusterId, shards = @[1]
+          clientKey,
+          listenAddress,
+          listenPort,
+          clusterId = clusterId,
+          subscribeShards = @[0'u16],
         )
 
       # And both mount metadata and relay
       discard
-        client.mountMetadata(0, @[1'u16]) # clusterId irrelevant, overridden by topic
+        client.mountMetadata(0, @[0'u16]) # clusterId irrelevant, overridden by topic
       discard
         server.mountMetadata(0, @[0'u16]) # clusterId irrelevant, overridden by topic
       (await client.mountRelay()).isOkOr:
@@ -89,8 +107,8 @@ suite "Peer Manager":
       await client.connectToNodes(@[serverRemotePeerInfo])
       await sleepAsync(FUTURE_TIMEOUT)
 
-      # When making an operation that triggers onPeerMetadata
-      client.subscribe((kind: SubscriptionKind.PubsubSub, topic: "newTopic")).isOkOr:
+      # When the client subscribes to a relay topic
+      client.subscribe((kind: SubscriptionKind.PubsubSub, topic: "newTopic"), nil).isOkOr:
         assert false, "Failed to subscribe to relay"
       await sleepAsync(FUTURE_TIMEOUT)
 
@@ -98,14 +116,22 @@ suite "Peer Manager":
         server.switch.isConnected(client.switch.peerInfo.toRemotePeerInfo().peerId)
         client.switch.isConnected(server.switch.peerInfo.toRemotePeerInfo().peerId)
 
-    asyncTest "relay with different shardId is disconnected":
+    asyncTest "relay with different shardId is not disconnected":
       # Given two nodes with different shardIds
       let
         server = newTestWakuNode(
-          serverKey, listenAddress, listenPort, clusterId = clusterId, shards = @[0]
+          serverKey,
+          listenAddress,
+          listenPort,
+          clusterId = clusterId,
+          subscribeShards = @[0'u16],
         )
         client = newTestWakuNode(
-          clientKey, listenAddress, listenPort, clusterId = clusterId, shards = @[1]
+          clientKey,
+          listenAddress,
+          listenPort,
+          clusterId = clusterId,
+          subscribeShards = @[1'u16],
         )
 
       # And both mount metadata and relay
@@ -127,11 +153,14 @@ suite "Peer Manager":
       await client.connectToNodes(@[serverRemotePeerInfo])
       await sleepAsync(FUTURE_TIMEOUT)
 
-      # When making an operation that triggers onPeerMetadata
-      client.subscribe((kind: SubscriptionKind.PubsubSub, topic: "newTopic")).isOkOr:
+      # When the client subscribes to a relay topic
+      client.subscribe((kind: SubscriptionKind.PubsubSub, topic: "newTopic"), nil).isOkOr:
         assert false, "Failed to subscribe to relay"
       await sleepAsync(FUTURE_TIMEOUT)
 
       check:
-        not server.switch.isConnected(client.switch.peerInfo.toRemotePeerInfo().peerId)
-        not client.switch.isConnected(server.switch.peerInfo.toRemotePeerInfo().peerId)
+        # the metadata exchange ran and recorded the disjoint shard sets
+        client.switch.peerStore[ShardBook][serverRemotePeerInfo.peerId] == @[0'u16]
+        server.switch.peerStore[ShardBook][client.switch.peerInfo.peerId] == @[1'u16]
+        server.switch.isConnected(client.switch.peerInfo.toRemotePeerInfo().peerId)
+        client.switch.isConnected(server.switch.peerInfo.toRemotePeerInfo().peerId)

--- a/tests/node/test_all.nim
+++ b/tests/node/test_all.nim
@@ -9,4 +9,5 @@ import
   ./test_wakunode_peer_manager,
   ./test_wakunode_health_monitor,
   ./test_wakunode_restart,
-  ./test_wakunode_sharding
+  ./test_wakunode_sharding,
+  ./peer_manager/test_all

--- a/tests/test_utils_compat.nim
+++ b/tests/test_utils_compat.nim
@@ -2,10 +2,7 @@
 
 import testutils/unittests
 import
-  results,
-  logos_delivery/waku/waku_core/message,
-  logos_delivery/waku/waku_core/time,
-  ./testlib/common
+  results, logos_delivery/waku/waku_core/message, logos_delivery/waku/waku_core/time
 
 suite "Waku Payload":
   test "Encode/Decode waku message with timestamp":

--- a/tests/test_waku_protobufs.nim
+++ b/tests/test_waku_protobufs.nim
@@ -1,17 +1,13 @@
 {.used.}
 
-import results, std/[sequtils, tables], testutils/unittests, chronos, chronicles
-import
-  logos_delivery/waku/waku_metadata,
-  logos_delivery/waku/waku_metadata/rpc,
-  ./testlib/wakucore,
-  ./testlib/wakunode
+import results, testutils/unittests, chronos
+import logos_delivery/waku/waku_metadata/rpc, ./testlib/wakucore
 
 procSuite "Waku Protobufs":
   # TODO: Missing test coverage in many encode/decode protobuf functions
 
   test "WakuMetadataResponse":
-    let res = WakuMetadataResponse(clusterId: Opt.some(7), shards: @[10, 23, 33])
+    let res = WakuMetadataResponse(clusterId: Opt.some(7'u32), shards: @[10, 23, 33])
 
     let buffer = res.encode()
 
@@ -22,7 +18,7 @@ procSuite "Waku Protobufs":
       decodedBuff.get().shards == res.shards
 
   test "WakuMetadataRequest":
-    let req = WakuMetadataRequest(clusterId: Opt.some(5), shards: @[100, 2, 0])
+    let req = WakuMetadataRequest(clusterId: Opt.some(5'u32), shards: @[100, 2, 0])
 
     let buffer = req.encode()
 

--- a/tests/waku_store/test_resume.nim
+++ b/tests/waku_store/test_resume.nim
@@ -5,7 +5,7 @@ import std/net, testutils/unittests, chronos, results
 import
   logos_delivery/waku/[
     node/peer_manager,
-    node/waku_node,
+    waku_node,
     waku_core,
     waku_store/resume,
     waku_store/common,

--- a/tests/waku_store_sync/test_all.nim
+++ b/tests/waku_store_sync/test_all.nim
@@ -1,3 +1,8 @@
 {.used.}
 
-import ./test_protocol, ./test_storage, ./test_codec
+import
+  ./test_protocol,
+  ./test_storage,
+  ./test_codec,
+  ./test_range_split,
+  ./test_state_transition

--- a/tests/waku_store_sync/test_range_split.nim
+++ b/tests/waku_store_sync/test_range_split.nim
@@ -1,5 +1,7 @@
-import unittest, nimcrypto, std/sequtils, results
-import ../../logos_delivery/waku/waku_store_sync/[reconciliation, common]
+{.used.}
+
+import testutils/unittests, nimcrypto, std/sequtils, results
+import ../../logos_delivery/waku/waku_store_sync/common
 import ../../logos_delivery/waku/waku_store_sync/storage/seq_storage
 import ../../logos_delivery/waku/waku_core/message/digest
 import ../../logos_delivery/waku/waku_core/topics/pubsub_topic
@@ -15,7 +17,7 @@ proc toDigest(s: string): WakuMessageHash =
 proc `..`(a, b: SyncID): Slice[SyncID] =
   Slice[SyncID](a: a, b: b)
 
-suite "Waku Sync – reconciliation":
+suite "Waku Sync: range splitting":
   test "fan-out: eight fingerprint sub-ranges for large slice":
     const N = 2_048
     const mismatchI = 70

--- a/tests/waku_store_sync/test_state_transition.nim
+++ b/tests/waku_store_sync/test_state_transition.nim
@@ -1,11 +1,13 @@
-import unittest, nimcrypto, std/sequtils
-import ../../logos_delivery/waku/waku_store_sync/[reconciliation, common]
+{.used.}
+
+import testutils/unittests, nimcrypto, std/sequtils
+import ../../logos_delivery/waku/waku_store_sync/common
 import ../../logos_delivery/waku/waku_store_sync/storage/seq_storage
 import ../../logos_delivery/waku/waku_core/message/digest
 import ../../logos_delivery/waku/waku_core/topics/pubsub_topic
 import ../../logos_delivery/waku/waku_core/topics/content_topic
 
-proc toDigest*(s: string): WakuMessageHash =
+proc toDigest(s: string): WakuMessageHash =
   let d = nimcrypto.keccak256.digest((s & "").toOpenArrayByte(0, s.high))
   for i in 0 .. 31:
     result[i] = d.data[i]
@@ -13,7 +15,7 @@ proc toDigest*(s: string): WakuMessageHash =
 proc `..`(a, b: SyncID): Slice[SyncID] =
   Slice[SyncID](a: a, b: b)
 
-suite "Waku Sync – reconciliation":
+suite "Waku Sync: state transition":
   test "Fingerprint → ItemSet → zero  (default thresholds)":
     const N = 2_000
     const idx = 137


### PR DESCRIPTION
Second batch after #4127 — **stacked on it, merge that one first.**

Eight more Nim suites that no entry point imported, so CI never compiled them and
refactors passed them by. Five did not compile at all. No product defect was found;
every break was a stale test expectation, each traced to the refactor that caused it
(#4035 `Opt.some` inference, #3410 losing `IpAddress`, #3929 dropping
`ProtoBuffer.maxSize`, #3614 moving the mount procs, #3468 `shards`→`subscribeShards`,
#3422 dropping `subscribe`'s default handler).

**`test_peer_manager.nim` needed more than repair.** Its second and third tests have
had byte-identical setups while asserting opposite outcomes ever since #2997
mechanically rewrote the shard arguments — nothing ran, so nothing complained, and
#3519 copied the mistake forward. Test 2 is repaired (client back to shard 0, which
its name always claimed) and test 3 is inverted rather than deleted: #3519
deliberately removed shard-mismatch disconnection, and that decision deserves a
regression test. To keep all three from asserting the same thing, test 3 now also
asserts `peerStore[ShardBook]`, which only `refreshPeerMetadata` writes — so it
cannot pass if the metadata exchange never fires. Verified by mutation.

Wiring: two imports into `waku_store_sync/test_all`; the four direct store imports in
`all_tests_waku` replaced by `./waku_store/test_all`; two new aggregates under
`node/peer_manager/`; two root files added directly.

Unreachable `test_*.nim`: **18 before, 9 after** — of those 9, four are aggregates or
helpers with no tests, four are RLN suites needing `librln`, one is
`test_migrations.nim`. This closes the category.

    baseline (#4127)  955 tests, 940 OK, 0 FAILED, 15 SKIPPED   1213.0s
    run 1             976 tests, 961 OK, 0 FAILED, 15 SKIPPED   1218.0s
    run 2             976 tests, 961 OK, 0 FAILED, 15 SKIPPED   1218.6s

+21 tests for +5s. Run twice back to back, identical results.

`test_migrations.nim` stays unwired: its imports point at a directory that does not
exist, its only dependency `testlib/simple_mock.nim` no longer compiles on the pinned
Nim, and its mocking patches x86-64 machine code — inert on arm64, including the
`test-macos-15` runner.
