### PR TITLE
fix(postgres): guard the partition maintenance against concurrent writers

### DIFF
--- a/logos_delivery/waku/common/databases/db_postgres/dbconn.nim
+++ b/logos_delivery/waku/common/databases/db_postgres/dbconn.nim
@@ -40,6 +40,13 @@ proc isPgDbConnOpen*(dbConnWrapper: DbConnWrapper): bool =
 proc setPgDbConnOpen*(dbConnWrapper: DbConnWrapper, newOpenState: bool) =
   dbConnWrapper.open = newOpenState
 
+const MaxDbErrorLen = 512
+  ## libpq can answer with very long messages -- the DETAIL and CONTEXT lines
+  ## carry row data -- and this string reaches both the logs and the error chain,
+  ## so it has to stay bounded. 512 keeps whole every message the callers must
+  ## classify: the longest of them, the constraint ones naming a partition twice,
+  ## are around 130 characters.
+
 proc check(db: DbConn): Result[void, string] =
   var message: string
   try:
@@ -48,7 +55,7 @@ proc check(db: DbConn): Result[void, string] =
     return err("exception in check: " & getCurrentExceptionMsg())
 
   if message.len > 0:
-    let truncatedErr = message[0 ..< min(80, message.len)]
+    let truncatedErr = message[0 ..< min(MaxDbErrorLen, message.len)]
     error "postgres check issue. see truncated db error.", error = truncatedErr
     return err(truncatedErr)
 

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/partitions_manager.nim
@@ -73,9 +73,23 @@ proc addPartitionInfo*(
 proc clearPartitionInfo*(self: PartitionManager) =
   self.partitions.clear()
 
-proc removeOldestPartitionName*(self: PartitionManager) =
-  ## Simply removed the partition from the tracked/known partitions queue.
-  ## Just remove it and ignore it.
+proc removeOldestPartitionName*(self: PartitionManager, expectedName: string) =
+  ## Removes the oldest partition from the tracked/known partitions queue, but
+  ## only when it is still the partition the caller decided to drop. Callers peek
+  ## at it and then await several slow queries before getting here, and the
+  ## factory loop may have refreshed the whole queue in between: popping blindly
+  ## then raises an IndexDefect if the queue ended up empty -- a Defect, so it
+  ## escapes `{.raises: [].}` and kills the node -- or forgets a partition that
+  ## is still attached.
+  if self.partitions.len == 0:
+    debug "no partition to remove", expectedName
+    return
+
+  if self.partitions.peekFirst().name != expectedName:
+    debug "oldest partition changed since it was chosen, not removing it",
+      expectedName, oldestName = self.partitions.peekFirst().name
+    return
+
   discard self.partitions.popFirst()
 
 proc isEmpty*(self: PartitionManager): bool =

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1154,6 +1154,33 @@ proc performWriteQuery*(
 
 const COULD_NOT_ACQUIRE_ADVISORY_LOCK* = "could not acquire advisory lock"
 
+const ConcurrentDdlOutcomes = [
+  # trying to add a partition constraint that another instance already added,
+  # e.g. constraint "messages_..._by_range_check" for relation "messages_..." already exists
+  "already exists",
+  # attaching a partition that another instance already attached,
+  # e.g. "messages_1720364735_1720364740" is already a partition
+  "is already a partition",
+  # dropping a constraint that another instance already dropped,
+  # e.g. constraint "..." of relation "messages_1720364735_1720364740" does not exist
+  "does not exist",
+  # CREATE TABLE IF NOT EXISTS is not atomic: when another instance creates the
+  # same partition concurrently, the loser gets a catalogue unique violation
+  # instead of the "already exists, skipping" notice
+  "pg_type_typname_nsp_index",
+  "pg_class_relname_nsp_index",
+]
+
+func isConcurrentDdlOutcome(error: string): bool =
+  ## Tells the outcomes that merely mean "another instance got there first"
+  ## apart from genuine failures. Both nodes of a shared-database deployment
+  ## run the partition maintenance, so these are expected, not exceptional.
+  for signature in ConcurrentDdlOutcomes:
+    if error.contains(signature):
+      return true
+
+  return false
+
 proc performWriteQueryWithLock(
     self: PostgresDriver, queryToProtect: string
 ): Future[ArchiveDriverResult[void]] {.async.} =
@@ -1190,22 +1217,8 @@ proc performWriteQueryWithLock(
       debug "Skip performWriteQuery because the advisory lock is acquired by other"
       return ok()
 
-    if error.contains("already exists"):
-      ## expected to happen when trying to add a partition table constraint that already exists
-      ## e.g., constraint "constraint_name" for relation "messages_1720364735_1720364740" already exists
-      debug "Skip already exists error", error = error
-      return ok()
-
-    if error.contains("is already a partition"):
-      ## expected to happen when a node tries to add a partition that is already attached,
-      ## e.g., "messages_1720364735_1720364740" is already a partition
-      debug "Skip is already a partition error", error = error
-      return ok()
-
-    if error.contains("does not exist"):
-      ## expected to happen when trying to drop a constraint that has already been dropped by other
-      ## constraint "constraint_name" of relation "messages_1720364735_1720364740" does not exist
-      debug "Skip does not exist error", error = error
+    if error.isConcurrentDdlOutcome():
+      debug "Skip error already handled by another instance", error = error
       return ok()
 
     debug "Protected query ended with error", error = $error

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1181,9 +1181,14 @@ func isConcurrentDdlOutcome(error: string): bool =
 
   return false
 
+type ProtectedQueryOutcome = enum
+  Executed ## this instance ran the statement
+  AlreadyDone ## another instance had already applied it
+  Deferred ## another instance holds the lock, so nothing was done
+
 proc performWriteQueryWithLock(
     self: PostgresDriver, queryToProtect: string
-): Future[ArchiveDriverResult[void]] {.async.} =
+): Future[ArchiveDriverResult[ProtectedQueryOutcome]] {.async.} =
   ## This wraps the original query in a script so that we make sure a pg_advisory lock protects it
   let query =
     fmt"""
@@ -1215,17 +1220,36 @@ proc performWriteQueryWithLock(
     if error.contains(COULD_NOT_ACQUIRE_ADVISORY_LOCK):
       ## We don't consider this as an error. Just someone else acquired the advisory lock
       debug "Skip performWriteQuery because the advisory lock is acquired by other"
-      return ok()
+      return ok(Deferred)
 
     if error.isConcurrentDdlOutcome():
       debug "Skip error already handled by another instance", error = error
-      return ok()
+      return ok(AlreadyDone)
 
     debug "Protected query ended with error", error = $error
     return err("protected query ended with error:" & $error)
 
   debug "Protected query ended correctly"
-  return ok()
+  return ok(Executed)
+
+proc performPartitionDdlSteps(
+    self: PostgresDriver, steps: seq[(string, string)]
+): Future[ArchiveDriverResult[bool]] {.async.} =
+  ## Runs the given (query, error context) steps in order, each one protected by
+  ## the advisory lock. Returns false as soon as one of them is deferred because
+  ## another instance holds the lock: the rest of that instance's sequence is not
+  ## ours to repeat -- carrying on would, for example, drop a constraint that we
+  ## never created, which is a fatal error for this node. The next maintenance
+  ## pass re-checks what is missing.
+  for (query, errContext) in steps:
+    let outcome = (await self.performWriteQueryWithLock(query)).valueOr:
+      return err(errContext & ": " & $error)
+
+    if outcome == Deferred:
+      debug "partition maintenance deferred to another instance", query
+      return ok(false)
+
+  return ok(true)
 
 proc addPartition(
     self: PostgresDriver, startTime: Timestamp
@@ -1252,16 +1276,10 @@ proc addPartition(
     " PARTITION OF messages_lookup FOR VALUES FROM (" & fromInNanoSec & ") TO (" &
     untilInNanoSec & ");"
 
-  (await self.performWriteQueryWithLock(createLookupQuery)).isOkOr:
-    return err(fmt"error adding lookup partition [{lookupPartitionName}]: " & $error)
-
   ## Create the partition table but not attach it yet to the main table
   let createPartitionQuery =
     "CREATE TABLE IF NOT EXISTS " & partitionName &
     " (LIKE messages INCLUDING DEFAULTS INCLUDING CONSTRAINTS);"
-
-  (await self.performWriteQueryWithLock(createPartitionQuery)).isOkOr:
-    return err(fmt"error adding partition [{partitionName}]: " & $error)
 
   ## Add constraint to the partition table so that EXCLUSIVE ACCESS is not performed when
   ## the partition is attached to the main table.
@@ -1271,24 +1289,33 @@ proc addPartition(
     " CHECK ( timestamp >= " & fromInNanoSec & " AND timestamp < " & untilInNanoSec &
     " );"
 
-  (await self.performWriteQueryWithLock(addTimeConstraintQuery)).isOkOr:
-    return err(fmt"error creating constraint [{partitionName}]: " & $error)
-
   ## Attaching the new created table as a new partition. That does not require EXCLUSIVE ACCESS.
   let attachPartitionQuery =
     "ALTER TABLE messages ATTACH PARTITION " & partitionName & " FOR VALUES FROM (" &
     fromInNanoSec & ") TO (" & untilInNanoSec & ");"
-
-  (await self.performWriteQueryWithLock(attachPartitionQuery)).isOkOr:
-    return err(fmt"error attaching partition [{partitionName}]: " & $error)
 
   ## Dropping the check constraint as it was only necessary to prevent full scan,
   ## and EXCLUSIVE ACCESS, to the whole messages table, when the new partition was attached.
   let dropConstraint =
     "ALTER TABLE " & partitionName & " DROP CONSTRAINT " & constraintName & ";"
 
-  (await self.performWriteQueryWithLock(dropConstraint)).isOkOr:
-    return err(fmt"error dropping constraint [{partitionName}]: " & $error)
+  let completed = (
+    await self.performPartitionDdlSteps(
+      @[
+        (createLookupQuery, fmt"error adding lookup partition [{lookupPartitionName}]"),
+        (createPartitionQuery, fmt"error adding partition [{partitionName}]"),
+        (addTimeConstraintQuery, fmt"error creating constraint [{partitionName}]"),
+        (attachPartitionQuery, fmt"error attaching partition [{partitionName}]"),
+        (dropConstraint, fmt"error dropping constraint [{partitionName}]"),
+      ]
+    )
+  ).valueOr:
+    return err($error)
+
+  if not completed:
+    ## Another instance is midway through this very sequence. Nothing to track
+    ## yet, the next factory iteration will see the partition it created.
+    return ok()
 
   debug "New partition added", query = createPartitionQuery
 
@@ -1403,9 +1430,17 @@ proc ensureLookupPartitions*(
     let createQuery =
       "CREATE TABLE IF NOT EXISTS " & lookupPartitionName &
       " (LIKE messages_lookup INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES);"
-    (await self.performWriteQueryWithLock(createQuery)).isOkOr:
-      return
-        err(fmt"error creating lookup partition [{lookupPartitionName}]: " & $error)
+    let created = (
+      await self.performPartitionDdlSteps(
+        @[(createQuery, fmt"error creating lookup partition [{lookupPartitionName}]")]
+      )
+    ).valueOr:
+      return err($error)
+
+    if not created:
+      ## Another instance is building this sibling, backfill included. Let it
+      ## finish; the next pass checks whether anything is still missing.
+      return ok()
 
     ## Plain query on purpose: a failure must abort the pass, never be
     ## skip-tolerated — the ATTACH below must imply a completed backfill.
@@ -1421,19 +1456,29 @@ proc ensureLookupPartitions*(
       "ALTER TABLE " & lookupPartitionName & " ADD CONSTRAINT " & constraintName &
       " CHECK ( timestamp >= " & fromInNanoSec & " AND timestamp < " & untilInNanoSec &
       " );"
-    (await self.performWriteQueryWithLock(addConstraintQuery)).isOkOr:
-      return err(fmt"error adding constraint [{lookupPartitionName}]: " & $error)
-
     let attachQuery =
       "ALTER TABLE messages_lookup ATTACH PARTITION " & lookupPartitionName &
       " FOR VALUES FROM (" & fromInNanoSec & ") TO (" & untilInNanoSec & ");"
-    (await self.performWriteQueryWithLock(attachQuery)).isOkOr:
-      return err(fmt"error attaching [{lookupPartitionName}]: " & $error)
 
     let dropConstraintQuery =
       "ALTER TABLE " & lookupPartitionName & " DROP CONSTRAINT " & constraintName & ";"
-    (await self.performWriteQueryWithLock(dropConstraintQuery)).isOkOr:
-      return err(fmt"error dropping constraint [{lookupPartitionName}]: " & $error)
+
+    let attached = (
+      await self.performPartitionDdlSteps(
+        @[
+          (addConstraintQuery, fmt"error adding constraint [{lookupPartitionName}]"),
+          (attachQuery, fmt"error attaching [{lookupPartitionName}]"),
+          (
+            dropConstraintQuery,
+            fmt"error dropping constraint [{lookupPartitionName}]",
+          ),
+        ]
+      )
+    ).valueOr:
+      return err($error)
+
+    if not attached:
+      return ok()
 
     info "created and backfilled lookup partition", lookupPartitionName
 

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1468,10 +1468,7 @@ proc ensureLookupPartitions*(
         @[
           (addConstraintQuery, fmt"error adding constraint [{lookupPartitionName}]"),
           (attachQuery, fmt"error attaching [{lookupPartitionName}]"),
-          (
-            dropConstraintQuery,
-            fmt"error dropping constraint [{lookupPartitionName}]",
-          ),
+          (dropConstraintQuery, fmt"error dropping constraint [{lookupPartitionName}]"),
         ]
       )
     ).valueOr:
@@ -1571,8 +1568,8 @@ proc loopPartitionFactory(
 
       if consecutiveFailures >= MaxConsecutivePartitionMaintenanceFailures:
         onFatalError(
-          "partition maintenance failed " & $consecutiveFailures &
-            " consecutive times: " & passRes.error
+          "partition maintenance failed " & $consecutiveFailures & " consecutive times: " &
+            passRes.error
         )
 
     await sleepAsync(DefaultDatabasePartitionCheckTimeInterval)
@@ -1651,7 +1648,7 @@ proc detachAndDropPartition(
   ?(await self.dropPartition(partitionName))
 
   debug "Removed partition", partition_name = partitionName, partition_size = partSize
-  self.partitionMngr.removeOldestPartitionName()
+  self.partitionMngr.removeOldestPartitionName(partitionName)
 
   return ok()
 

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, strutils, strformat, times, sugar],
+  std/[sequtils, strutils, strformat, times, sugar, random],
   stew/[byteutils, arrayops],
   results,
   chronos,
@@ -1485,6 +1485,8 @@ const DefaultDatabasePartitionCheckTimeInterval = timer.minutes(10)
 
 const MaxConsecutivePartitionMaintenanceFailures = 6
 
+const MaxPartitionCheckJitterSecs = 120
+
 proc runPartitionMaintenance(
     self: PostgresDriver
 ): Future[ArchiveDriverResult[void]] {.async.} =
@@ -1550,6 +1552,11 @@ proc loopPartitionFactory(
 
   var consecutiveFailures = 0
 
+  ## The instances sharing a database are typically (re)started together, and a
+  ## fixed interval then keeps their maintenance passes locked to the very same
+  ## tick for as long as they run, so that they contend on every iteration.
+  var rng = initRand()
+
   while true:
     trace "loopPartitionFactory iteration started"
 
@@ -1572,7 +1579,10 @@ proc loopPartitionFactory(
             passRes.error
         )
 
-    await sleepAsync(DefaultDatabasePartitionCheckTimeInterval)
+    await sleepAsync(
+      DefaultDatabasePartitionCheckTimeInterval +
+        timer.seconds(rng.rand(MaxPartitionCheckJitterSecs))
+    )
 
 proc startPartitionFactory*(
     self: PostgresDriver, onFatalError: OnFatalErrorHandler

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1486,6 +1486,60 @@ proc ensureLookupPartitions*(
 
 const DefaultDatabasePartitionCheckTimeInterval = timer.minutes(10)
 
+const MaxConsecutivePartitionMaintenanceFailures = 6
+
+proc runPartitionMaintenance(
+    self: PostgresDriver
+): Future[ArchiveDriverResult[void]] {.async.} =
+  ## One pass of the partition factory: cleanup of what previous passes left
+  ## behind, refresh of the tracked partitions and, when needed, creation of the
+  ## partition that will hold the messages to come.
+
+  ## Must precede the partition checks (see dropStrayLookupPartitions).
+  (await self.dropStrayLookupPartitions()).isOkOr:
+    error "failed to drop stray lookup partitions", error = $error
+
+  (await self.dropOrphanPartitions()).isOkOr:
+    return err("error when dropping orphan partitions: " & $error)
+
+  trace "Check if a new partition is needed"
+
+  ## Let's make the 'partition_manager' aware of the current partitions
+  (await self.refreshPartitionsInfo()).isOkOr:
+    return err("issue refreshing the partitions info: " & $error)
+
+  let now = times.now().toTime().toUnix()
+
+  if self.partitionMngr.isEmpty():
+    debug "Adding partition because now there aren't more partitions"
+    (await self.addPartition(now)).isOkOr:
+      return err("error when creating a new partition from empty state: " & $error)
+  else:
+    let newestPartition = self.partitionMngr.getNewestPartition().valueOr:
+      return err("could not get newest partition: " & $error)
+
+    if newestPartition.containsMoment(now):
+      debug "Creating a new partition for the future"
+      ## The current used partition is the last one that was created.
+      ## Thus, let's create another partition for the future.
+
+      (await self.addPartition(newestPartition.getLastMoment())).isOkOr:
+        return err("could not add the next partition for 'now': " & $error)
+    elif now >= newestPartition.getLastMoment():
+      debug "Creating a new partition to contain current messages"
+      ## There is no partition to contain the current time.
+      ## This happens if the node has been stopped for quite a long time.
+      ## Then, let's create the needed partition to contain 'now'.
+      (await self.addPartition(now)).isOkOr:
+        return err("could not add the next partition: " & $error)
+
+  ## After the partition checks, so a long backfill never gates builder.nim's
+  ## startup partition wait; non-fatal, the next pass retries.
+  (await self.ensureLookupPartitions()).isOkOr:
+    error "failed to ensure lookup partitions", error = $error
+
+  return ok()
+
 proc loopPartitionFactory(
     self: PostgresDriver, onFatalError: OnFatalErrorHandler
 ) {.async.} =
@@ -1497,53 +1551,29 @@ proc loopPartitionFactory(
 
   debug "Starting loopPartitionFactory"
 
+  var consecutiveFailures = 0
+
   while true:
     trace "loopPartitionFactory iteration started"
 
-    ## Must precede the partition checks (see dropStrayLookupPartitions).
-    (await self.dropStrayLookupPartitions()).isOkOr:
-      error "failed to drop stray lookup partitions", error = $error
-
-    (await self.dropOrphanPartitions()).isOkOr:
-      onFatalError("error when dropping orphan partitions: " & $error)
-
-    trace "Check if a new partition is needed"
-
-    ## Let's make the 'partition_manager' aware of the current partitions
-    (await self.refreshPartitionsInfo()).isOkOr:
-      onFatalError("issue in loopPartitionFactory: " & $error)
-
-    let now = times.now().toTime().toUnix()
-
-    if self.partitionMngr.isEmpty():
-      debug "Adding partition because now there aren't more partitions"
-      (await self.addPartition(now)).isOkOr:
-        onFatalError("error when creating a new partition from empty state: " & $error)
+    let passRes = await self.runPartitionMaintenance()
+    if passRes.isOk():
+      consecutiveFailures = 0
     else:
-      let newestPartitionRes = self.partitionMngr.getNewestPartition()
-      if newestPartitionRes.isErr():
-        onFatalError("could not get newest partition: " & $newestPartitionRes.error)
+      ## Partitions are created an hour ahead of time and this loop runs every
+      ## ten minutes, so about six passes can fail before the messages arriving
+      ## have nowhere to land. A single failed pass is usually a race with the
+      ## other instances maintaining the same database, which is transient by
+      ## nature; only a persistent failure is worth bringing the node down for.
+      consecutiveFailures.inc()
+      error "partition maintenance pass failed, will retry",
+        error = passRes.error, consecutiveFailures
 
-      let newestPartition = newestPartitionRes.get()
-      if newestPartition.containsMoment(now):
-        debug "Creating a new partition for the future"
-        ## The current used partition is the last one that was created.
-        ## Thus, let's create another partition for the future.
-
-        (await self.addPartition(newestPartition.getLastMoment())).isOkOr:
-          onFatalError("could not add the next partition for 'now': " & $error)
-      elif now >= newestPartition.getLastMoment():
-        debug "Creating a new partition to contain current messages"
-        ## There is no partition to contain the current time.
-        ## This happens if the node has been stopped for quite a long time.
-        ## Then, let's create the needed partition to contain 'now'.
-        (await self.addPartition(now)).isOkOr:
-          onFatalError("could not add the next partition: " & $error)
-
-    ## After the partition checks, so a long backfill never gates builder.nim's
-    ## startup partition wait; non-fatal, the next pass retries.
-    (await self.ensureLookupPartitions()).isOkOr:
-      error "failed to ensure lookup partitions", error = $error
+      if consecutiveFailures >= MaxConsecutivePartitionMaintenanceFailures:
+        onFatalError(
+          "partition maintenance failed " & $consecutiveFailures &
+            " consecutive times: " & passRes.error
+        )
 
     await sleepAsync(DefaultDatabasePartitionCheckTimeInterval)
 

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1314,7 +1314,7 @@ proc addPartition*(
       ]
     )
   ).valueOr:
-    return err($error)
+    return err("failed calling performPartitionDdlSteps: " & $error)
 
   if not completed:
     ## Another instance is midway through this very sequence. Nothing to track
@@ -1439,7 +1439,7 @@ proc ensureLookupPartitions*(
         @[(createQuery, "error creating lookup partition: " & lookupPartitionName)]
       )
     ).valueOr:
-      return err($error)
+      return err("failed calling performPartitionDdlSteps: " & $error)
 
     if not created:
       ## Another instance is building this sibling, backfill included. Let it
@@ -1476,7 +1476,7 @@ proc ensureLookupPartitions*(
         ]
       )
     ).valueOr:
-      return err($error)
+      return err("failed calling performPartitionDdlSteps: " & $error)
 
     if not attached:
       return ok()

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1314,7 +1314,7 @@ proc addPartition*(
       ]
     )
   ).valueOr:
-    return err("failed calling performPartitionDdlSteps: " & $error)
+    return err("failed addPartition calling performPartitionDdlSteps: " & $error)
 
   if not completed:
     ## Another instance is midway through this very sequence. Nothing to track
@@ -1439,7 +1439,7 @@ proc ensureLookupPartitions*(
         @[(createQuery, "error creating lookup partition: " & lookupPartitionName)]
       )
     ).valueOr:
-      return err("failed calling performPartitionDdlSteps: " & $error)
+      return err("failed ensureLookupPartitions calling performPartitionDdlSteps: " & $error)
 
     if not created:
       ## Another instance is building this sibling, backfill included. Let it
@@ -1476,7 +1476,7 @@ proc ensureLookupPartitions*(
         ]
       )
     ).valueOr:
-      return err("failed calling performPartitionDdlSteps: " & $error)
+      return err("failed ensureLookupPartitions calling performPartitionDdlSteps: " & $error)
 
     if not attached:
       return ok()

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1306,11 +1306,11 @@ proc addPartition*(
   let completed = (
     await self.performPartitionDdlSteps(
       @[
-        (createLookupQuery, fmt"error adding lookup partition [{lookupPartitionName}]"),
-        (createPartitionQuery, fmt"error adding partition [{partitionName}]"),
-        (addTimeConstraintQuery, fmt"error creating constraint [{partitionName}]"),
-        (attachPartitionQuery, fmt"error attaching partition [{partitionName}]"),
-        (dropConstraint, fmt"error dropping constraint [{partitionName}]"),
+        (createLookupQuery, "error adding lookup partition: " & lookupPartitionName),
+        (createPartitionQuery, "error adding partition: " & partitionName),
+        (addTimeConstraintQuery, "error creating constraint: " & partitionName),
+        (attachPartitionQuery, "error attaching partition: " & partitionName),
+        (dropConstraint, "error dropping constraint: " & partitionName),
       ]
     )
   ).valueOr:
@@ -1436,7 +1436,7 @@ proc ensureLookupPartitions*(
       " (LIKE messages_lookup INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES);"
     let created = (
       await self.performPartitionDdlSteps(
-        @[(createQuery, fmt"error creating lookup partition [{lookupPartitionName}]")]
+        @[(createQuery, "error creating lookup partition: " & lookupPartitionName)]
       )
     ).valueOr:
       return err($error)
@@ -1470,9 +1470,9 @@ proc ensureLookupPartitions*(
     let attached = (
       await self.performPartitionDdlSteps(
         @[
-          (addConstraintQuery, fmt"error adding constraint [{lookupPartitionName}]"),
-          (attachQuery, fmt"error attaching [{lookupPartitionName}]"),
-          (dropConstraintQuery, fmt"error dropping constraint [{lookupPartitionName}]"),
+          (addConstraintQuery, "error adding constraint: " & lookupPartitionName),
+          (attachQuery, "error attaching: " & lookupPartitionName),
+          (dropConstraintQuery, "error dropping constraint: " & lookupPartitionName),
         ]
       )
     ).valueOr:

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1060,7 +1060,8 @@ method deleteOldestMessagesNotWithinLimit*(
 
 method close*(s: PostgresDriver): Future[ArchiveDriverResult[void]] {.async.} =
   ## Cancel the partition factory loop
-  s.futLoopPartitionFactory.cancelSoon()
+  if not s.futLoopPartitionFactory.isNil():
+    s.futLoopPartitionFactory.cancelSoon()
 
   ## Cancel analyze table loop
   if not s.futLoopAnalyzeTable.isNil():
@@ -1154,6 +1155,9 @@ proc performWriteQuery*(
 
 const COULD_NOT_ACQUIRE_ADVISORY_LOCK* = "could not acquire advisory lock"
 
+const PartitionAdvisoryLockId* = 123456789
+  ## Serializes the partition maintenance among the instances sharing a database
+
 const ConcurrentDdlOutcomes = [
   # trying to add a partition constraint that another instance already added,
   # e.g. constraint "messages_..._by_range_check" for relation "messages_..." already exists
@@ -1171,7 +1175,7 @@ const ConcurrentDdlOutcomes = [
   "pg_class_relname_nsp_index",
 ]
 
-func isConcurrentDdlOutcome(error: string): bool =
+func isConcurrentDdlOutcome*(error: string): bool =
   ## Tells the outcomes that merely mean "another instance got there first"
   ## apart from genuine failures. Both nodes of a shared-database deployment
   ## run the partition maintenance, so these are expected, not exceptional.
@@ -1197,7 +1201,7 @@ proc performWriteQueryWithLock(
               lock_acquired boolean;
           BEGIN
               -- Try to acquire the advisory lock
-              lock_acquired := pg_try_advisory_lock(123456789);
+              lock_acquired := pg_try_advisory_lock({PartitionAdvisoryLockId});
 
               IF NOT lock_acquired THEN
                   RAISE EXCEPTION '{COULD_NOT_ACQUIRE_ADVISORY_LOCK}';
@@ -1208,12 +1212,12 @@ proc performWriteQueryWithLock(
                   {queryToProtect}
               EXCEPTION WHEN OTHERS THEN
                   -- Ensure the lock is released if an error occurs
-                  PERFORM pg_advisory_unlock(123456789);
+                  PERFORM pg_advisory_unlock({PartitionAdvisoryLockId});
                   RAISE;
               END;
 
               -- Release the advisory lock after the query completes successfully
-              PERFORM pg_advisory_unlock(123456789);
+              PERFORM pg_advisory_unlock({PartitionAdvisoryLockId});
           END $$;
 """
   (await self.performWriteQuery(query)).isOkOr:
@@ -1251,7 +1255,7 @@ proc performPartitionDdlSteps(
 
   return ok(true)
 
-proc addPartition(
+proc addPartition*(
     self: PostgresDriver, startTime: Timestamp
 ): Future[ArchiveDriverResult[void]] {.async.} =
   ## Creates a partition table that will store the messages that fall in the range

--- a/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
+++ b/logos_delivery/waku/waku_archive/driver/postgres_driver/postgres_driver.nim
@@ -1439,7 +1439,8 @@ proc ensureLookupPartitions*(
         @[(createQuery, "error creating lookup partition: " & lookupPartitionName)]
       )
     ).valueOr:
-      return err("failed ensureLookupPartitions calling performPartitionDdlSteps: " & $error)
+      return
+        err("failed ensureLookupPartitions calling performPartitionDdlSteps: " & $error)
 
     if not created:
       ## Another instance is building this sibling, backfill included. Let it
@@ -1476,7 +1477,8 @@ proc ensureLookupPartitions*(
         ]
       )
     ).valueOr:
-      return err("failed ensureLookupPartitions calling performPartitionDdlSteps: " & $error)
+      return
+        err("failed ensureLookupPartitions calling performPartitionDdlSteps: " & $error)
 
     if not attached:
       return ok()

--- a/tests/waku_archive/test_driver_postgres.nim
+++ b/tests/waku_archive/test_driver_postgres.nim
@@ -247,3 +247,129 @@ suite "Postgres driver":
     check attachedStray notin
       (await driver.getPartitionsList("messages_lookup")).expect("lookup list")
     check not (await driver.existsTable(detachedStray)).expect("existsTable")
+
+  ## The partition maintenance runs on every instance sharing the database, so
+  ## these check that a sequence meeting another one in flight ends well. The
+  ## window is well in the past, so that it never collides with the partition
+  ## the factory keeps creating for the present time.
+  const partitionStart = Timestamp(1_700_000_000) ## 2023-11-14 22:13:20 UTC
+  const partitionName = "messages_1700000000_1700002800"
+  const partitionConstraint = partitionName & "_by_range_check"
+  const partitionFromNanos = "1700000000000000000"
+  const partitionUntilNanos = "1700002800000000000"
+
+  proc createPartitionTableQuery(): string =
+    return
+      "CREATE TABLE IF NOT EXISTS " & partitionName &
+      " (LIKE messages INCLUDING DEFAULTS INCLUDING CONSTRAINTS);"
+
+  proc addConstraintQuery(): string =
+    return
+      "ALTER TABLE " & partitionName & " ADD CONSTRAINT " & partitionConstraint &
+      " CHECK ( timestamp >= " & partitionFromNanos & " AND timestamp < " &
+      partitionUntilNanos & " );"
+
+  asyncTest "A long database error reaches the caller in one piece":
+    ## The words telling a concurrent-DDL outcome apart from a real failure sit
+    ## past the 80th character of these messages, so the guards in the partition
+    ## maintenance only work as long as the whole message is propagated.
+    (await driver.performWriteQuery(createPartitionTableQuery())).expect(
+      "create the partition table"
+    )
+    (await driver.performWriteQuery(addConstraintQuery())).expect("add the constraint")
+
+    let repeatedRes = await driver.performWriteQuery(addConstraintQuery())
+
+    ## constraint "<45 chars>" for relation "<30 chars>" already exists
+    ## is 127 characters long, and the deciding words start at the 113th
+    check repeatedRes.isErr()
+    check repeatedRes.error.contains("already exists")
+
+  asyncTest "Complete a partition another instance left half built":
+    ## The other instance created the partition table and added its range
+    ## constraint, and went away before attaching it. Our sequence has to take
+    ## the steps it finds already done and complete the rest.
+    (await driver.performWriteQuery(createPartitionTableQuery())).expect(
+      "create the partition table"
+    )
+    (await driver.performWriteQuery(addConstraintQuery())).expect("add the constraint")
+
+    (await driver.addPartition(partitionStart)).expect("addPartition")
+
+    check partitionName in (await driver.getPartitionsList()).expect("partitions list")
+
+  asyncTest "Defer the partition creation to the instance holding the lock":
+    ## A pool of one connection, so that the session-level advisory lock stays
+    ## held across the queries below, like an instance midway through its own
+    ## sequence.
+    let lockHolder = PgAsyncPool.new(storeMessageDbUrl, 1).expect("raw pool")
+    (
+      await lockHolder.pgQuery(
+        "SELECT pg_advisory_lock(" & $PartitionAdvisoryLockId & ");"
+      )
+    ).expect("take the advisory lock")
+
+    ## Built without the builder on purpose: no partition factory runs on it, so
+    ## its partition tracking is empty and says whether the sequence below ran
+    ## to the end -- the tracking is only updated by its very last line.
+    let ourInstance =
+      PostgresDriver.new(storeMessageDbUrl, maxConnections = 4).expect("second driver")
+
+    ## Deferring is not a failure, but nothing may be created either: the steps
+    ## belong to the sequence of whoever holds the lock.
+    (await ourInstance.addPartition(partitionStart)).expect("deferred addPartition")
+
+    check not (await driver.existsTable(partitionName)).expect("existsTable")
+    check not ourInstance.containsAnyPartition()
+
+    (
+      await lockHolder.pgQuery(
+        "SELECT pg_advisory_unlock(" & $PartitionAdvisoryLockId & ");"
+      )
+    ).expect("release the advisory lock")
+    (await lockHolder.close()).expect("close the raw pool")
+
+    ## The work was postponed, not lost: the next attempt goes through
+    (await ourInstance.addPartition(partitionStart)).expect("addPartition")
+
+    check partitionName in (await driver.getPartitionsList()).expect("partitions list")
+    check ourInstance.containsAnyPartition()
+
+    (await ourInstance.close()).expect("close the second driver")
+
+suite "Postgres driver - concurrent DDL outcomes":
+  ## The messages below are the ones the fleets produced while two instances
+  ## maintained the same partitions. Every one of them means "another instance
+  ## already did this", and none of them may be treated as a failure.
+  const constraintAlreadyExists =
+    "ERROR:  constraint \"messages_1720364735_1720364740_by_range_check\" " &
+    "for relation \"messages_1720364735_1720364740\" already exists"
+
+  const constraintDoesNotExist =
+    "ERROR:  constraint \"messages_1720364735_1720364740_by_range_check\" " &
+    "of relation \"messages_1720364735_1720364740\" does not exist"
+
+  const alreadyAPartition =
+    "ERROR:  \"messages_1720364735_1720364740\" is already a partition"
+
+  ## CREATE TABLE IF NOT EXISTS is not atomic, so the instance losing that race
+  ## gets a catalogue unique violation instead of the "skipping" notice
+  const typeCatalogueCollision =
+    "ERROR:  duplicate key value violates unique constraint " &
+    "\"pg_type_typname_nsp_index\""
+
+  const classCatalogueCollision =
+    "ERROR:  duplicate key value violates unique constraint " &
+    "\"pg_class_relname_nsp_index\""
+
+  test "Classify the outcomes of a concurrent partition maintenance":
+    check constraintAlreadyExists.isConcurrentDdlOutcome()
+    check constraintDoesNotExist.isConcurrentDdlOutcome()
+    check alreadyAPartition.isConcurrentDdlOutcome()
+    check typeCatalogueCollision.isConcurrentDdlOutcome()
+    check classCatalogueCollision.isConcurrentDdlOutcome()
+
+  test "Do not classify a genuine failure as a concurrent outcome":
+    check not "ERROR:  could not acquire advisory lock".isConcurrentDdlOutcome()
+    check not "ERROR:  no space left on device".isConcurrentDdlOutcome()
+    check not "ERROR:  deadlock detected".isConcurrentDdlOutcome()

--- a/tests/waku_archive/test_partition_manager.nim
+++ b/tests/waku_archive/test_partition_manager.nim
@@ -14,3 +14,26 @@ suite "Partition Manager":
     # 1717372800 == Mon Jun 03 2024 00:00:00 GMT+0000
     # 1717376400 == Mon Jun 03 2024 01:00:00 GMT+0000
     check 1717376400 == partitions_manager.calcEndPartitionTime(Timestamp(1717372800))
+
+  test "Remove the oldest partition only when it is the expected one":
+    let manager = PartitionManager.new()
+    manager.addPartitionInfo("messages_1717372800_1717376400", 1717372800, 1717376400)
+    manager.addPartitionInfo("messages_1717376400_1717380000", 1717376400, 1717380000)
+
+    ## The partitions queue may be refreshed while the caller is awaiting the
+    ## queries that drop the partition it chose, so a stale name must not remove
+    ## whatever ended up being the oldest one.
+    manager.removeOldestPartitionName("messages_1717369200_1717372800")
+    check manager.getOldestPartition().get().getName() ==
+      "messages_1717372800_1717376400"
+
+    manager.removeOldestPartitionName("messages_1717372800_1717376400")
+    check manager.getOldestPartition().get().getName() ==
+      "messages_1717376400_1717380000"
+
+  test "Remove a partition from an empty manager":
+    let manager = PartitionManager.new()
+
+    ## Must not raise, even though the queue is empty
+    manager.removeOldestPartitionName("messages_1717372800_1717376400")
+    check manager.isEmpty()


### PR DESCRIPTION
## Description

The delivery fleets run two nodes against one database per DC, so both of them
run the partition maintenance on the same tables. That is supposed to be safe:
`performWriteQueryWithLock` has guards for the outcomes a concurrent writer
produces. In practice a lost race kills the node, and because the module dies
inside the wrapper the container never exits and the restart policy never
fires, so the node stays down until the next recreate.

Four things combine into that:

1. **The existing guards are unreachable.** `check()` truncated every Postgres
   error to 80 characters *before* returning it, and the deciding keyword sits
   past the cut whenever the identifier is a partition name:

   | full message | len | keyword at | survives the cut |
   |---|---|---|---|
   | `constraint "messages_<from>_<until>_by_range_check" for relation "messages_<from>_<until>" already exists` | 127 | 113 | no |
   | `constraint "…_by_range_check" of relation "messages_…" does not exist` | 126 | 112 | no |
   | `relation "messages_…" is already a partition` | 72 | 50 | yes |

   The third row is the tell: the only guard short enough to survive is the one
   protecting the ATTACH step, and ATTACH is the one step that has never killed
   a node.

2. **One signature has no guard at any length.** `CREATE TABLE IF NOT EXISTS`
   is not atomic in Postgres, so a concurrent creation of the same partition
   surfaces as `duplicate key value violates unique constraint
   "pg_type_typname_nsp_index"` instead of the "already exists, skipping"
   notice.

3. **A deferred step did not stop the sequence.** Adding one partition is five
   separate statements, and each one is sent on its own, wrapped in a
   `DO $$ … $$` block that takes `pg_try_advisory_lock(123456789)`, runs the
   statement and releases the lock again:

   | # | statement |
   |---|---|
   | 1 | `CREATE TABLE IF NOT EXISTS lookup_<from>_<until> PARTITION OF messages_lookup FOR VALUES FROM (…) TO (…)` |
   | 2 | `CREATE TABLE IF NOT EXISTS messages_<from>_<until> (LIKE messages INCLUDING DEFAULTS INCLUDING CONSTRAINTS)` |
   | 3 | `ALTER TABLE messages_<from>_<until> ADD CONSTRAINT messages_<from>_<until>_by_range_check CHECK (timestamp >= … AND timestamp < …)` |
   | 4 | `ALTER TABLE messages ATTACH PARTITION messages_<from>_<until> FOR VALUES FROM (…) TO (…)` |
   | 5 | `ALTER TABLE messages_<from>_<until> DROP CONSTRAINT messages_<from>_<until>_by_range_check` |

   Steps 3 and 5 exist only to keep step 4 cheap: with the CHECK in place,
   ATTACH validates the range from the catalogue instead of scanning the
   partition, so its ACCESS EXCLUSIVE lock on `messages` is brief — and once
   the partition is attached the constraint is redundant, hence the drop.

   Since the advisory lock is released between the statements, two instances
   interleave freely, and `pg_try_advisory_lock` returning false raised
   `could not acquire advisory lock`, which the driver turned into `ok()` —
   indistinguishable, to the caller, from "the statement ran". So the sequence
   simply continued with the next step:

   ```
   node A                                node B
   1 CREATE lookup_…          ok
   2 CREATE messages_…        ok         1 CREATE lookup_…       lock busy → "ok"
   3 ADD CONSTRAINT …         ok         2 CREATE messages_…     lock busy → "ok"
   4 ATTACH PARTITION …       ok         3 ADD CONSTRAINT …      lock busy → "ok"
   5 DROP CONSTRAINT …        ok         4 ATTACH PARTITION …    "is already a partition"
                                         5 DROP CONSTRAINT …     ERROR: constraint … does not exist
   ```

   B never created that constraint — A did, and A had already dropped it at its
   own step 5. With the roles reversed the same interleaving yields the
   `already exists` variant on step 3 instead, which is the `do-ams3` crash of
   Aug 19. Either way the node dies on a step whose precondition it never
   established, and `ensureLookupPartitions` runs the same shape of sequence for
   the lookup siblings.

   After this PR the first deferral ends the pass: B stops at step 1, and its
   next iteration finds the partition already complete and does nothing.

4. **Any single failure was fatal.** Partitions are created an hour ahead and
   the loop runs every ten minutes, so a failed pass has roughly six retries
   before messages have nowhere to land — there was no reason to `quit()` on
   the first one.

Plus one crash of its own kind: `removeOldestPartitionName` popped the tracked
partitions queue blindly, and the caller peeks at the head then awaits several
slow queries before getting there, so the factory loop may have refreshed the
queue in between. `popFirst` on an emptied `Deque` raises an `IndexDefect`,
which is a Defect and escapes `{.raises: [].}`.

## Changes

One commit per guard:

- `return a db error that the callers can classify` — the 80-character cut is
  raised to 512. The cap is kept on purpose: it was added because libpq DETAIL
  and CONTEXT lines carry row data and this string reaches the logs. 512 leaves
  a wide margin over the ~130 characters of the longest message a caller has to
  classify.
- `also tolerate concurrent CREATE TABLE catalogue collisions` — the tolerated
  outcomes move into one named classifier, extended with the `pg_type` and
  `pg_class` unique violations.
- `stop a partition sequence when another instance holds the lock` — the
  protected query now reports `Executed` / `AlreadyDone` / `Deferred`, and the
  partition sequences abort on the first deferral.
- `only quit when partition maintenance keeps failing` — the pass is extracted
  into `runPartitionMaintenance`, and the loop escalates to the fatal handler
  only after 6 consecutive failed passes (~1 h).
- `drop the partition we chose, not whatever is at the head` — the pop is
  name-checked and tolerates an empty queue, with unit tests for both.
- `jitter the partition maintenance interval` — instances recreated together
  otherwise stay phase-locked to the same tick and meet on every iteration.

Behaviour when nothing races is unchanged: same statements, same order.

## Testing

Regression tests only: each one was checked to go red when the guard it covers
is reverted, and green again with it in place.

| test | fails without |
|---|---|
| A long database error reaches the caller in one piece | `check()` returning enough of the message to classify it |
| Complete a partition another instance left half built | the same — the `already exists` it must tolerate is 127 characters long |
| Defer the partition creation to the instance holding the lock | the sequence stopping at the first deferral (the partition tracking is only updated by the last line of a sequence that ran to the end) |
| Classify the outcomes of a concurrent partition maintenance | any of the tolerated signatures, the `pg_type` / `pg_class` ones included |
| Remove the oldest partition only when it is the expected one | the name-checked pop — it removes a live partition instead |
| Remove a partition from an empty manager | the same — `IndexDefect`, exactly as in production |

Run against `postgres:15.4-alpine3.18`, the image CI uses:
`test_driver_postgres` 12 OK, `test_partition_manager` 3 OK.

For the tests to reach it, `addPartition` and the outcome classifier are
exported, the advisory lock id becomes a named constant so a test can hold the
same lock, and `close()` now tolerates a driver whose partition factory was
never started.

## Issue

Part of #4064 — this covers the crashes caused by concurrent partition
maintenance. Left for follow-ups, and independent of this change: the
`closeDbConn` file-descriptor leak (`PQsocket()` returns -1 on the dead
connection we are closing, so the selector entry leaks), a schema assertion at
migration time (the version row alone is not evidence that v6/v7 ran), and an
insert-failure metric so a store node writing zero rows is noticed.
