### PR TITLE
fix(archive): make a node that writes nothing visible

### DIFF
--- a/logos_delivery/waku/waku_archive/archive.nim
+++ b/logos_delivery/waku/waku_archive/archive.nim
@@ -125,7 +125,7 @@ proc handleMessage*(
 
   (await self.driver.put(msgHash, pubsubTopic, msg)).isOkOr:
     logos_delivery_archive_errors.inc(labelValues = [insertFailure])
-    trace "failed to insert message",
+    debug "failed to insert message",
       msg_hash = msgHashHex,
       pubsubTopic = pubsubTopic,
       contentTopic = msg.contentTopic,
@@ -169,7 +169,7 @@ proc syncMessageIngress*(
   let insertStartTime = getTime().toUnixFloat()
   (await self.driver.put(msgHash, pubsubTopic, msg)).isOkOr:
     logos_delivery_archive_errors.inc(labelValues = [insertFailure])
-    trace "failed to insert message in in syncMessageIngress",
+    debug "failed to insert message in in syncMessageIngress",
       msg_hash = msgHashHex,
       pubsubTopic = pubsubTopic,
       contentTopic = msg.contentTopic,

--- a/logos_delivery/waku/waku_archive/archive.nim
+++ b/logos_delivery/waku/waku_archive/archive.nim
@@ -92,6 +92,11 @@ proc new*(
     driver: driver, validator: validator, retentionPolicies: retentionPolicies
   )
 
+  ## Publish both series right away, so that a node that has not written yet is
+  ## reported as writing nothing instead of not being reported at all.
+  logos_delivery_archive_inserts.inc(0, labelValues = [relayIngress])
+  logos_delivery_archive_inserts.inc(0, labelValues = [syncIngress])
+
   return ok(archive)
 
 proc handleMessage*(
@@ -135,6 +140,7 @@ proc handleMessage*(
     DefaultRelayShard
 
   logos_delivery_archive_messages_per_shard.inc(labelValues = [$shard.shardId])
+  logos_delivery_archive_inserts.inc(labelValues = [relayIngress])
 
   trace "message archived",
     msg_hash = msgHashHex,
@@ -173,6 +179,7 @@ proc syncMessageIngress*(
 
   let insertDuration = getTime().toUnixFloat() - insertStartTime
   logos_delivery_archive_insert_duration_seconds.observe(insertDuration)
+  logos_delivery_archive_inserts.inc(labelValues = [syncIngress])
 
   trace "message archived in syncMessageIngress",
     msg_hash = msgHashHex,

--- a/logos_delivery/waku/waku_archive/archive_metrics.nim
+++ b/logos_delivery/waku/waku_archive/archive_metrics.nim
@@ -8,6 +8,8 @@ declarePublicGauge logos_delivery_archive_messages_per_shard,
   "number of historical messages per shard ", ["shard"]
 declarePublicCounter logos_delivery_archive_errors,
   "number of store protocol errors", ["type"]
+declarePublicCounter logos_delivery_archive_inserts,
+  "number of messages written to the archive", ["source"]
 declarePublicHistogram logos_delivery_archive_insert_duration_seconds,
   "message insertion duration"
 declarePublicHistogram logos_delivery_archive_query_duration_seconds,
@@ -19,3 +21,8 @@ const
   invalidMessageFuture* = "invalid_message_future_timestamp"
   insertFailure* = "insert_failure"
   retPolicyFailure* = "retpolicy_failure"
+
+# Ingress that wrote the message (metric label values)
+const
+  relayIngress* = "relay"
+  syncIngress* = "sync"

--- a/tests/waku_archive/archive_utils.nim
+++ b/tests/waku_archive/archive_utils.nim
@@ -24,6 +24,20 @@ proc newSqliteArchiveDriver*(): ArchiveDriver =
 proc newWakuArchive*(driver: ArchiveDriver): WakuArchive =
   WakuArchive.new(driver).get()
 
+type FailingArchiveDriver* = ref object of ArchiveDriver
+  ## Refuses every write, which is what a node with a broken database does.
+
+method put*(
+    driver: FailingArchiveDriver,
+    messageHash: WakuMessageHash,
+    pubsubTopic: PubsubTopic,
+    message: WakuMessage,
+): Future[ArchiveDriverResult[void]] {.async.} =
+  return err("failing archive driver stub")
+
+proc newFailingArchiveDriver*(): ArchiveDriver =
+  return FailingArchiveDriver()
+
 proc put*(
     driver: ArchiveDriver, pubsubTopic: PubSubTopic, msgList: seq[WakuMessage]
 ): ArchiveDriver =

--- a/tests/waku_archive/test_waku_archive.nim
+++ b/tests/waku_archive/test_waku_archive.nim
@@ -1,6 +1,7 @@
 {.used.}
 
-import results, std/sequtils, testutils/unittests, chronos, libp2p/crypto/crypto
+import
+  results, std/sequtils, testutils/unittests, chronos, metrics, libp2p/crypto/crypto
 
 import
   logos_delivery/waku/[
@@ -9,9 +10,21 @@ import
     waku_core,
     waku_core/message/digest,
     waku_archive,
+    waku_archive/archive_metrics,
   ],
   ../waku_archive/archive_utils,
   ../testlib/wakucore
+
+proc insertCount(source: string): float64 =
+  ## `value(labelValues = ...)` ignores the label selector in metrics 0.2.1 and
+  ## answers with whichever child was created first, so the series has to be
+  ## read by name. Counters are registered with the '_total' suffix.
+  try:
+    return logos_delivery_archive_inserts.valueByName(
+      "logos_delivery_archive_inserts_total", [source]
+    )
+  except ValueError:
+    return 0.0
 
 suite "Waku Archive - message handling":
   test "it should archive a valid and non-ephemeral message":
@@ -539,3 +552,34 @@ procSuite "Waku Archive - find messages":
     let response = res.tryGet()
     check:
       response.messages.len == 0
+
+suite "Waku Archive - insert metrics":
+  ## The collectors are process-global and shared with every other test in this
+  ## binary, hence the baseline taken inside each test.
+  test "the insert counter only moves when the relay ingress wrote":
+    let baseline = insertCount(relayIngress)
+
+    let failing = newWakuArchive(newFailingArchiveDriver())
+    waitFor failing.handleMessage(DefaultPubSubTopic, fakeWakuMessage())
+
+    check insertCount(relayIngress) == baseline
+
+    let stored = newWakuArchive(newSqliteArchiveDriver())
+    waitFor stored.handleMessage(DefaultPubSubTopic, fakeWakuMessage())
+
+    check insertCount(relayIngress) == baseline + 1
+
+  test "the insert counter only moves when the sync ingress wrote":
+    let baseline = insertCount(syncIngress)
+    let message = fakeWakuMessage()
+    let messageHash = computeMessageHash(DefaultPubSubTopic, message)
+
+    let failing = newWakuArchive(newFailingArchiveDriver())
+    check (waitFor failing.syncMessageIngress(messageHash, DefaultPubSubTopic, message)).isErr()
+
+    check insertCount(syncIngress) == baseline
+
+    let stored = newWakuArchive(newSqliteArchiveDriver())
+    check (waitFor stored.syncMessageIngress(messageHash, DefaultPubSubTopic, message)).isOk()
+
+    check insertCount(syncIngress) == baseline + 1


### PR DESCRIPTION
## Description

A store node that writes nothing looks exactly like a healthy one. The per-shard
gauge resets on restart and never sees the store-sync ingress, the stored-message
count is a half-hourly total that retention keeps flat and that goes stale in
silence when its query fails, and a failed insert only produced a `trace` line,
compiled out at the level the fleets run. That is how a drifted database
discarded a testnet's traffic for 75+ hours with every signal green.

## Changes

- `logos_delivery_archive_inserts_total{source="relay"|"sync"}`, incremented on
  every successful write on both ingress paths — the sync one increments nothing
  countable today. Alertable as
  `sum(increase(logos_delivery_archive_inserts_total[1h])) == 0`.
- Both series are published at zero when the archive is built, so the alert needs
  no `absent()` handling on a node that has not written yet.
- Failed inserts are logged at `debug` with the driver's full message — they
  were at `trace`, which is compiled out at the level the fleets run.
- Two regression tests: each writes once through a driver that refuses
  everything and once through a working one, and each goes red when its
  increment is removed.

No dashboard changes: `metrics/*.json` are Grafana exports and there is nothing
to plot until this is deployed and scraped.

## Issue

Part of #4064
