### PR TITLE
chore: pin boringssl v0.0.11

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -72,6 +72,10 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
 requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
+# v0.0.11: pins nim-lsquic's floating "nim-boringssl >= 0.0.4" range. Earlier
+# releases export the bundled BoringSSL symbols from shared libraries, letting
+# a host-process OpenSSL interpose them (issue #4085).
+requires "https://github.com/vacp2p/nim-boringssl#346429e4cda48e775f2d1eb3ccb8757edf4f3648"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -127,15 +127,9 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
       " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       cBindingsFlags & getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
-    # -Bsymbolic binds the library's references to its own symbols at link
-    # time. Without it, a host process that already loads OpenSSL (e.g.
-    # Node.js) interposes our statically linked BoringSSL functions and data
-    # (ASN1_ITEM tables), and QUIC startup crashes in lsquic setupSSLContext
-    # (issue #4085).
-    let elfFlags = when defined(linux): "--passL:-Wl,-Bsymbolic " else: ""
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      elfFlags & cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
+      cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
   buildLibrary libName & ".dll", folderName,
@@ -191,9 +185,8 @@ proc buildMobileAndroid(srcDir = ".", params = "") =
   if not dirExists outDir:
     mkDir outDir
 
-  # -Bsymbolic: see buildLibrary's dynamic branch (issue #4085).
   exec "nim c" & " --out:" & outDir &
-    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-Wl,-Bsymbolic --passL:-L" &
+    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-L" &
     outdir & " --passL:-lrln --passL:-llog --cpu:" & cpu & " --nimMainPrefix:liblogosdelivery --os:android -d:androidNDK " & params &
     getNimParams() & " " & srcDir & "/liblogosdelivery.nim"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -69,6 +69,10 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
 requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
+# v0.0.11: pins nim-lsquic's floating "nim-boringssl >= 0.0.4" range. Earlier
+# releases export the bundled BoringSSL symbols from shared libraries, letting
+# a host-process OpenSSL interpose them (issue #4085).
+requires "https://github.com/vacp2p/nim-boringssl#346429e4cda48e775f2d1eb3ccb8757edf4f3648"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -130,15 +130,9 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
       " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       cBindingsFlags & getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
-    # -Bsymbolic binds the library's references to its own symbols at link
-    # time. Without it, a host process that already loads OpenSSL (e.g.
-    # Node.js) interposes our statically linked BoringSSL functions and data
-    # (ASN1_ITEM tables), and QUIC startup crashes in lsquic setupSSLContext
-    # (issue #4085).
-    let elfFlags = when defined(linux): "--passL:-Wl,-Bsymbolic " else: ""
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      elfFlags & cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
+      cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
   buildLibrary libName & ".dll", folderName,
@@ -194,9 +188,8 @@ proc buildMobileAndroid(srcDir = ".", params = "") =
   if not dirExists outDir:
     mkDir outDir
 
-  # -Bsymbolic: see buildLibrary's dynamic branch (issue #4085).
   exec "nim c" & " --out:" & outDir &
-    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-Wl,-Bsymbolic --passL:-L" &
+    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-L" &
     outdir & " --passL:-lrln --passL:-llog --cpu:" & cpu & " --nimMainPrefix:liblogosdelivery --os:android -d:androidNDK " & params &
     getNimParams() & " " & srcDir & "/liblogosdelivery.nim"
 

--- a/nimble.lock
+++ b/nimble.lock
@@ -659,15 +659,15 @@
       }
     },
     "boringssl": {
-      "version": "0.0.8",
-      "vcsRevision": "e77caabae78fbc9aa5b78a0a521181b077c82571",
+      "version": "0.0.11",
+      "vcsRevision": "346429e4cda48e775f2d1eb3ccb8757edf4f3648",
       "url": "https://github.com/vacp2p/nim-boringssl",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "2f603bb6d70683393bbb091bf6bd325d9c52be9f"
+        "sha1": "49acb43d56a26b30587c9758edb34e3c44b63d8f"
       }
     },
     "protobuf_serialization": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -292,8 +292,8 @@
 
   boringssl = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
-    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
+    rev = "346429e4cda48e775f2d1eb3ccb8757edf4f3648";
+    sha256 = "0x46sdq75zp84qahwh472qr33xw38adrsp41fksh7xwwd6384fl3";
     fetchSubmodules = true;
   };
 

--- a/tests/ffi/test_ffi_persistency_lifecycle.nim
+++ b/tests/ffi/test_ffi_persistency_lifecycle.nim
@@ -42,8 +42,6 @@
 ##     --out:build/liblogosdelivery.dylib --app:lib --noMain --threads:on \
 ##     --mm:refc --opt:speed --passL:librln_v2.0.2.a --passL:-lm \
 ##     -d:chronicles_log_level=INFO library/liblogosdelivery.nim
-## On Linux add `--passL:-Wl,-Bsymbolic` (as the repo's own Linux target
-## does) so the driver's Nim runtime does not interpose the library's.
 ## Override the location with LIBLOGOSDELIVERY=<path>.
 ##
 ## Not registered in an aggregate -- it needs the shared library built


### PR DESCRIPTION
## Description

Revert `nim-boringssl` hack and bump `nim-boringssl` dep to v0.0.11.

## Changes

* revert #4086
* pin nim-boringssl v0.0.11, which includes:
    *  https://github.com/vacp2p/nim-boringssl/pull/14

## Issue

Maintenance Y2026H2 #4043