### PR TITLE
feat(net): dial through a NetBackend

### DIFF
--- a/logos_delivery/waku/factory/builder.nim
+++ b/logos_delivery/waku/factory/builder.nim
@@ -33,6 +33,7 @@ type
     peerStorageCapacity: Opt[int]
 
     # Peer manager config
+    netBackend: NetBackend
     maxRelayPeers: int
     maxServicePeers: int
     colocationLimit: int
@@ -104,6 +105,9 @@ proc withNetworkConfigurationDetails*(
   ok()
 
 ## Peer storage and peer manager
+
+proc withNetBackend*(builder: var WakuNodeBuilder, netBackend: NetBackend) =
+  builder.netBackend = netBackend
 
 proc withPeerStorage*(
     builder: var WakuNodeBuilder, peerStorage: PeerStorage, capacity = Opt.none(int)
@@ -208,6 +212,7 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
 
   let peerManager = PeerManager.new(
     switch = switch,
+    netBackend = builder.netBackend,
     storage = builder.peerStorage.get(nil),
     maxRelayPeers = Opt.some(builder.maxRelayPeers),
     maxServicePeers = Opt.some(builder.maxServicePeers),

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -1,0 +1,50 @@
+## The peer manager dial path: its own switch, or a libp2p node another process owns.
+
+{.push raises: [].}
+
+import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
+
+logScope:
+  topics = "waku net backend"
+
+type
+  NetBackend* = ref object of RootObj
+
+  SwitchNetBackend* = ref object of NetBackend
+    switch: Switch
+
+method dial*(
+    backend: NetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.base, async: (raises: []).} =
+  raiseAssert "[NetBackend.dial] abstract method not implemented"
+
+func new*(T: type SwitchNetBackend, switch: Switch): T =
+  SwitchNetBackend(switch: switch)
+
+method dial*(
+    backend: SwitchNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  let dialFut = backend.switch.dial(peerId, addrs, proto)
+
+  let res = catch:
+    if await dialFut.withTimeout(timeout):
+      return Opt.some(dialFut.read())
+
+  if not dialFut.finished():
+    await noCancel cancelAndWait(dialFut)
+
+  let reasonFailed = if res.isOk(): "timed out" else: res.error.msg
+
+  trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
+
+  return Opt.none(Connection)
+
+{.pop.}

--- a/logos_delivery/waku/node/peer_manager/peer_manager.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_manager.nim
@@ -25,11 +25,12 @@ import
     common/utils/parse_size_units,
     node/health_monitor/online_monitor,
     node/waku_switch,
+    net/net_backend,
   ],
   ./peer_store/peer_storage,
   ./waku_peer_store
 
-export waku_peer_store, peer_storage, peers
+export waku_peer_store, peer_storage, peers, net_backend
 
 declareCounter logos_delivery_peers_dials, "Number of peer dials", ["outcome"]
 # TODO: Populate from PeerStore.Source when ready
@@ -92,6 +93,7 @@ type ConnectionChangeHandler* = proc(
 type PeerManager* = ref object of RootObj
   brokerCtx: BrokerContext
   switch*: Switch
+  netBackend*: NetBackend
   wakuMetadata*: WakuMetadata
   initialBackoffInSec*: int
   backoffFactor*: int
@@ -450,20 +452,7 @@ proc dialPeer(
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
-  # Dial Peer
-  let dialFut = pm.switch.dial(peerId, addrs, proto)
-
-  let res = catch:
-    if await dialFut.withTimeout(dialTimeout):
-      return Opt.some(dialFut.read())
-    else:
-      await cancelAndWait(dialFut)
-
-  let reasonFailed = if res.isOk: "timed out" else: res.error.msg
-
-  trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
-
-  return Opt.none(Connection)
+  return await pm.netBackend.dial(peerId, addrs, proto, dialTimeout)
 
 proc dialPeer*(
     pm: PeerManager,
@@ -1180,6 +1169,7 @@ proc new*(
     colocationLimit = DefaultColocationLimit,
     shardedPeerManagement = false,
     maxConnections: int = MaxConnections,
+    netBackend: NetBackend = nil,
 ): PeerManager {.gcsafe.} =
   let capacity = switch.peerStore.capacity
   if maxConnections > capacity:
@@ -1220,6 +1210,11 @@ proc new*(
 
   let pm = PeerManager(
     switch: switch,
+    netBackend:
+      if netBackend.isNil():
+        SwitchNetBackend.new(switch)
+      else:
+        netBackend,
     brokerCtx: brokerCtx,
     wakuMetadata: wakuMetadata,
     storage: storage,

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -41,6 +41,9 @@ import
   ./waku_store/test_waku_store,
   ./waku_store/test_wakunode_store
 
+# Net backend test suite
+import ./waku_net/test_net_backend
+
 # Waku store sync suite
 import ./waku_store_sync/test_all
 

--- a/tests/waku_net/test_net_backend.nim
+++ b/tests/waku_net/test_net_backend.nim
@@ -1,0 +1,76 @@
+{.used.}
+
+import results, testutils/unittests, chronos, chronicles
+import libp2p/[multiaddress, peerid]
+import libp2p/protocols/protocol
+
+import
+  logos_delivery/waku/[net/net_backend, node/peer_manager, waku_core],
+  ../testlib/[wakucore, testasync]
+
+const TestCodec = "/waku/test/1.0.0"
+
+type StubNetBackend = ref object of NetBackend
+  dials: int
+  lastPeerId: PeerId
+  lastAddrs: seq[MultiAddress]
+  lastProto: string
+
+method dial(
+    backend: StubNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  backend.dials.inc()
+  backend.lastPeerId = peerId
+  backend.lastAddrs = addrs
+  backend.lastProto = proto
+
+  return Opt.none(Connection)
+
+suite "Net backend":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var serverPeerInfo {.threadvar.}: RemotePeerInfo
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+      await conn.close()
+
+    serverSwitch.mount(LPProtocol.new(@[TestCodec], handle))
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis) # the listener is not ready on macos CI without it
+
+    serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "the default backend dials over the switch":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    check peerManager.netBackend of SwitchNetBackend
+
+    let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
+
+    check conn.isSome()
+    await conn.get().close()
+
+  asyncTest "a backend of its own takes every dial":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
+
+    check:
+      conn.isNone()
+      backend.dials == 1
+      backend.lastPeerId == serverPeerInfo.peerId
+      backend.lastAddrs == serverPeerInfo.addrs
+      backend.lastProto == TestCodec


### PR DESCRIPTION
## Description

`PeerManager.dialPeer` is the funnel every Edge protocol client reaches: store, lightpush, filter and peer exchange all call it, and it ends in `pm.switch.dial(peerId, addrs, proto)`. That line hard-wires the node to the libp2p stack it builds itself.

This lifts that line behind a `NetBackend`, so a later change can dial over a libp2p node another module in the same process already owns, without touching a single protocol client. It is the first slice of the plan for that feature; the bridge itself, the C ABI and the config key follow in their own PRs.

Nothing changes for a node today. `PeerManager` installs the switch-backed default unless a caller passes another backend, and the moved code keeps the timeout and the trace that `dialPeer` had.

## Changes

`logos_delivery/waku/net/net_backend.nim` declares `NetBackend` with one method, `dial(peerId, addrs, proto, timeout)`, and `SwitchNetBackend` holding the `Switch`.

`PeerManager` gains a `netBackend` field and a `netBackend` parameter on `new`, which defaults to `SwitchNetBackend.new(switch)`. `dialPeer` now calls `pm.netBackend.dial(...)`. The self-dial and relay-codec guards stay where they are, because they are peer-manager policy and not transport.

`WakuNodeBuilder` gains `withNetBackend`, and passes whatever it holds to `PeerManager.new`. No caller sets it yet.

`SwitchNetBackend.dial` cancels the dial future on every path that does not return it. The body that moved out of `dialPeer` cancelled it only on the timeout path, so a cancelled dial left the future running and its connection unowned.

## Not covered

Two dial sites still reach the switch directly, so a registered backend does not see them: `refreshPeerMetadata` in `peer_manager.nim` and `pingPeer` in `waku/api/ping.nim`. The metadata one needs an addr-less `dial(peerId, proto)` on the backend, because the peer store holds no addrs for an inbound peer. Both come in a follow-up.

## Checks

`tests/waku_net/test_net_backend.nim` covers both directions: the default backend is a `SwitchNetBackend` and dials a mounted protocol over a real switch, and a backend installed by the caller takes the dial instead and sees the peer id, the addrs and the codec it was asked for.

The suites that exercise `dialPeer` are the new one plus `waku_store`, `waku_filter_v2`, `waku_lightpush`, `waku_peer_exchange` and `test_peer_manager`.
