### PR TITLE
fix(e2e): stop the API/e2e suite segfaulting at process exit

### DIFF
--- a/tests-e2e/tests/conftest.py
+++ b/tests-e2e/tests/conftest.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import inspect
 import glob
+import logging
+import sys
 from src.libs.custom_logger import get_custom_logger
 import os
 import pytest
@@ -13,6 +15,26 @@ from src.data_storage import DS
 from src.postgres_setup import start_postgres, stop_postgres
 
 logger = get_custom_logger(__name__)
+
+
+_session_exit_status = None
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    global _session_exit_status
+    _session_exit_status = int(exitstatus)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config):
+    # liblogosdelivery threads outlive destroy; finalizing the interpreter under them segfaults.
+    if _session_exit_status is None:
+        return
+    sys.stdout.flush()
+    sys.stderr.flush()
+    logging.shutdown()
+    os._exit(_session_exit_status)
 
 
 # See https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures


### PR DESCRIPTION
# Description

1. Exit the `tests-e2e` pytest process with `os._exit` once the session has finished, so the interpreter is never finalized while liblogosdelivery's threads are still running.

`logosdelivery_destroy` recycles the FFI context instead of tearing it down: `ffi_context_pool.nim` returns the slot to the pool "WITHOUT stopping its threads, so a later createFFIContext reuses them". The worker and event threads are created with the first node and stay alive for the whole process — measured, the thread count goes 1 → 3 on the first `create_and_start` and stays at 3 across every `stop_and_destroy`. Interpreter shutdown then finalizes the DSO underneath those threads and the process dies with SIGSEGV after the last test has already passed.

This is 20% of `send-api-e2e-tests / api-e2e` runs (33/162 since 2026-07-27); 34 of the 38 api-e2e failures in that window end in exit 139.

<details>
<summary>AI-made decisions</summary>

- Hooked `pytest_unconfigure` rather than `pytest_sessionfinish` so allure results, the log file and the terminal summary are all written before the process is replaced.
- Gated on a `pytest_sessionfinish` having run, so a crash *during* the tests still surfaces as a failure — the same suite had a mid-run segfault variant until 2026-08-06 and this must not start hiding it.
- Not fixed library-side: nim-ffi exports no process-level shutdown, so there is nothing for the binding to call at exit. The real fix is a `stopAndJoinThreads` over the pool in nim-ffi; this only stops CI flaking.
- Left the pinned nim-ffi alone. #4111 and #4135 (both 2026-08-19) already carry every destroy/recycle fix through nim-ffi #151, and the exit-time crash still reproduced on 08-21 and 08-23 on top of them.
</details>
