### PR TITLE
Port wrapper tests batch3

### DIFF
--- a/.github/workflows/e2e-api-tests.yml
+++ b/.github/workflows/e2e-api-tests.yml
@@ -46,4 +46,4 @@ jobs:
         working-directory: tests-e2e
         run: |
           echo "docker peer image: ${NODE_2:-public default (DEFAULT_NWAKU)}"
-          pytest tests/wrappers_tests -m "${{ inputs.subset == 'docker' && 'docker_required' || 'not docker_required' }}" --reruns 2
+          pytest tests/wrappers_tests -m "${{ inputs.subset == 'docker' && 'docker_required' || 'not docker_required and not slow' }}" --reruns 2

--- a/tests-e2e/README.md
+++ b/tests-e2e/README.md
@@ -21,8 +21,9 @@ pip install -r tests-e2e/requirements.txt
 
 # 3. Run (from tests-e2e/)
 cd tests-e2e
-pytest tests/wrappers_tests -m "not docker_required"   # 51 pure-binding tests
-pytest tests/wrappers_tests -m docker_required          # 5 tests that also need a Docker nwaku peer (S11/S19/S20/S25/S31)
+pytest tests/wrappers_tests -m "not docker_required and not slow"   # 60 pure-binding tests, the CI selection
+pytest tests/wrappers_tests -m docker_required                      # 5 tests that also need a Docker nwaku peer (S11/S19/S20/S25/S31)
+pytest tests/wrappers_tests -m slow                                 # 1 SDS-R repair test, minutes long
 ```
 
 ## CI
@@ -30,3 +31,6 @@ pytest tests/wrappers_tests -m docker_required          # 5 tests that also need
 `.github/workflows/e2e-api-tests.yml` (called from `ci.yml`, `needs: build`) downloads the
 `liblogosdelivery` artifact produced by the `build` job and runs the non-docker subset on every PR —
 so a protocol change and its e2e test land in the same PR.
+
+The `slow` test is deselected there and there is no scheduled e2e job, so nothing runs it
+automatically; run it by hand when touching SDS-R.

--- a/tests-e2e/pytest.ini
+++ b/tests-e2e/pytest.ini
@@ -13,3 +13,4 @@ timeout = 300
 markers =
     smoke: marks tests as smoke test (deselect with '-m "not smoke"')
     docker_required: test requires Docker nodes (WakuNode)
+    slow: minutes-long test, excluded from the CI selection (deselect with '-m "not slow"')

--- a/tests-e2e/src/node/subprocess_node.py
+++ b/tests-e2e/src/node/subprocess_node.py
@@ -4,9 +4,10 @@ import multiprocessing as mp
 import os
 import queue
 import tempfile
+import time
 
 from src.libs.common import delay
-from src.node.wrapper_helpers import EventCollector, create_message_bindings, wait_for_connected
+from src.node.wrapper_helpers import EVENT_CHANNEL_RECEIVED, EventCollector, create_message_bindings, get_node_multiaddr, wait_for_connected
 from src.node.wrappers_manager import WrapperManager
 
 # `spawn`, not `fork`: the child loads its own liblogosdelivery.
@@ -14,9 +15,36 @@ _SPAWN = mp.get_context("spawn")
 
 SENDER_READY_TIMEOUT_S = 120.0
 SENDER_STOP_TIMEOUT_S = 30.0
+SEND_ACK_TIMEOUT_S = 60.0
+_SERVE_POLL_S = 0.2
+
+CMD_SEND = "send"
+CMD_RECREATE = "recreate"
 
 
-def _sender_worker(config, content_topic, channel_id, sender_id, payload_b64, settle_s, result_q, stop_evt):
+def _send(sender, channel_id, payload_b64):
+    """Sends on the channel; returns None on success, an error string otherwise."""
+    send_result = sender.channel_send(channel_id, create_message_bindings(payload=payload_b64))
+    if send_result.is_err():
+        return f"sender channel_send failed: {send_result.err()}"
+    if not send_result.ok_value:
+        return f"sender channel_send returned an empty handle: {send_result.ok_value!r}"
+    return None
+
+
+def _recreate(sender, channel_id, content_topic, sender_id):
+    """Closes the channel and creates it again under the same id."""
+    close_result = sender.channel_close(channel_id)
+    if close_result.is_err():
+        return f"sender channel_close failed: {close_result.err()}"
+
+    create_result = sender.channel_create(channel_id, content_topic, sender_id)
+    if create_result.is_err():
+        return f"sender channel_create failed: {create_result.err()}"
+    return None
+
+
+def _sender_worker(config, content_topic, channel_id, sender_id, payload_b64, settle_s, result_q, cmd_q, evt_q, stop_evt):
     # A private cwd so the library's default "./data" store is not the parent node's.
     os.chdir(tempfile.mkdtemp(prefix="rc_sender_"))
 
@@ -27,7 +55,8 @@ def _sender_worker(config, content_topic, channel_id, sender_id, payload_b64, se
         return
 
     with started.ok_value as sender:
-        if wait_for_connected(collector) is None:
+        # No staticnodes: this peer is first up, the node under test dials it later.
+        if config.get("staticnodes") and wait_for_connected(collector) is None:
             result_q.put("sender did not reach Connected/PartiallyConnected state")
             return
 
@@ -43,38 +72,67 @@ def _sender_worker(config, content_topic, channel_id, sender_id, payload_b64, se
 
         delay(settle_s)
 
-        send_result = sender.channel_send(channel_id, create_message_bindings(payload=payload_b64))
-        if send_result.is_err():
-            result_q.put(f"sender channel_send failed: {send_result.err()}")
-            return
-        if not send_result.ok_value:
-            result_q.put(f"sender channel_send returned an empty handle: {send_result.ok_value!r}")
-            return
+        if payload_b64 is not None:
+            outcome = _send(sender, channel_id, payload_b64)
+            if outcome is not None:
+                result_q.put(outcome)
+                return
 
-        # Signal the message is on the wire, then stay alive so the relay
-        # connection persists while it propagates to the receiver.
-        result_q.put(None)
-        stop_evt.wait()
+        # Signal readiness, then stay alive so the relay connection persists
+        # while messages propagate and SDS answers repair requests.
+        result_q.put({"multiaddr": get_node_multiaddr(sender)})
+
+        forwarded = 0
+        while not stop_evt.is_set():
+            received = [e for e in collector.snapshot() if e.get("eventType") == EVENT_CHANNEL_RECEIVED and e.get("channelId") == channel_id]
+            for event in received[forwarded:]:
+                evt_q.put(event)
+            forwarded = len(received)
+
+            try:
+                op, arg = cmd_q.get(timeout=_SERVE_POLL_S)
+            except queue.Empty:
+                continue
+
+            if op == CMD_SEND:
+                result_q.put(_send(sender, channel_id, arg))
+                continue
+
+            outcome = _recreate(sender, channel_id, content_topic, sender_id)
+            if outcome is None:
+                # channel_close drops the content topic subscription and
+                # channel_create re-adds it; let the mesh catch up before the
+                # next send, or it goes out to nobody.
+                delay(settle_s)
+            result_q.put(outcome)
 
 
 class ChannelSenderProcess:
-    """Run a channel sender node in a separate, storage-isolated process.
+    """Run a channel peer node in a separate, storage-isolated process.
 
-    `__enter__` starts the sender and blocks until the message is on the wire
-    (raising on failure/timeout); `__exit__` tears it down. Needed because nodes
+    `__enter__` blocks until the peer is ready, including its initial
+    `payload_b64` send when given; `__exit__` tears it down. Needed because nodes
     sharing a storage path drop each other's channel messages as duplicates.
+
+    `multiaddr` lets the node under test dial this peer, `send()` drives further
+    sends, `close_and_recreate()` cycles the channel under the same id, and
+    `wait_for_received()` reports what this peer received.
     """
 
-    def __init__(self, config, *, content_topic, channel_id, sender_id, payload_b64, settle_s):
+    def __init__(self, config, *, content_topic, channel_id, sender_id, payload_b64=None, settle_s):
         self._args = (config, content_topic, channel_id, sender_id, payload_b64, settle_s)
         self._stop_evt = _SPAWN.Event()
         self._result_q = _SPAWN.Queue()
+        self._cmd_q = _SPAWN.Queue()
+        self._evt_q = _SPAWN.Queue()
         self._proc = None
+        self._received = []
+        self.multiaddr = None
 
     def __enter__(self) -> "ChannelSenderProcess":
         self._proc = _SPAWN.Process(
             target=_sender_worker,
-            args=(*self._args, self._result_q, self._stop_evt),
+            args=(*self._args, self._result_q, self._cmd_q, self._evt_q, self._stop_evt),
             daemon=True,
         )
         self._proc.start()
@@ -83,10 +141,39 @@ class ChannelSenderProcess:
         except queue.Empty:
             self.__exit__(None, None, None)
             raise AssertionError(f"sender subprocess did not report readiness within {SENDER_READY_TIMEOUT_S}s")
-        if outcome is not None:
+        if not isinstance(outcome, dict):
             self.__exit__(None, None, None)
             raise AssertionError(outcome)
+        self.multiaddr = outcome["multiaddr"]
         return self
+
+    def _run(self, op, arg, what) -> None:
+        self._cmd_q.put((op, arg))
+        try:
+            outcome = self._result_q.get(timeout=SEND_ACK_TIMEOUT_S)
+        except queue.Empty:
+            raise AssertionError(f"sender subprocess did not acknowledge {what} within {SEND_ACK_TIMEOUT_S}s")
+        if outcome is not None:
+            raise AssertionError(outcome)
+
+    def send(self, payload_b64) -> None:
+        """Sends another message on the channel, blocking until the peer acks it."""
+        self._run(CMD_SEND, payload_b64, "a send")
+
+    def close_and_recreate(self) -> None:
+        """Closes and re-creates the channel under the same id, blocking until
+        the peer has re-subscribed and the mesh has settled."""
+        self._run(CMD_RECREATE, None, "a close/re-create")
+
+    def wait_for_received(self, count, timeout_s) -> list:
+        """Channel messages this peer received, oldest first; waits for `count`."""
+        deadline = time.monotonic() + timeout_s
+        while len(self._received) < count and time.monotonic() < deadline:
+            try:
+                self._received.append(self._evt_q.get(timeout=_SERVE_POLL_S))
+            except queue.Empty:
+                continue
+        return list(self._received)
 
     def __exit__(self, *_) -> None:
         self._stop_evt.set()

--- a/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
@@ -36,6 +36,11 @@ RC08_CAUSAL_SETTLE_S = 5
 RC09_CHANNEL_PREFIX = "rc09-channel"
 RC09_CONTENT_TOPIC = "/test/1/rc09-channel/proto"
 
+RC10_CHANNEL_PREFIX = "rc10-channel"
+RC10_CONTENT_TOPIC = "/test/1/rc10-channel/proto"
+# B's channel must exist before A's second send, or m2 lands with nothing to park it.
+RC10_CHANNEL_SETTLE_S = 5
+
 RC12_CHANNEL_PREFIX = "rc12-channel"
 RC12_CONTENT_TOPIC = "/test/1/rc12-channel/proto"
 SENDER_C = "rc12-sender-c"
@@ -101,6 +106,28 @@ def wait_for_message_received(collector, content_topic, timeout_s, poll_interval
                 return event
         if time.monotonic() >= deadline:
             return None
+        time.sleep(poll_interval_s)
+
+
+def wire_payload(event):
+    """The SDS envelope an event carried; the FFI sends it as an array of bytes."""
+    return bytes((event.get("message") or {}).get("payload") or ())
+
+
+def wait_for_distinct_message_received(collector, content_topic, count, timeout_s, poll_interval_s=0.5):
+    """Distinct-envelope events on `content_topic`, oldest first; waits for `count`.
+
+    Keyed on the envelope so a rebroadcast, which is a fresh message_received
+    carrying the same bytes, cannot pass for a second message.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        received = {}
+        for event in collector.snapshot():
+            if event.get("eventType") == MESSAGE_RECEIVED_EVENT and (event.get("message") or {}).get("contentTopic") == content_topic:
+                received.setdefault(wire_payload(event), event)
+        if len(received) >= count or time.monotonic() >= deadline:
+            return list(received.values())
         time.sleep(poll_interval_s)
 
 
@@ -411,6 +438,82 @@ class TestChannelDelivery:
                     f"B must end up with the message sent before it joined, then the one after; "
                     f"got {channel_payloads(recovered)!r}. Collected events: {receiver_collector.snapshot()}"
                 )
+
+    def test_rc10_missing_dependency_is_parked(self, node_config):
+        """RC10 setup: a message whose causal dependency B never saw is parked,
+        not delivered.
+
+        B is connected and subscribed throughout but has no channel when A sends
+        m1, so m1 stops at B's messaging layer. B then creates the channel and A
+        sends m2, which carries m1 in its causal history: message_received proves
+        m2 arrived, and the absence of a channel event proves SDS parked it.
+
+        Recovery from here is SDS-R repair, in test_channel_repair.py.
+        """
+        channel_id = unique_channel_id(RC10_CHANNEL_PREFIX)
+        m1, m2 = "rc10 sent before B has a channel", "rc10 depends on m1"
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+
+        receiver_collector = EventCollector()
+        receiver_result = WrapperManager.create_and_start(config=node_config, event_cb=receiver_collector.event_callback)
+        assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+        with receiver_result.ok_value as receiver:
+            sender_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(receiver)],
+                "portsShift": 1,
+            }
+
+            subscribe_result = receiver.subscribe_content_topic(RC10_CONTENT_TOPIC)
+            assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
+
+            with ChannelSenderProcess(
+                sender_config,
+                content_topic=RC10_CONTENT_TOPIC,
+                channel_id=channel_id,
+                sender_id=SENDER_A,
+                payload_b64=to_base64(m1),
+                settle_s=MESH_SETTLE_S,
+            ) as sender:
+                arrived = wait_for_message_received(receiver_collector, RC10_CONTENT_TOPIC, DELIVERY_TIMEOUT_S)
+                assert arrived is not None, (
+                    f"receiver never saw a {MESSAGE_RECEIVED_EVENT} for m1 within {DELIVERY_TIMEOUT_S}s; "
+                    f"the dependency was never established. Collected events: {receiver_collector.snapshot()}"
+                )
+
+                leaked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
+                assert leaked is None, f"a node with no channel must not emit {CHANNEL_RECEIVED_EVENT}; got: {leaked!r}"
+
+                receiver_create = receiver.channel_create(channel_id, RC10_CONTENT_TOPIC, SENDER_B)
+                assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+                delay(RC10_CHANNEL_SETTLE_S)
+
+                sender.send(to_base64(m2))
+
+                both = wait_for_distinct_message_received(receiver_collector, RC10_CONTENT_TOPIC, 2, DELIVERY_TIMEOUT_S)
+                assert len(both) == 2, (
+                    f"receiver must see m2 at the messaging layer within {DELIVERY_TIMEOUT_S}s; "
+                    f"got {len(both)} distinct {MESSAGE_RECEIVED_EVENT} envelopes. "
+                    f"Collected events: {receiver_collector.snapshot()}"
+                )
+                # Channel encryption is a noop here, so m2's content is on the wire verbatim.
+                assert m2.encode() in wire_payload(both[1]), (
+                    f"the second envelope must carry m2, not repeat m1; got {wire_payload(both[1])!r}. "
+                    f"Collected events: {receiver_collector.snapshot()}"
+                )
+
+                parked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
+                assert parked is None, f"m2 must stay parked while m1 is missing, not surface as {CHANNEL_RECEIVED_EVENT}; got: {parked!r}"
 
     def test_rc12_three_participants_all_receive(self, node_config):
         """RC12: A, B and C share one channel; A's send reaches both B and C.

--- a/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
@@ -23,6 +23,26 @@ MESSAGE_RECEIVED_EVENT = "message_received"
 RC06_CHANNEL_PREFIX = "rc06-channel"
 RC06_CONTENT_TOPIC = "/test/1/rc06-channel/proto"
 
+RC07_CHANNEL_PREFIX = "rc07-channel"
+RC07_CONTENT_TOPIC = "/test/1/rc07-channel/proto"
+RC07_OTHER_CONTENT_TOPIC = "/test/1/rc07-other/proto"
+
+RC08_CHANNEL_PREFIX = "rc08-channel"
+RC08_CONTENT_TOPIC = "/test/1/rc08-channel/proto"
+# A reply references what it answers only once that landed in the sender's SDS
+# history; replying immediately races that write and asserts nothing.
+RC08_CAUSAL_SETTLE_S = 5
+
+RC09_CHANNEL_PREFIX = "rc09-channel"
+RC09_CONTENT_TOPIC = "/test/1/rc09-channel/proto"
+
+RC12_CHANNEL_PREFIX = "rc12-channel"
+RC12_CONTENT_TOPIC = "/test/1/rc12-channel/proto"
+SENDER_C = "rc12-sender-c"
+
+RC13_CHANNEL_PREFIX = "rc13-channel"
+RC13_CONTENT_TOPIC = "/test/1/rc13-channel/proto"
+
 CLOSED_CHANNEL_PREFIX = "rc-closed-channel"
 CLOSED_CONTENT_TOPIC = "/test/1/rc-closed-channel/proto"
 
@@ -32,6 +52,10 @@ DELIVERY_TIMEOUT_S = 50.0
 # channel ingress decision has already been made on that same event, so this is
 # just a short grace window to catch any late channel_message_received.
 NO_CHANNEL_DELIVERY_WINDOW_S = 10.0
+
+# A has no peer to dial before it sends, so no mesh to settle.
+RC09_SENDER_SETTLE_S = 2
+RC09_RECOVERY_TIMEOUT_S = 90.0
 
 
 def wait_for_channel_received(collector, channel_id, timeout_s, poll_interval_s=0.5):
@@ -43,6 +67,25 @@ def wait_for_channel_received(collector, channel_id, timeout_s, poll_interval_s=
         if time.monotonic() >= deadline:
             return None
         time.sleep(poll_interval_s)
+
+
+def wait_for_channel_received_count(collector, channel_id, count, timeout_s, poll_interval_s=0.5):
+    """Channel events for `channel_id`, oldest first; waits for `count` of them.
+
+    Returns whatever has arrived when the timeout expires, so a caller can
+    assert on both the order and the shortfall.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        received = [e for e in collector.snapshot() if e.get("eventType") == CHANNEL_RECEIVED_EVENT and e.get("channelId") == channel_id]
+        if len(received) >= count or time.monotonic() >= deadline:
+            return received
+        time.sleep(poll_interval_s)
+
+
+def channel_payloads(events):
+    """Decoded payloads of channel events, oldest first."""
+    return [base64.b64decode(event["payload"]) for event in events]
 
 
 def wait_for_message_received(collector, content_topic, timeout_s, poll_interval_s=0.5):
@@ -185,6 +228,324 @@ class TestChannelDelivery:
                 # The channel ingress filter drops the unmarked message: no channel event.
                 leaked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
                 assert leaked is None, f"an unmarked message must not surface as a {CHANNEL_RECEIVED_EVENT}; got: {leaked!r}"
+
+    def test_rc07_wrong_content_topic_dropped(self, node_config):
+        """RC07: a correctly-marked channel message published on a different
+        content topic is dropped at channel ingress.
+
+        A runs the same channelId as B but on RC07_OTHER_CONTENT_TOPIC. B is
+        subscribed to that topic too, so B's messaging layer still surfaces the
+        message (message_received), proving it arrived, but B's channel is bound
+        to RC07_CONTENT_TOPIC and must not fire channel_message_received.
+        """
+        channel_id = unique_channel_id(RC07_CHANNEL_PREFIX)
+        payload_b64 = to_base64("rc07 message on the wrong content topic")
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+
+        receiver_collector = EventCollector()
+        receiver_result = WrapperManager.create_and_start(config=node_config, event_cb=receiver_collector.event_callback)
+        assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+        with receiver_result.ok_value as receiver:
+            sender_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(receiver)],
+                "portsShift": 1,
+            }
+
+            for content_topic in (RC07_CONTENT_TOPIC, RC07_OTHER_CONTENT_TOPIC):
+                subscribe_result = receiver.subscribe_content_topic(content_topic)
+                assert subscribe_result.is_ok(), f"receiver subscribe_content_topic {content_topic} failed: {subscribe_result.err()}"
+
+            receiver_create = receiver.channel_create(channel_id, RC07_CONTENT_TOPIC, SENDER_B)
+            assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+            with ChannelSenderProcess(
+                sender_config,
+                content_topic=RC07_OTHER_CONTENT_TOPIC,
+                channel_id=channel_id,
+                sender_id=SENDER_A,
+                payload_b64=payload_b64,
+                settle_s=MESH_SETTLE_S,
+            ):
+                arrived = wait_for_message_received(receiver_collector, RC07_OTHER_CONTENT_TOPIC, DELIVERY_TIMEOUT_S)
+                assert arrived is not None, (
+                    f"receiver never saw a {MESSAGE_RECEIVED_EVENT} for {RC07_OTHER_CONTENT_TOPIC} within {DELIVERY_TIMEOUT_S}s; "
+                    f"cannot conclude the channel dropped it. Collected events: {receiver_collector.snapshot()}"
+                )
+
+                leaked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
+                assert leaked is None, f"a message on a foreign content topic must not surface as a {CHANNEL_RECEIVED_EVENT}; got: {leaked!r}"
+
+    def test_rc08_bidirectional_exchange_preserves_causal_order(self, node_config):
+        """RC08: A and B exchange interleaved messages on one channel, and each
+        side delivers the other's in causal order.
+
+        Each reply is sent only after the message it answers has landed, so m2
+        references m1 and m3 references m2. B must deliver m1 then m3, A must
+        deliver m2.
+        """
+        channel_id = unique_channel_id(RC08_CHANNEL_PREFIX)
+        m1, m2, m3 = "rc08 from A", "rc08 reply from B", "rc08 follow-up from A"
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+
+        receiver_collector = EventCollector()
+        receiver_result = WrapperManager.create_and_start(config=node_config, event_cb=receiver_collector.event_callback)
+        assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+        with receiver_result.ok_value as receiver:
+            sender_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(receiver)],
+                "portsShift": 1,
+            }
+
+            subscribe_result = receiver.subscribe_content_topic(RC08_CONTENT_TOPIC)
+            assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
+
+            receiver_create = receiver.channel_create(channel_id, RC08_CONTENT_TOPIC, SENDER_B)
+            assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+            with ChannelSenderProcess(
+                sender_config,
+                content_topic=RC08_CONTENT_TOPIC,
+                channel_id=channel_id,
+                sender_id=SENDER_A,
+                payload_b64=to_base64(m1),
+                settle_s=MESH_SETTLE_S,
+            ) as sender:
+                first = wait_for_channel_received(receiver_collector, channel_id, DELIVERY_TIMEOUT_S)
+                assert first is not None, (
+                    f"B never saw A's first message within {DELIVERY_TIMEOUT_S}s; "
+                    f"nothing to reply to. Collected events: {receiver_collector.snapshot()}"
+                )
+
+                # B replies only now, so m2 carries m1 in its causal history.
+                delay(RC08_CAUSAL_SETTLE_S)
+                reply_result = receiver.channel_send(channel_id, create_message_bindings(payload=to_base64(m2)))
+                assert reply_result.is_ok(), f"receiver channel_send failed: {reply_result.err()}"
+
+                delivered_to_a = sender.wait_for_received(1, DELIVERY_TIMEOUT_S)
+                assert channel_payloads(delivered_to_a) == [m2.encode()], f"A must deliver B's reply; got {channel_payloads(delivered_to_a)!r}"
+
+                # Same race on A's side.
+                delay(RC08_CAUSAL_SETTLE_S)
+                sender.send(to_base64(m3))
+
+                delivered_to_b = wait_for_channel_received_count(receiver_collector, channel_id, 2, DELIVERY_TIMEOUT_S)
+                assert channel_payloads(delivered_to_b) == [m1.encode(), m3.encode()], (
+                    f"B must deliver A's messages in causal order; got {channel_payloads(delivered_to_b)!r}. "
+                    f"Collected events: {receiver_collector.snapshot()}"
+                )
+
+    def test_rc09_late_joining_receiver_still_receives(self, node_config):
+        """RC09: A sends m1 while B is not up yet; B joins and still ends up with
+        both m1 and m2.
+
+        Recovery here is the send service's relay retry, not SDS: A republishes
+        m1 while it is unacknowledged (within MaxTimeInCache) and it lands as
+        soon as B joins the mesh. SDS-R is not exercised — a repair request only
+        rides out after T_req, a hash in [repairTMin, repairTMax) = [30s, 300s)
+        that logos-delivery does not expose, so it cannot be driven from an E2E
+        test. That path is RC10 — see test_rc10_missing_dependency_is_parked
+        below and tests/wrappers_tests/test_channel_repair.py.
+        """
+        channel_id = unique_channel_id(RC09_CHANNEL_PREFIX)
+        m1, m2 = "rc09 sent while B is away", "rc09 sent after B joins"
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+        # A comes up first with nobody to dial; B joins later and dials A.
+        sender_config = {**node_config, "portsShift": 1}
+
+        with ChannelSenderProcess(
+            sender_config,
+            content_topic=RC09_CONTENT_TOPIC,
+            channel_id=channel_id,
+            sender_id=SENDER_A,
+            payload_b64=to_base64(m1),
+            settle_s=RC09_SENDER_SETTLE_S,
+        ) as sender:
+            receiver_collector = EventCollector()
+            receiver_config = {**node_config, "staticnodes": [sender.multiaddr]}
+            receiver_result = WrapperManager.create_and_start(config=receiver_config, event_cb=receiver_collector.event_callback)
+            assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+            with receiver_result.ok_value as receiver:
+                assert wait_for_connected(receiver_collector) is not None, "Receiver did not reach Connected/PartiallyConnected state"
+
+                subscribe_result = receiver.subscribe_content_topic(RC09_CONTENT_TOPIC)
+                assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
+
+                receiver_create = receiver.channel_create(channel_id, RC09_CONTENT_TOPIC, SENDER_B)
+                assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+                delay(MESH_SETTLE_S)
+
+                sender.send(to_base64(m2))
+
+                recovered = wait_for_channel_received_count(receiver_collector, channel_id, 2, RC09_RECOVERY_TIMEOUT_S)
+                assert channel_payloads(recovered) == [m1.encode(), m2.encode()], (
+                    f"B must end up with the message sent before it joined, then the one after; "
+                    f"got {channel_payloads(recovered)!r}. Collected events: {receiver_collector.snapshot()}"
+                )
+
+    def test_rc12_three_participants_all_receive(self, node_config):
+        """RC12: A, B and C share one channel; A's send reaches both B and C.
+
+        Each delivers m1 exactly once, with A's senderId and the exact payload.
+        B is the node under test; A and C run as storage-isolated peers dialing it.
+        """
+        channel_id = unique_channel_id(RC12_CHANNEL_PREFIX)
+        m1 = "rc12 from A"
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+
+        receiver_collector = EventCollector()
+        receiver_result = WrapperManager.create_and_start(config=node_config, event_cb=receiver_collector.event_callback)
+        assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+        with receiver_result.ok_value as receiver:
+            peer_config = {**node_config, "staticnodes": [get_node_multiaddr(receiver)]}
+
+            subscribe_result = receiver.subscribe_content_topic(RC12_CONTENT_TOPIC)
+            assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
+
+            receiver_create = receiver.channel_create(channel_id, RC12_CONTENT_TOPIC, SENDER_B)
+            assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+            # C joins first so it is meshed by the time A sends m1.
+            with ChannelSenderProcess(
+                {**peer_config, "portsShift": 2},
+                content_topic=RC12_CONTENT_TOPIC,
+                channel_id=channel_id,
+                sender_id=SENDER_C,
+                settle_s=MESH_SETTLE_S,
+            ) as third_party:
+                with ChannelSenderProcess(
+                    {**peer_config, "portsShift": 1},
+                    content_topic=RC12_CONTENT_TOPIC,
+                    channel_id=channel_id,
+                    sender_id=SENDER_A,
+                    payload_b64=to_base64(m1),
+                    settle_s=MESH_SETTLE_S,
+                ):
+                    assert (
+                        wait_for_channel_received(receiver_collector, channel_id, DELIVERY_TIMEOUT_S) is not None
+                    ), f"B never saw A's message within {DELIVERY_TIMEOUT_S}s. Collected events: {receiver_collector.snapshot()}"
+                    assert third_party.wait_for_received(1, DELIVERY_TIMEOUT_S), f"C never saw A's message within {DELIVERY_TIMEOUT_S}s"
+
+                    # B and C must have exactly one delivery; any second event is a duplicate.
+                    on_b = wait_for_channel_received_count(receiver_collector, channel_id, 2, NO_CHANNEL_DELIVERY_WINDOW_S)
+                    on_c = third_party.wait_for_received(2, NO_CHANNEL_DELIVERY_WINDOW_S)
+
+                    assert channel_payloads(on_b) == [m1.encode()], f"B must deliver A's message exactly once; got {channel_payloads(on_b)!r}"
+                    assert channel_payloads(on_c) == [m1.encode()], f"C must deliver A's message exactly once; got {channel_payloads(on_c)!r}"
+                    assert [e["senderId"] for e in on_b + on_c] == [
+                        SENDER_A,
+                        SENDER_A,
+                    ], f"both events must carry {SENDER_A!r}, got {[e.get('senderId') for e in on_b + on_c]!r}"
+
+    def test_rc13_close_recreate_then_send_delivers_new_message(self, node_config):
+        """RC13: A closes and re-creates its channel, then sends again.
+
+        A sends m1, cycles the channel under the same id, then sends m2. B must
+        deliver m2 exactly once and ordered after m1, and must not replay m1 —
+        the re-created channel picks up the restored SDS history rather than
+        starting a fresh one.
+
+        Distinct from the nim in-process test, which cycles the *receiver's*
+        channel and asserts a replayed m1 is suppressed on ingress; here the
+        cycle is on the send path.
+        """
+        channel_id = unique_channel_id(RC13_CHANNEL_PREFIX)
+        m1, m2 = "rc13 before close", "rc13 after re-create"
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+
+        receiver_collector = EventCollector()
+        receiver_result = WrapperManager.create_and_start(config=node_config, event_cb=receiver_collector.event_callback)
+        assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+        with receiver_result.ok_value as receiver:
+            sender_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(receiver)],
+                "portsShift": 1,
+            }
+
+            subscribe_result = receiver.subscribe_content_topic(RC13_CONTENT_TOPIC)
+            assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
+
+            receiver_create = receiver.channel_create(channel_id, RC13_CONTENT_TOPIC, SENDER_B)
+            assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+            with ChannelSenderProcess(
+                sender_config,
+                content_topic=RC13_CONTENT_TOPIC,
+                channel_id=channel_id,
+                sender_id=SENDER_A,
+                payload_b64=to_base64(m1),
+                settle_s=MESH_SETTLE_S,
+            ) as sender:
+                first = wait_for_channel_received(receiver_collector, channel_id, DELIVERY_TIMEOUT_S)
+                assert first is not None, (
+                    f"No {CHANNEL_RECEIVED_EVENT} for m1 on {channel_id} within {DELIVERY_TIMEOUT_S}s; "
+                    f"the close/re-create is only meaningful once m1 landed. Collected events: {receiver_collector.snapshot()}"
+                )
+
+                sender.close_and_recreate()
+                sender.send(to_base64(m2))
+
+                received = wait_for_channel_received_count(receiver_collector, channel_id, 2, DELIVERY_TIMEOUT_S)
+                assert len(received) == 2, (
+                    f"expected m1 then m2 on {channel_id}, got {len(received)}: {channel_payloads(received)!r}. "
+                    f"Collected events: {receiver_collector.snapshot()}"
+                )
+                assert channel_payloads(received) == [
+                    m1.encode(),
+                    m2.encode(),
+                ], f"expected [m1, m2] in causal order, got: {channel_payloads(received)!r}"
+
+                # A third event could only be a replayed m1 from the re-created channel.
+                settled = wait_for_channel_received_count(receiver_collector, channel_id, 3, NO_CHANNEL_DELIVERY_WINDOW_S)
+                assert len(settled) == 2, f"re-create must not re-deliver m1; got: {channel_payloads(settled)!r}"
 
     def test_receive_after_close_emits_no_channel_event(self, node_config):
         """A closed channel must not deliver: B closes its channel, then A sends a

--- a/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
@@ -8,10 +8,11 @@ from src.node.wrapper_helpers import (
     EventCollector,
     create_message_bindings,
     get_node_multiaddr,
+    unique_channel_id,
     wait_for_connected,
 )
 
-CHANNEL_ID = "rc05-channel"
+RC05_CHANNEL_PREFIX = "rc05-channel"
 CONTENT_TOPIC = "/test/1/rc05-channel/proto"
 SENDER_A = "rc05-sender-a"
 SENDER_B = "rc05-sender-b"
@@ -19,10 +20,10 @@ SENDER_B = "rc05-sender-b"
 CHANNEL_RECEIVED_EVENT = "channel_message_received"
 MESSAGE_RECEIVED_EVENT = "message_received"
 
-RC06_CHANNEL_ID = "rc06-channel"
+RC06_CHANNEL_PREFIX = "rc06-channel"
 RC06_CONTENT_TOPIC = "/test/1/rc06-channel/proto"
 
-CLOSED_CHANNEL_ID = "rc-closed-channel"
+CLOSED_CHANNEL_PREFIX = "rc-closed-channel"
 CLOSED_CONTENT_TOPIC = "/test/1/rc-closed-channel/proto"
 
 MESH_SETTLE_S = 10
@@ -70,6 +71,7 @@ class TestChannelDelivery:
         A runs in a separate, storage-isolated process: nodes sharing a storage path
         make B drop A's message as a duplicate. See src/node/subprocess_node.py.
         """
+        channel_id = unique_channel_id(RC05_CHANNEL_PREFIX)
         payload_b64 = to_base64("rc05 hello from A")
 
         node_config.update(
@@ -95,20 +97,20 @@ class TestChannelDelivery:
             subscribe_result = receiver.subscribe_content_topic(CONTENT_TOPIC)
             assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
 
-            receiver_create = receiver.channel_create(CHANNEL_ID, CONTENT_TOPIC, SENDER_B)
+            receiver_create = receiver.channel_create(channel_id, CONTENT_TOPIC, SENDER_B)
             assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
 
             with ChannelSenderProcess(
                 sender_config,
                 content_topic=CONTENT_TOPIC,
-                channel_id=CHANNEL_ID,
+                channel_id=channel_id,
                 sender_id=SENDER_A,
                 payload_b64=payload_b64,
                 settle_s=MESH_SETTLE_S,
             ):
-                received = wait_for_channel_received(receiver_collector, CHANNEL_ID, DELIVERY_TIMEOUT_S)
+                received = wait_for_channel_received(receiver_collector, channel_id, DELIVERY_TIMEOUT_S)
                 assert received is not None, (
-                    f"No {CHANNEL_RECEIVED_EVENT} on B for {CHANNEL_ID} within {DELIVERY_TIMEOUT_S}s. "
+                    f"No {CHANNEL_RECEIVED_EVENT} on B for {channel_id} within {DELIVERY_TIMEOUT_S}s. "
                     f"Collected events: {receiver_collector.snapshot()}"
                 )
                 assert base64.b64decode(received["payload"]) == base64.b64decode(
@@ -127,6 +129,7 @@ class TestChannelDelivery:
         proving the message arrived, but the channel ingress filter drops it: no
         channel_message_received fires for the channel.
         """
+        channel_id = unique_channel_id(RC06_CHANNEL_PREFIX)
         payload_b64 = to_base64("rc06 unmarked message")
 
         node_config.update(
@@ -161,7 +164,7 @@ class TestChannelDelivery:
                 assert subscribe_result.is_ok(), f"sender subscribe_content_topic failed: {subscribe_result.err()}"
 
                 # Only B runs a channel; A never marks its traffic.
-                receiver_create = receiver.channel_create(RC06_CHANNEL_ID, RC06_CONTENT_TOPIC, SENDER_B)
+                receiver_create = receiver.channel_create(channel_id, RC06_CONTENT_TOPIC, SENDER_B)
                 assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
 
                 delay(MESH_SETTLE_S)
@@ -180,7 +183,7 @@ class TestChannelDelivery:
                 )
 
                 # The channel ingress filter drops the unmarked message: no channel event.
-                leaked = wait_for_channel_received(receiver_collector, RC06_CHANNEL_ID, NO_CHANNEL_DELIVERY_WINDOW_S)
+                leaked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
                 assert leaked is None, f"an unmarked message must not surface as a {CHANNEL_RECEIVED_EVENT}; got: {leaked!r}"
 
     def test_receive_after_close_emits_no_channel_event(self, node_config):
@@ -194,6 +197,7 @@ class TestChannelDelivery:
         channel_close unsubscribes the content topic (logos-delivery#4081), so B
         re-subscribes to keep message_received as the witness.
         """
+        channel_id = unique_channel_id(CLOSED_CHANNEL_PREFIX)
         payload_b64 = to_base64("message for a closed channel")
 
         node_config.update(
@@ -219,10 +223,10 @@ class TestChannelDelivery:
             subscribe_result = receiver.subscribe_content_topic(CLOSED_CONTENT_TOPIC)
             assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
 
-            receiver_create = receiver.channel_create(CLOSED_CHANNEL_ID, CLOSED_CONTENT_TOPIC, SENDER_B)
+            receiver_create = receiver.channel_create(channel_id, CLOSED_CONTENT_TOPIC, SENDER_B)
             assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
 
-            receiver_close = receiver.channel_close(CLOSED_CHANNEL_ID)
+            receiver_close = receiver.channel_close(channel_id)
             assert receiver_close.is_ok(), f"receiver channel_close failed: {receiver_close.err()}"
 
             resubscribe_result = receiver.subscribe_content_topic(CLOSED_CONTENT_TOPIC)
@@ -231,7 +235,7 @@ class TestChannelDelivery:
             with ChannelSenderProcess(
                 sender_config,
                 content_topic=CLOSED_CONTENT_TOPIC,
-                channel_id=CLOSED_CHANNEL_ID,
+                channel_id=channel_id,
                 sender_id=SENDER_A,
                 payload_b64=payload_b64,
                 settle_s=MESH_SETTLE_S,
@@ -242,5 +246,5 @@ class TestChannelDelivery:
                     f"cannot conclude the closed channel stayed silent. Collected events: {receiver_collector.snapshot()}"
                 )
 
-                leaked = wait_for_channel_received(receiver_collector, CLOSED_CHANNEL_ID, NO_CHANNEL_DELIVERY_WINDOW_S)
+                leaked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
                 assert leaked is None, f"a closed channel must not emit {CHANNEL_RECEIVED_EVENT}; got: {leaked!r}"

--- a/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
@@ -1,4 +1,5 @@
 import base64
+import re
 import time
 
 from src.libs.common import delay, to_base64
@@ -29,9 +30,9 @@ RC07_OTHER_CONTENT_TOPIC = "/test/1/rc07-other/proto"
 
 RC08_CHANNEL_PREFIX = "rc08-channel"
 RC08_CONTENT_TOPIC = "/test/1/rc08-channel/proto"
-# A reply references what it answers only once that landed in the sender's SDS
-# history; replying immediately races that write and asserts nothing.
-RC08_CAUSAL_SETTLE_S = 5
+# Let the delivery settle before replying, so the exchange is interleaved rather
+# than two sends racing each other.
+RC08_INTERLEAVE_SETTLE_S = 5
 
 RC09_CHANNEL_PREFIX = "rc09-channel"
 RC09_CONTENT_TOPIC = "/test/1/rc09-channel/proto"
@@ -112,6 +113,20 @@ def wait_for_message_received(collector, content_topic, timeout_s, poll_interval
 def wire_payload(event):
     """The SDS envelope an event carried; the FFI sends it as an array of bytes."""
     return bytes((event.get("message") or {}).get("payload") or ())
+
+
+SDS_MESSAGE_ID_RE = re.compile(rb"[0-9a-f]{64}")
+
+
+def envelope_message_ids(envelope):
+    """SDS message ids in an envelope: its own first, then its causal history.
+
+    Ids are 64-char hex strings the minprotobuf embeds verbatim, and no other
+    field can produce that run — the bloom filter stores hashed bits, not ids.
+    Channel encryption is a noop (`setNoopEncryption`), so the envelope reaches
+    a message_received event in the clear.
+    """
+    return SDS_MESSAGE_ID_RE.findall(envelope)
 
 
 def wait_for_distinct_message_received(collector, content_topic, count, timeout_s, poll_interval_s=0.5):
@@ -312,13 +327,17 @@ class TestChannelDelivery:
                 leaked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
                 assert leaked is None, f"a message on a foreign content topic must not surface as a {CHANNEL_RECEIVED_EVENT}; got: {leaked!r}"
 
-    def test_rc08_bidirectional_exchange_preserves_causal_order(self, node_config):
-        """RC08: A and B exchange interleaved messages on one channel, and each
-        side delivers the other's in causal order.
+    def test_rc08_bidirectional_exchange_delivers_both_ways(self, node_config):
+        """RC08: A and B exchange interleaved messages on one channel, both
+        directions deliver, and m3 carries m1 in its causal history.
 
-        Each reply is sent only after the message it answers has landed, so m2
-        references m1 and m3 references m2. B must deliver m1 then m3, A must
-        deliver m2.
+        Arrival order alone proves nothing here — each send waits for the
+        previous message to land, so [m1, m3] would hold with causal history
+        switched off entirely. The causal claim is therefore checked against the
+        wire: when A sends m3 its SDS history holds m1 (sent) and m2 (received),
+        so m3's envelope must reference m1's message id. Parking and release of
+        an out-of-order dependency are covered by
+        test_rc10_missing_dependency_is_parked and test_channel_repair.py.
         """
         channel_id = unique_channel_id(RC08_CHANNEL_PREFIX)
         m1, m2, m3 = "rc08 from A", "rc08 reply from B", "rc08 follow-up from A"
@@ -363,8 +382,8 @@ class TestChannelDelivery:
                     f"nothing to reply to. Collected events: {receiver_collector.snapshot()}"
                 )
 
-                # B replies only now, so m2 carries m1 in its causal history.
-                delay(RC08_CAUSAL_SETTLE_S)
+                # B replies only now, so the exchange is genuinely interleaved.
+                delay(RC08_INTERLEAVE_SETTLE_S)
                 reply_result = receiver.channel_send(channel_id, create_message_bindings(payload=to_base64(m2)))
                 assert reply_result.is_ok(), f"receiver channel_send failed: {reply_result.err()}"
 
@@ -372,13 +391,26 @@ class TestChannelDelivery:
                 assert channel_payloads(delivered_to_a) == [m2.encode()], f"A must deliver B's reply; got {channel_payloads(delivered_to_a)!r}"
 
                 # Same race on A's side.
-                delay(RC08_CAUSAL_SETTLE_S)
+                delay(RC08_INTERLEAVE_SETTLE_S)
                 sender.send(to_base64(m3))
 
                 delivered_to_b = wait_for_channel_received_count(receiver_collector, channel_id, 2, DELIVERY_TIMEOUT_S)
                 assert channel_payloads(delivered_to_b) == [m1.encode(), m3.encode()], (
-                    f"B must deliver A's messages in causal order; got {channel_payloads(delivered_to_b)!r}. "
+                    f"B must deliver both of A's messages, in send order; got {channel_payloads(delivered_to_b)!r}. "
                     f"Collected events: {receiver_collector.snapshot()}"
+                )
+
+                envelopes = [wire_payload(e) for e in wait_for_distinct_message_received(receiver_collector, RC08_CONTENT_TOPIC, 2, DELIVERY_TIMEOUT_S)]
+                m1_envelope = next((e for e in envelopes if m1.encode() in e), None)
+                m3_envelope = next((e for e in envelopes if m3.encode() in e), None)
+                assert m1_envelope and m3_envelope, f"B must have seen both envelopes on the wire; got {envelopes!r}"
+
+                m1_ids = envelope_message_ids(m1_envelope)
+                assert m1_ids, f"no SDS message id in m1's envelope: {m1_envelope!r}"
+                m3_ids = envelope_message_ids(m3_envelope)
+                assert m1_ids[0] in m3_ids[1:], (
+                    f"m3 must carry m1 in its causal history; m1 is {m1_ids[0]!r}, "
+                    f"m3's envelope references {m3_ids[1:]!r}"
                 )
 
     def test_rc09_late_joining_receiver_still_receives(self, node_config):
@@ -582,9 +614,9 @@ class TestChannelDelivery:
         """RC13: A closes and re-creates its channel, then sends again.
 
         A sends m1, cycles the channel under the same id, then sends m2. B must
-        deliver m2 exactly once and ordered after m1, and must not replay m1 —
-        the re-created channel picks up the restored SDS history rather than
-        starting a fresh one.
+        deliver m2 exactly once, after m1, and must not replay m1. Whether the
+        re-created channel restored A's SDS history or started a fresh one is
+        not distinguishable here — both satisfy these assertions.
 
         Distinct from the nim in-process test, which cycles the *receiver's*
         channel and asserts a replayed m1 is suppressed on ingress; here the
@@ -644,7 +676,7 @@ class TestChannelDelivery:
                 assert channel_payloads(received) == [
                     m1.encode(),
                     m2.encode(),
-                ], f"expected [m1, m2] in causal order, got: {channel_payloads(received)!r}"
+                ], f"expected [m1, m2] in send order, got: {channel_payloads(received)!r}"
 
                 # A third event could only be a replayed m1 from the re-created channel.
                 settled = wait_for_channel_received_count(receiver_collector, channel_id, 3, NO_CHANNEL_DELIVERY_WINDOW_S)

--- a/tests-e2e/tests/wrappers_tests/test_channel_lifecycle.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_lifecycle.py
@@ -14,6 +14,7 @@ RC03_OPEN_CHANNEL_PREFIX = "rc03-open"
 RC03_RANDOM_CHANNEL_PREFIX = "rc03-random"
 
 RC04_CHANNEL_PREFIX = "rc04-channel"
+RC04_CLOSED_CHANNEL_PREFIX = "rc04-closed-channel"
 RC04_EPHEMERAL_CHANNEL_PREFIX = "rc04-ephemeral-channel"
 RC04_DISTINCT_CHANNEL_PREFIX = "rc04-distinct-channel"
 
@@ -173,6 +174,38 @@ class TestChannelLifecycle:
             send_result = node.channel_send(channel_id, create_message_bindings())
             assert send_result.is_ok(), f"channel_send with a non-empty payload failed: {send_result.err()}"
             assert send_result.ok_value, f"channel_send must return a non-empty channelReqId handle, got: {send_result.ok_value!r}"
+        finally:
+            node.stop_and_destroy()
+
+    def test_rc04_send_after_close_rejected(self, node_config):
+        """RC04 variant: sending after the channel is closed is rejected.
+
+        Exercises the teardown -> send ordering (distinct from RC02's
+        never-created id): once channel_close removes the id, channel_send Errs
+        with "unknown channel: <id>". No events are expected.
+        """
+        node_config.update({"mode": "Core", "numShardsInNetwork": 1})
+        channel_id = unique_channel_id(RC04_CLOSED_CHANNEL_PREFIX)
+
+        collector = EventCollector()
+        create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
+        assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
+        node = create_node_result.ok_value
+
+        try:
+            create_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
+            assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
+
+            delay(CHANNEL_SETTLE_S)
+
+            close_result = node.channel_close(channel_id)
+            assert close_result.is_ok(), f"channel_close failed: {close_result.err()}"
+
+            send_result = node.channel_send(channel_id, create_message_bindings())
+            assert send_result.is_err(), f"channel_send after close must fail, got Ok({send_result.ok_value!r})"
+            assert f"unknown channel: {channel_id}" in send_result.err(), f"unexpected error message: {send_result.err()!r}"
+
+            assert collector.events == [], f"expected no events, got: {collector.events}"
         finally:
             node.stop_and_destroy()
 

--- a/tests-e2e/tests/wrappers_tests/test_channel_lifecycle.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_lifecycle.py
@@ -1,21 +1,21 @@
-import uuid
-
 import pytest
 from src.node.wrappers_manager import WrapperManager
-from src.node.wrapper_helpers import EventCollector, create_message_bindings
+from src.node.wrapper_helpers import EventCollector, create_message_bindings, unique_channel_id
 from src.libs.common import delay
 
-CHANNEL_ID = "rc01-channel"
+RC01_CHANNEL_PREFIX = "rc01-channel"
 CONTENT_TOPIC = "/test/1/channel/proto"
 SENDER_ID = "rc01-sender"
 
-UNKNOWN_CHANNEL_ID = "rc02-unknown-channel"
+UNKNOWN_CHANNEL_PREFIX = "rc02-unknown-channel"
 
-RC03_CHANNEL_ID = "rc03-channel"
+RC03_CHANNEL_PREFIX = "rc03-channel"
+RC03_OPEN_CHANNEL_PREFIX = "rc03-open"
+RC03_RANDOM_CHANNEL_PREFIX = "rc03-random"
 
-RC04_CHANNEL_ID = "rc04-channel"
-RC04_EPHEMERAL_CHANNEL_ID = "rc04-ephemeral-channel"
-RC04_DISTINCT_CHANNEL_ID = "rc04-distinct-channel"
+RC04_CHANNEL_PREFIX = "rc04-channel"
+RC04_EPHEMERAL_CHANNEL_PREFIX = "rc04-ephemeral-channel"
+RC04_DISTINCT_CHANNEL_PREFIX = "rc04-distinct-channel"
 
 # Give the reliable channel manager a moment to settle a freshly-created
 # channel before we act on it.
@@ -32,6 +32,7 @@ class TestChannelLifecycle:
         """
         # channel_create subscribes to its content topic, which needs autosharding.
         node_config.update({"mode": "Core", "numShardsInNetwork": 1})
+        channel_id = unique_channel_id(RC01_CHANNEL_PREFIX)
 
         collector = EventCollector()
         create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
@@ -39,13 +40,13 @@ class TestChannelLifecycle:
         node = create_node_result.ok_value
 
         try:
-            create_result = node.channel_create(CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            create_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
             assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
-            assert create_result.ok_value == CHANNEL_ID, f"channel_create returned unexpected id: {create_result.ok_value!r}"
+            assert create_result.ok_value == channel_id, f"channel_create returned unexpected id: {create_result.ok_value!r}"
 
-            duplicate_result = node.channel_create(CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            duplicate_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
             assert duplicate_result.is_err(), f"duplicate channel_create must fail, got Ok({duplicate_result.ok_value!r})"
-            assert f"channel already exists: {CHANNEL_ID}" in duplicate_result.err(), f"unexpected error message: {duplicate_result.err()!r}"
+            assert f"channel already exists: {channel_id}" in duplicate_result.err(), f"unexpected error message: {duplicate_result.err()!r}"
 
             assert collector.events == [], f"expected no events, got: {collector.events}"
         finally:
@@ -57,6 +58,7 @@ class TestChannelLifecycle:
         The send must Err with "unknown channel: <id>" and emit no events.
         """
         node_config.update({"mode": "Core"})
+        unknown_channel_id = unique_channel_id(UNKNOWN_CHANNEL_PREFIX)
 
         collector = EventCollector()
         create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
@@ -64,9 +66,9 @@ class TestChannelLifecycle:
         node = create_node_result.ok_value
 
         try:
-            send_result = node.channel_send(UNKNOWN_CHANNEL_ID, create_message_bindings())
+            send_result = node.channel_send(unknown_channel_id, create_message_bindings())
             assert send_result.is_err(), f"channel_send on unknown channel must fail, got Ok({send_result.ok_value!r})"
-            assert f"unknown channel: {UNKNOWN_CHANNEL_ID}" in send_result.err(), f"unexpected error message: {send_result.err()!r}"
+            assert f"unknown channel: {unknown_channel_id}" in send_result.err(), f"unexpected error message: {send_result.err()!r}"
 
             assert collector.events == [], f"expected no events, got: {collector.events}"
         finally:
@@ -80,6 +82,8 @@ class TestChannelLifecycle:
         Lifecycle teardown + idempotency guard. No events are expected.
         """
         node_config.update({"mode": "Core", "numShardsInNetwork": 1})
+        channel_id = unique_channel_id(RC03_CHANNEL_PREFIX)
+        unknown_channel_id = unique_channel_id(UNKNOWN_CHANNEL_PREFIX)
 
         collector = EventCollector()
         create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
@@ -87,21 +91,21 @@ class TestChannelLifecycle:
         node = create_node_result.ok_value
 
         try:
-            create_result = node.channel_create(RC03_CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            create_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
             assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
 
             delay(CHANNEL_SETTLE_S)
 
-            close_result = node.channel_close(RC03_CHANNEL_ID)
+            close_result = node.channel_close(channel_id)
             assert close_result.is_ok(), f"channel_close on an existing channel failed: {close_result.err()}"
 
-            reclose_result = node.channel_close(RC03_CHANNEL_ID)
+            reclose_result = node.channel_close(channel_id)
             assert reclose_result.is_err(), f"second channel_close must fail, got Ok({reclose_result.ok_value!r})"
-            assert f"unknown channel: {RC03_CHANNEL_ID}" in reclose_result.err(), f"unexpected error message: {reclose_result.err()!r}"
+            assert f"unknown channel: {channel_id}" in reclose_result.err(), f"unexpected error message: {reclose_result.err()!r}"
 
-            unknown_close_result = node.channel_close(UNKNOWN_CHANNEL_ID)
+            unknown_close_result = node.channel_close(unknown_channel_id)
             assert unknown_close_result.is_err(), f"channel_close on unknown channel must fail, got Ok({unknown_close_result.ok_value!r})"
-            assert f"unknown channel: {UNKNOWN_CHANNEL_ID}" in unknown_close_result.err(), f"unexpected error message: {unknown_close_result.err()!r}"
+            assert f"unknown channel: {unknown_channel_id}" in unknown_close_result.err(), f"unexpected error message: {unknown_close_result.err()!r}"
 
             assert collector.events == [], f"expected no events, got: {collector.events}"
         finally:
@@ -116,8 +120,8 @@ class TestChannelLifecycle:
         """
         node_config.update({"mode": "Core", "numShardsInNetwork": 1})
 
-        channel_id = f"rc03-open-{uuid.uuid4()}"
-        random_id = f"rc03-random-{uuid.uuid4()}"
+        channel_id = unique_channel_id(RC03_OPEN_CHANNEL_PREFIX)
+        random_id = unique_channel_id(RC03_RANDOM_CHANNEL_PREFIX)
 
         collector = EventCollector()
         create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
@@ -150,22 +154,23 @@ class TestChannelLifecycle:
         Input validation + the immediate-handle contract of send.
         """
         node_config.update({"mode": "Core", "numShardsInNetwork": 1})
+        channel_id = unique_channel_id(RC04_CHANNEL_PREFIX)
 
         create_node_result = WrapperManager.create_and_start(config=node_config)
         assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
         node = create_node_result.ok_value
 
         try:
-            create_result = node.channel_create(RC04_CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            create_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
             assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
 
             delay(CHANNEL_SETTLE_S)
 
-            empty_result = node.channel_send(RC04_CHANNEL_ID, create_message_bindings(payload=""))
+            empty_result = node.channel_send(channel_id, create_message_bindings(payload=""))
             assert empty_result.is_err(), f"channel_send with an empty payload must fail, got Ok({empty_result.ok_value!r})"
             assert "empty payload" in empty_result.err(), f"unexpected error message: {empty_result.err()!r}"
 
-            send_result = node.channel_send(RC04_CHANNEL_ID, create_message_bindings())
+            send_result = node.channel_send(channel_id, create_message_bindings())
             assert send_result.is_ok(), f"channel_send with a non-empty payload failed: {send_result.err()}"
             assert send_result.ok_value, f"channel_send must return a non-empty channelReqId handle, got: {send_result.ok_value!r}"
         finally:
@@ -178,18 +183,19 @@ class TestChannelLifecycle:
         not the send contract, so channel_send returns Ok(channelReqId) immediately.
         """
         node_config.update({"mode": "Core", "numShardsInNetwork": 1})
+        channel_id = unique_channel_id(RC04_EPHEMERAL_CHANNEL_PREFIX)
 
         create_node_result = WrapperManager.create_and_start(config=node_config)
         assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
         node = create_node_result.ok_value
 
         try:
-            create_result = node.channel_create(RC04_EPHEMERAL_CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            create_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
             assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
 
             delay(CHANNEL_SETTLE_S)
 
-            send_result = node.channel_send(RC04_EPHEMERAL_CHANNEL_ID, create_message_bindings(ephemeral=True))
+            send_result = node.channel_send(channel_id, create_message_bindings(ephemeral=True))
             assert send_result.is_ok(), f"ephemeral channel_send failed: {send_result.err()}"
             assert send_result.ok_value, f"channel_send must return a non-empty channelReqId handle, got: {send_result.ok_value!r}"
         finally:
@@ -202,22 +208,23 @@ class TestChannelLifecycle:
         return two different (non-empty) channelReqId handles.
         """
         node_config.update({"mode": "Core", "numShardsInNetwork": 1})
+        channel_id = unique_channel_id(RC04_DISTINCT_CHANNEL_PREFIX)
 
         create_node_result = WrapperManager.create_and_start(config=node_config)
         assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
         node = create_node_result.ok_value
 
         try:
-            create_result = node.channel_create(RC04_DISTINCT_CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            create_result = node.channel_create(channel_id, CONTENT_TOPIC, SENDER_ID)
             assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
 
             delay(CHANNEL_SETTLE_S)
 
-            first_result = node.channel_send(RC04_DISTINCT_CHANNEL_ID, create_message_bindings())
+            first_result = node.channel_send(channel_id, create_message_bindings())
             assert first_result.is_ok(), f"first channel_send failed: {first_result.err()}"
             assert first_result.ok_value, f"first channel_send returned an empty handle: {first_result.ok_value!r}"
 
-            second_result = node.channel_send(RC04_DISTINCT_CHANNEL_ID, create_message_bindings())
+            second_result = node.channel_send(channel_id, create_message_bindings())
             assert second_result.is_ok(), f"second channel_send failed: {second_result.err()}"
             assert second_result.ok_value, f"second channel_send returned an empty handle: {second_result.ok_value!r}"
 

--- a/tests-e2e/tests/wrappers_tests/test_channel_repair.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_repair.py
@@ -1,0 +1,117 @@
+"""RC10 outcome: SDS-R repair recovers a missing dependency.
+
+Marked `slow` and kept out of the CI selection: the repair request only rides
+out after T_req, so the test spends minutes waiting. The CI-safe setup half is
+test_rc10_missing_dependency_is_parked in test_channel_delivery.py.
+"""
+
+import time
+
+import pytest
+
+from src.libs.common import delay, to_base64
+from src.node.subprocess_node import ChannelSenderProcess
+from src.node.wrappers_manager import WrapperManager
+from src.node.wrapper_helpers import EventCollector, create_message_bindings, get_node_multiaddr, unique_channel_id
+from tests.wrappers_tests.test_channel_delivery import (
+    CHANNEL_RECEIVED_EVENT,
+    DELIVERY_TIMEOUT_S,
+    MESH_SETTLE_S,
+    MESSAGE_RECEIVED_EVENT,
+    NO_CHANNEL_DELIVERY_WINDOW_S,
+    RC10_CHANNEL_PREFIX,
+    RC10_CHANNEL_SETTLE_S,
+    RC10_CONTENT_TOPIC,
+    SENDER_A,
+    SENDER_B,
+    channel_payloads,
+    wait_for_channel_received,
+    wait_for_channel_received_count,
+    wait_for_distinct_message_received,
+    wait_for_message_received,
+)
+
+# A repair request only rides out attached to an outgoing message, so B keeps
+# sending until T_req has elapsed for m1.
+NUDGE_INTERVAL_S = 10.0
+REPAIR_TIMEOUT_S = 330.0
+
+
+@pytest.mark.slow
+class TestChannelRepair:
+    @pytest.mark.timeout(REPAIR_TIMEOUT_S + 120)
+    def test_rc10_repair_delivers_missing_dependency(self, node_config):
+        """RC10: B parks m2 on the missing m1, then recovers both in causal order.
+
+        B has no channel when A sends m1, so m1 is lost to B's SDS and m2 arrives
+        referencing it. B keeps sending until one of its messages carries the
+        repair request and A rebroadcasts m1.
+        """
+        channel_id = unique_channel_id(RC10_CHANNEL_PREFIX)
+        m1, m2 = "rc10 sent before B has a channel", "rc10 depends on m1"
+
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "reliabilityEnabled": False,
+                "numShardsInNetwork": 1,
+            }
+        )
+
+        receiver_collector = EventCollector()
+        receiver_result = WrapperManager.create_and_start(config=node_config, event_cb=receiver_collector.event_callback)
+        assert receiver_result.is_ok(), f"Failed to start receiver: {receiver_result.err()}"
+
+        with receiver_result.ok_value as receiver:
+            sender_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(receiver)],
+                "portsShift": 1,
+            }
+
+            subscribe_result = receiver.subscribe_content_topic(RC10_CONTENT_TOPIC)
+            assert subscribe_result.is_ok(), f"receiver subscribe_content_topic failed: {subscribe_result.err()}"
+
+            with ChannelSenderProcess(
+                sender_config,
+                content_topic=RC10_CONTENT_TOPIC,
+                channel_id=channel_id,
+                sender_id=SENDER_A,
+                payload_b64=to_base64(m1),
+                settle_s=MESH_SETTLE_S,
+            ) as sender:
+                arrived = wait_for_message_received(receiver_collector, RC10_CONTENT_TOPIC, DELIVERY_TIMEOUT_S)
+                assert arrived is not None, (
+                    f"receiver never saw a {MESSAGE_RECEIVED_EVENT} for m1 within {DELIVERY_TIMEOUT_S}s; "
+                    f"the dependency was never established. Collected events: {receiver_collector.snapshot()}"
+                )
+
+                receiver_create = receiver.channel_create(channel_id, RC10_CONTENT_TOPIC, SENDER_B)
+                assert receiver_create.is_ok(), f"receiver channel_create failed: {receiver_create.err()}"
+
+                delay(RC10_CHANNEL_SETTLE_S)
+
+                sender.send(to_base64(m2))
+
+                both = wait_for_distinct_message_received(receiver_collector, RC10_CONTENT_TOPIC, 2, DELIVERY_TIMEOUT_S)
+                assert len(both) == 2, (
+                    f"receiver must see m2 at the messaging layer within {DELIVERY_TIMEOUT_S}s; "
+                    f"got {len(both)} distinct {MESSAGE_RECEIVED_EVENT} envelopes. "
+                    f"Collected events: {receiver_collector.snapshot()}"
+                )
+
+                parked = wait_for_channel_received(receiver_collector, channel_id, NO_CHANNEL_DELIVERY_WINDOW_S)
+                assert parked is None, f"m2 must park on the missing m1, not surface as {CHANNEL_RECEIVED_EVENT}; got: {parked!r}"
+
+                recovered = []
+                deadline = time.monotonic() + REPAIR_TIMEOUT_S
+                while len(recovered) < 2 and time.monotonic() < deadline:
+                    nudge_result = receiver.channel_send(channel_id, create_message_bindings(payload=to_base64("rc10 nudge")))
+                    assert nudge_result.is_ok(), f"receiver channel_send failed: {nudge_result.err()}"
+                    recovered = wait_for_channel_received_count(receiver_collector, channel_id, 2, NUDGE_INTERVAL_S)
+
+                assert channel_payloads(recovered) == [m1.encode(), m2.encode()], (
+                    f"the repair must deliver m1, releasing m2 behind it; got {channel_payloads(recovered)!r} "
+                    f"after {REPAIR_TIMEOUT_S}s. Collected events: {receiver_collector.snapshot()}"
+                )


### PR DESCRIPTION
Eight channel tests exist in logos-delivery-interop-tests and not here — RC04, RC07,
RC08, RC09, RC10 (parking and repair), RC12, RC13. This ports them.

**Ported, not copied.** Interop's `build_node_config()` defaults `relay`/`store` to
True and applies `mode=Edge` before explicit fields — the trap #4077 documented. None
of these eight uses Edge, but two ran with store on while every other channel test
disables it; ported with `store: False`. Stale claims dropped rather than carried: the
repair test's "exits 139 (#4103)" docstring and the `addfinalizer` built for it (#4109
fixed the segfault), and `subprocess_node.py`'s Persistency-singleton rationale (#4117
established the real cause).

**RC08 proved nothing as ported.** It waits for each message to land before sending the
next, so B seeing [m1, m3] follows from the test's own sequencing. It now checks the
wire: channel encryption is a noop, so `message_received` carries the SDS envelope
verbatim, and m3's envelope must reference m1's message id. Mutating the expected id
reddens it.

Full non-docker set with `not slow`, twice back to back: 57 passed, 2 skipped,
1 xfailed, identical. Five tests mutation-checked. Not ported:
`test_fixed_channel_id_exchange`, a skipped repro harness for the closed #4103.