### PR TITLE
feat(net): send Edge requests through the net backend

### DIFF
--- a/logos_delivery/waku/factory/builder.nim
+++ b/logos_delivery/waku/factory/builder.nim
@@ -33,6 +33,7 @@ type
     peerStorageCapacity: Opt[int]
 
     # Peer manager config
+    netBackend: NetBackend
     maxRelayPeers: int
     maxServicePeers: int
     colocationLimit: int
@@ -56,6 +57,9 @@ type
 
 proc init*(T: type WakuNodeBuilder): WakuNodeBuilder =
   WakuNodeBuilder()
+
+proc withNetBackend*(builder: var WakuNodeBuilder, netBackend: NetBackend) =
+  builder.netBackend = netBackend
 
 ## General
 
@@ -208,6 +212,7 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
 
   let peerManager = PeerManager.new(
     switch = switch,
+    netBackend = builder.netBackend,
     storage = builder.peerStorage.get(nil),
     maxRelayPeers = Opt.some(builder.maxRelayPeers),
     maxServicePeers = Opt.some(builder.maxServicePeers),

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -1,0 +1,50 @@
+## The one funnel every outbound protocol stream goes through, so a node can
+## dial over its own switch or over a libp2p node another process owns.
+
+{.push raises: [].}
+
+import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
+
+logScope:
+  topics = "waku net backend"
+
+type
+  NetBackend* = ref object of RootObj
+
+  SwitchNetBackend* = ref object of NetBackend
+    switch: Switch
+
+method dial*(
+    backend: NetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.base, async: (raises: []).} =
+  raiseAssert "[NetBackend.dial] abstract method not implemented"
+
+func new*(T: type SwitchNetBackend, switch: Switch): T =
+  SwitchNetBackend(switch: switch)
+
+method dial*(
+    backend: SwitchNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  let dialFut = backend.switch.dial(peerId, addrs, proto)
+
+  let res = catch:
+    if await dialFut.withTimeout(timeout):
+      return Opt.some(dialFut.read())
+    else:
+      await cancelAndWait(dialFut)
+
+  let reasonFailed = if res.isOk(): "timed out" else: res.error.msg
+
+  trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
+
+  return Opt.none(Connection)
+
+{.pop.}

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -1,5 +1,5 @@
-## The one funnel every outbound protocol stream goes through, so a node can
-## dial over its own switch or over a libp2p node another process owns.
+## Abstracts the libp2p operations the Edge protocol clients need, so a node can
+## run them over its own switch or over a libp2p node another process owns.
 
 {.push raises: [].}
 
@@ -8,11 +8,56 @@ import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
 logScope:
   topics = "waku net backend"
 
+const
+  DefaultNetDialTimeout* = chronos.seconds(10)
+  DefaultNetMaxResponseSize* = 1024 * 1024
+
 type
+  NetErrorKind* {.pure.} = enum
+    Dial
+    Write
+    Read
+
+  NetError* = object
+    kind*: NetErrorKind
+    cause*: string
+
+  NetRequest* = object
+    peerId*: PeerId
+    addrs*: seq[MultiAddress]
+    proto*: string
+    payload*: seq[byte]
+    maxSize*: int
+    timeout*: Duration
+
   NetBackend* = ref object of RootObj
 
   SwitchNetBackend* = ref object of NetBackend
     switch: Switch
+
+func init*(
+    T: type NetRequest,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultNetDialTimeout,
+): NetRequest =
+  NetRequest(
+    peerId: peerId,
+    addrs: addrs,
+    proto: proto,
+    payload: payload,
+    maxSize: maxSize,
+    timeout: timeout,
+  )
+
+func dialError*(cause: string): NetError =
+  NetError(kind: NetErrorKind.Dial, cause: cause)
+
+func `$`*(err: NetError): string =
+  $err.kind & " failed: " & err.cause
 
 method dial*(
     backend: NetBackend,
@@ -21,10 +66,60 @@ method dial*(
     proto: string,
     timeout: Duration,
 ): Future[Opt[Connection]] {.base, async: (raises: []).} =
-  raiseAssert "[NetBackend.dial] abstract method not implemented"
+  error "backend serves no streams", proto = proto
+  return Opt.none(Connection)
+
+method connect*(
+    backend: NetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
+): Future[Result[void, string]] {.base, async: (raises: []).} =
+  return err("backend opens no connections")
+
+method request*(
+    backend: NetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.base, async: (raises: []).} =
+  ## One length-prefixed frame out, one back, over a stream of its own.
+  let connection = (await backend.dial(req.peerId, req.addrs, req.proto, req.timeout)).valueOr:
+    return err(dialError($req.peerId & " on " & req.proto))
+
+  defer:
+    await connection.closeWithEof()
+
+  let writeRes = catch:
+    await connection.writeLP(req.payload)
+  if writeRes.isErr():
+    return err(NetError(kind: NetErrorKind.Write, cause: writeRes.error.msg))
+
+  let readRes = catch:
+    await connection.readLp(req.maxSize)
+
+  let buffer = readRes.valueOr:
+    return err(NetError(kind: NetErrorKind.Read, cause: error.msg))
+
+  return ok(buffer)
 
 func new*(T: type SwitchNetBackend, switch: Switch): T =
   SwitchNetBackend(switch: switch)
+
+method connect*(
+    backend: SwitchNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    timeout: Duration,
+): Future[Result[void, string]] {.async: (raises: []).} =
+  let connectFut = backend.switch.connect(peerId, addrs)
+
+  let res = catch:
+    if await connectFut.withTimeout(timeout):
+      connectFut.read()
+      return ok()
+
+  if not connectFut.finished():
+    await noCancel cancelAndWait(connectFut)
+
+  if res.isErr():
+    return err(res.error.msg)
+
+  return err("timed out")
 
 method dial*(
     backend: SwitchNetBackend,
@@ -38,8 +133,9 @@ method dial*(
   let res = catch:
     if await dialFut.withTimeout(timeout):
       return Opt.some(dialFut.read())
-    else:
-      await cancelAndWait(dialFut)
+
+  if not dialFut.finished():
+    await noCancel cancelAndWait(dialFut)
 
   let reasonFailed = if res.isOk(): "timed out" else: res.error.msg
 

--- a/logos_delivery/waku/node/peer_manager/peer_manager.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_manager.nim
@@ -25,11 +25,12 @@ import
     common/utils/parse_size_units,
     node/health_monitor/online_monitor,
     node/waku_switch,
+    net/net_backend,
   ],
   ./peer_store/peer_storage,
   ./waku_peer_store
 
-export waku_peer_store, peer_storage, peers
+export waku_peer_store, peer_storage, peers, net_backend
 
 declareCounter logos_delivery_peers_dials, "Number of peer dials", ["outcome"]
 # TODO: Populate from PeerStore.Source when ready
@@ -92,6 +93,7 @@ type ConnectionChangeHandler* = proc(
 type PeerManager* = ref object of RootObj
   brokerCtx: BrokerContext
   switch*: Switch
+  netBackend*: NetBackend
   wakuMetadata*: WakuMetadata
   initialBackoffInSec*: int
   backoffFactor*: int
@@ -450,20 +452,7 @@ proc dialPeer(
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
-  # Dial Peer
-  let dialFut = pm.switch.dial(peerId, addrs, proto)
-
-  let res = catch:
-    if await dialFut.withTimeout(dialTimeout):
-      return Opt.some(dialFut.read())
-    else:
-      await cancelAndWait(dialFut)
-
-  let reasonFailed = if res.isOk: "timed out" else: res.error.msg
-
-  trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
-
-  return Opt.none(Connection)
+  return await pm.netBackend.dial(peerId, addrs, proto, dialTimeout)
 
 proc dialPeer*(
     pm: PeerManager,
@@ -1180,6 +1169,7 @@ proc new*(
     colocationLimit = DefaultColocationLimit,
     shardedPeerManagement = false,
     maxConnections: int = MaxConnections,
+    netBackend: NetBackend = nil,
 ): PeerManager {.gcsafe.} =
   let capacity = switch.peerStore.capacity
   if maxConnections > capacity:
@@ -1220,6 +1210,11 @@ proc new*(
 
   let pm = PeerManager(
     switch: switch,
+    netBackend:
+      if netBackend.isNil():
+        SwitchNetBackend.new(switch)
+      else:
+        netBackend,
     brokerCtx: brokerCtx,
     wakuMetadata: wakuMetadata,
     storage: storage,

--- a/logos_delivery/waku/node/peer_manager/peer_manager.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_manager.nim
@@ -60,7 +60,7 @@ randomize()
 
 const
   # TODO: Make configurable
-  DefaultDialTimeout* = chronos.seconds(10)
+  DefaultDialTimeout* = DefaultNetDialTimeout
 
   # Max attempts before removing the peer
   MaxFailedAttempts = 5
@@ -348,29 +348,17 @@ proc connectPeer*(
   trace "Connecting to peer",
     wireAddr = peer.addrs, peerId = peerId, failedAttempts = failedAttempts
 
-  var deadline = sleepAsync(dialTimeout)
-  let workfut = pm.switch.connect(peerId, peer.addrs)
+  let connected = await pm.netBackend.connect(peerId, peer.addrs, dialTimeout)
 
-  # Can't use catch: with .withTimeout() in this case
-  let res = catch:
-    await workfut or deadline
+  if connected.isOk():
+    logos_delivery_peers_dials.inc(labelValues = ["successful"])
+    logos_delivery_node_conns_initiated.inc(labelValues = [source])
 
-  let reasonFailed =
-    if not workfut.finished():
-      await workfut.cancelAndWait()
-      "timed out"
-    elif res.isErr():
-      res.error.msg
-    else:
-      if not deadline.finished():
-        await deadline.cancelAndWait()
+    peerStore[NumberFailedConnBook][peerId] = 0
 
-      logos_delivery_peers_dials.inc(labelValues = ["successful"])
-      logos_delivery_node_conns_initiated.inc(labelValues = [source])
+    return true
 
-      peerStore[NumberFailedConnBook][peerId] = 0
-
-      return true
+  let reasonFailed = connected.error
 
   # Dial failed
   peerStore[NumberFailedConnBook][peerId] = peerStore[NumberFailedConnBook][peerId] + 1
@@ -381,7 +369,7 @@ proc connectPeer*(
     peerId = peerId,
     reason = reasonFailed,
     failedAttempts = peerStore[NumberFailedConnBook][peerId]
-  logos_delivery_peers_dials.inc(labelValues = [reasonFailed])
+  logos_delivery_peers_dials.inc(labelValues = ["failed"])
 
   return false
 
@@ -431,9 +419,26 @@ proc disconnectNode*(pm: PeerManager, peer: RemotePeerInfo) {.async.} =
   let peerId = peer.peerId
   await pm.disconnectNode(peerId)
 
-# Dialing should be used for just protocols that require a stream to write and read
-# This shall not be used to dial Relay protocols, since that would create
-# unneccesary unused streams.
+func checkStreamTarget(
+    pm: PeerManager, peerId: PeerId, proto: string
+): Result[void, string] =
+  if peerId == pm.switch.peerInfo.peerId:
+    return err("could not open a stream to self")
+
+  # A relay stream would sit there unused, so relay codecs never get one.
+  if proto == WakuRelayCodec:
+    return err("streams shall not be used to connect to relays")
+
+  ok()
+
+proc rememberPeer(pm: PeerManager, remotePeerInfo: RemotePeerInfo, proto: string) =
+  if pm.switch.peerStore.hasPeer(remotePeerInfo.peerId, proto):
+    return
+
+  trace "Adding newly dialed peer to manager",
+    peerId = $remotePeerInfo.peerId, addrs = remotePeerInfo.addrs, proto = proto
+  pm.addPeer(remotePeerInfo)
+
 proc dialPeer(
     pm: PeerManager,
     peerId: PeerID,
@@ -442,12 +447,8 @@ proc dialPeer(
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Opt[Connection]] {.async.} =
-  if peerId == pm.switch.peerInfo.peerId:
-    error "could not dial self"
-    return Opt.none(Connection)
-
-  if proto == WakuRelayCodec:
-    error "dial shall not be used to connect to relays"
+  pm.checkStreamTarget(peerId, proto).isOkOr:
+    error "dial refused", peerId = peerId, proto = proto, reason = error
     return Opt.none(Connection)
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
@@ -464,12 +465,7 @@ proc dialPeer*(
   # Dial a given peer and add it to the list of known peers
   # TODO: check peer validity and score before continuing. Limit number of peers to be managed.
 
-  # First add dialed peer info to peer store, if it does not exist yet..
-  # TODO: nim libp2p peerstore already adds them
-  if not pm.switch.peerStore.hasPeer(remotePeerInfo.peerId, proto):
-    trace "Adding newly dialed peer to manager",
-      peerId = $remotePeerInfo.peerId, address = $remotePeerInfo.addrs[0], proto = proto
-    pm.addPeer(remotePeerInfo)
+  pm.rememberPeer(remotePeerInfo, proto)
 
   return await pm.dialPeer(
     remotePeerInfo.peerId, remotePeerInfo.addrs, proto, dialTimeout, source
@@ -487,6 +483,43 @@ proc dialPeer*(
 
   let addrs = pm.switch.peerStore[AddressBook][peerId]
   return await pm.dialPeer(peerId, addrs, proto, dialTimeout, source)
+
+proc request*(
+    pm: PeerManager,
+    remotePeerInfo: RemotePeerInfo,
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultDialTimeout,
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  ## Sends one length-prefixed frame to `proto` on `peer` and reads the answer.
+  pm.checkStreamTarget(remotePeerInfo.peerId, proto).isOkOr:
+    return err(dialError(error))
+
+  pm.rememberPeer(remotePeerInfo, proto)
+
+  return await pm.netBackend.request(
+    NetRequest.init(
+      peerId = remotePeerInfo.peerId,
+      addrs = remotePeerInfo.addrs,
+      proto = proto,
+      payload = payload,
+      maxSize = maxSize,
+      timeout = timeout,
+    )
+  )
+
+proc request*(
+    pm: PeerManager,
+    peerId: PeerId,
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultDialTimeout,
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  let peer = RemotePeerInfo.init(peerId, pm.switch.peerStore[AddressBook][peerId])
+
+  return await pm.request(peer, proto, payload, maxSize, timeout)
 
 proc canBeConnected*(pm: PeerManager, peerId: PeerId): bool =
   # Returns if we can try to connect to this peer, based on past failed attempts

--- a/logos_delivery/waku/waku_filter_v2/client.nim
+++ b/logos_delivery/waku/waku_filter_v2/client.nim
@@ -40,42 +40,22 @@ proc sendSubscribeRequest(
   trace "Sending filter subscribe request",
     peerId = servicePeer.peerId, filterSubscribeRequest
 
-  var connOpt: Opt[Connection]
-  try:
-    connOpt = await wfc.peerManager.dialPeer(servicePeer, WakuFilterSubscribeCodec)
-    if connOpt.isNone():
+  let respBuf = (
+    await wfc.peerManager.request(
+      servicePeer,
+      WakuFilterSubscribeCodec,
+      filterSubscribeRequest.encode().buffer,
+      DefaultMaxSubscribeResponseSize,
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
       trace "Failed to dial filter service peer", servicePeer
       logos_delivery_filter_errors.inc(labelValues = [dialFailure])
       return err(FilterSubscribeError.peerDialFailure($servicePeer))
-  except CatchableError:
-    let errMsg = "failed to dialPeer: " & getCurrentExceptionMsg()
-    trace "failed to dialPeer", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
 
-  let connection = connOpt.get()
-
-  defer:
-    await connection.closeWithEOF()
-
-  try:
-    await connection.writeLP(filterSubscribeRequest.encode().buffer)
-  except CatchableError:
-    let errMsg =
-      "exception in waku_filter_v2 client writeLP: " & getCurrentExceptionMsg()
-    trace "exception in waku_filter_v2 client writeLP", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
-
-  var respBuf: seq[byte]
-  try:
-    respBuf = await connection.readLp(DefaultMaxSubscribeResponseSize)
-  except CatchableError:
-    let errMsg =
-      "exception in waku_filter_v2 client readLp: " & getCurrentExceptionMsg()
-    trace "exception in waku_filter_v2 client readLp", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
+    trace "filter subscribe request failed", error = $error
+    logos_delivery_filter_errors.inc(labelValues = [requestFailure])
+    return err(FilterSubscribeError.badResponse(error.cause))
 
   let response = FilterSubscribeResponse.decode(respBuf).valueOr:
     trace "Failed to decode filter subscribe response", servicePeer

--- a/logos_delivery/waku/waku_filter_v2/protocol_metrics.nim
+++ b/logos_delivery/waku/waku_filter_v2/protocol_metrics.nim
@@ -26,3 +26,4 @@ const
   requestIdMismatch* = "request_id_mismatch"
   errorResponse* = "error_response"
   pushTimeoutFailure* = "push_timeout_failure"
+  requestFailure* = "request_failure"

--- a/logos_delivery/waku/waku_lightpush/client.nim
+++ b/logos_delivery/waku/waku_lightpush/client.nim
@@ -30,34 +30,7 @@ func shortPeerId(peer: PeerId): string =
 func shortPeerId(peer: RemotePeerInfo): string =
   shortLog(peer.peerId)
 
-proc sendPushRequest(
-    wl: WakuLightPushClient,
-    req: LightPushRequest,
-    peer: PeerId | RemotePeerInfo,
-    conn: Opt[Connection] = Opt.none(Connection),
-): Future[WakuLightPushResult] {.async.} =
-  let connection = conn.valueOr:
-    (await wl.peerManager.dialPeer(peer, WakuLightPushCodec)).valueOr:
-      logos_delivery_lightpush_v3_errors.inc(labelValues = [dialFailure])
-      return lighpushErrorResult(
-        LightPushErrorCode.NO_PEERS_TO_RELAY,
-        dialFailure & ": " & $peer & " is not accessible",
-      )
-
-  defer:
-    await connection.closeWithEOF()
-
-  await connection.writeLP(req.encode().buffer)
-
-  var buffer: seq[byte]
-  try:
-    buffer = await connection.readLp(DefaultMaxRpcSize.int)
-  except LPStreamRemoteClosedError:
-    debug "Failed to read response from peer", error = getCurrentExceptionMsg()
-    return lightpushResultInternalError(
-      "Failed to read response from peer: " & getCurrentExceptionMsg()
-    )
-
+proc parsePushResponse(req: LightPushRequest, buffer: seq[byte]): WakuLightPushResult =
   let response = LightpushResponse.decode(buffer).valueOr:
     debug "Failed to decode response"
     logos_delivery_lightpush_v3_errors.inc(labelValues = [decodeRpcFailure])
@@ -70,6 +43,44 @@ proc sendPushRequest(
     return lightpushResultInternalError("response failure, requestId mismatch")
 
   return toPushResult(response)
+
+proc sendPushRequestOverConn(
+    wl: WakuLightPushClient, req: LightPushRequest, connection: Connection
+): Future[WakuLightPushResult] {.async.} =
+  defer:
+    await connection.closeWithEOF()
+
+  await connection.writeLP(req.encode().buffer)
+
+  var buffer: seq[byte]
+  try:
+    buffer = await connection.readLp(MaxLightpushResponseSize)
+  except LPStreamRemoteClosedError:
+    debug "Failed to read response from peer", error = getCurrentExceptionMsg()
+    return lightpushResultInternalError(
+      "Failed to read response from peer: " & getCurrentExceptionMsg()
+    )
+
+  return parsePushResponse(req, buffer)
+
+proc sendPushRequest(
+    wl: WakuLightPushClient, req: LightPushRequest, peer: PeerId | RemotePeerInfo
+): Future[WakuLightPushResult] {.async.} =
+  let buffer = (
+    await wl.peerManager.request(
+      peer, WakuLightPushCodec, req.encode().buffer, MaxLightpushResponseSize
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
+      logos_delivery_lightpush_v3_errors.inc(labelValues = [dialFailure])
+      return lighpushErrorResult(
+        LightPushErrorCode.NO_PEERS_TO_RELAY,
+        dialFailure & ": " & $peer & " is not accessible",
+      )
+    debug "Lightpush request failed", error = $error
+    return lightpushResultInternalError($error)
+
+  return parsePushResponse(req, buffer)
 
 proc publish*(
     wl: WakuLightPushClient,
@@ -99,7 +110,7 @@ proc publish*(
 
   let relayPeerCount =
     when dest is Connection:
-      ?await wl.sendPushRequest(request, dest.peerId, Opt.some(dest))
+      ?await wl.sendPushRequestOverConn(request, dest)
     else:
       ?await wl.sendPushRequest(request, dest)
 

--- a/logos_delivery/waku/waku_lightpush/common.nim
+++ b/logos_delivery/waku/waku_lightpush/common.nim
@@ -7,6 +7,8 @@ from ../waku_core/codecs import WakuLightPushCodec
 export WakuLightPushCodec
 export LightPushStatusCode
 
+const MaxLightpushResponseSize* = 64 * 1024
+
 const LightPushSuccessCode* = (SUCCESS: LightPushStatusCode(200))
 
 const LightPushErrorCode* = (

--- a/logos_delivery/waku/waku_peer_exchange/client.nim
+++ b/logos_delivery/waku/waku_peer_exchange/client.nim
@@ -25,34 +25,7 @@ type WakuPeerExchangeClient* = ref object
 proc new*(T: type WakuPeerExchangeClient, peerManager: PeerManager): T =
   WakuPeerExchangeClient(peerManager: peerManager)
 
-proc request*(
-    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, conn: Connection
-): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
-  let rpc = PeerExchangeRpc.makeRequest(numPeers)
-
-  var buffer: seq[byte]
-  var callResult =
-    (status_code: PeerExchangeResponseStatusCode.SUCCESS, status_desc: Opt.none(string))
-  try:
-    await conn.writeLP(rpc.encode().buffer)
-    buffer = await conn.readLp(DefaultMaxRpcSize.int)
-  except CatchableError as exc:
-    debug "Exception when handling peer exchange request", error = exc.msg
-    logos_delivery_px_client_errors.inc(
-      labelValues = ["error_sending_or_receiving_px_req"]
-    )
-    callResult = (
-      status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
-      status_desc: Opt.some($exc.msg),
-    )
-  finally:
-    # close, no more data is expected
-    await conn.closeWithEof()
-
-  if callResult.status_code != PeerExchangeResponseStatusCode.SUCCESS:
-    debug "Peer exchange request failed", status_code = callResult.status_code
-    return err(callResult)
-
+proc decodeResponse(buffer: seq[byte]): WakuPeerExchangeResult[PeerExchangeResponse] =
   let decoded = PeerExchangeRpc.decode(buffer).valueOr:
     debug "Peer exchange request error decoding buffer", error = $error
     return err(
@@ -73,11 +46,44 @@ proc request*(
   return ok(decoded.response)
 
 proc request*(
+    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, conn: Connection
+): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
+  let rpc = PeerExchangeRpc.makeRequest(numPeers)
+
+  var buffer: seq[byte]
+  var callResult =
+    (status_code: PeerExchangeResponseStatusCode.SUCCESS, status_desc: Opt.none(string))
+  try:
+    await conn.writeLP(rpc.encode().buffer)
+    buffer = await conn.readLp(DefaultMaxRpcSize.int)
+  except CatchableError as exc:
+    debug "Exception when handling peer exchange request", error = exc.msg
+    logos_delivery_px_client_errors.inc(labelValues = [sendOrReceiveFailure])
+    callResult = (
+      status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+      status_desc: Opt.some($exc.msg),
+    )
+  finally:
+    # close, no more data is expected
+    await conn.closeWithEof()
+
+  if callResult.status_code != PeerExchangeResponseStatusCode.SUCCESS:
+    debug "Peer exchange request failed", status_code = callResult.status_code
+    return err(callResult)
+
+  return decodeResponse(buffer)
+
+proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, peer: RemotePeerInfo
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
-  try:
-    let connOpt = await wpx.peerManager.dialPeer(peer, WakuPeerExchangeCodec)
-    if connOpt.isNone():
+  let rpc = PeerExchangeRpc.makeRequest(numPeers)
+
+  let buffer = (
+    await wpx.peerManager.request(
+      peer, WakuPeerExchangeCodec, rpc.encode().buffer, DefaultMaxRpcSize.int
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
       debug "Peer exchange request dial failed, no connection"
       return err(
         (
@@ -85,15 +91,17 @@ proc request*(
           status_desc: Opt.some(dialFailure),
         )
       )
-    return await wpx.request(numPeers, connOpt.get())
-  except CatchableError:
-    debug "Peer exchange request exception", error = getCurrentExceptionMsg()
+
+    debug "Peer exchange request failed", error = $error
+    logos_delivery_px_client_errors.inc(labelValues = [sendOrReceiveFailure])
     return err(
       (
-        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
-        status_desc: Opt.some("exception dialing peer: " & getCurrentExceptionMsg()),
+        status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+        status_desc: Opt.some(error.cause),
       )
     )
+
+  return decodeResponse(buffer)
 
 proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq

--- a/logos_delivery/waku/waku_peer_exchange/common.nim
+++ b/logos_delivery/waku/waku_peer_exchange/common.nim
@@ -18,5 +18,6 @@ const
   retrievePeersDiscv5Error* = "retrieve_peers_discv5_failure"
   pxFailure* = "px_failure"
   streamClosedFailure* = "stream_closed_failure"
+  sendOrReceiveFailure* = "error_sending_or_receiving_px_req"
 
 type WakuPeerExchangeResult*[T] = Result[T, PeerExchangeResponseStatus]

--- a/logos_delivery/waku/waku_store/client.nim
+++ b/logos_delivery/waku/waku_store/client.nim
@@ -30,28 +30,32 @@ proc new*(
   WakuStoreClient(peerManager: peerManager, rng: rng)
 
 proc sendStoreRequest(
-    self: WakuStoreClient, request: StoreQueryRequest, connection: Connection
+    self: WakuStoreClient, request: StoreQueryRequest, peer: RemotePeerInfo | PeerId
 ): Future[StoreQueryResult] {.async, gcsafe.} =
   var req = request
 
-  self.peerManager.addActiveStoreRequest(connection.peerId)
+  let peerId = when peer is PeerId: peer else: peer.peerId
+
+  self.peerManager.addActiveStoreRequest(peerId)
   defer:
-    self.peerManager.removeActiveStoreRequest(connection.peerId)
-    await connection.closeWithEof()
+    self.peerManager.removeActiveStoreRequest(peerId)
 
   if req.requestId == "":
     req.requestId = generateRequestId(self.rng)
 
-  let writeRes = catch:
-    await connection.writeLP(req.encode().buffer)
-  if writeRes.isErr():
-    return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: writeRes.error.msg))
-
-  let readRes = catch:
-    await connection.readLp(DefaultMaxRpcSize.int)
-
-  let buf = readRes.valueOr:
-    return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.msg))
+  let buf = (
+    await self.peerManager.request(
+      peer, WakuStoreCodec, req.encode().buffer, MaxStoreResponseSize.int
+    )
+  ).valueOr:
+    case error.kind
+    of NetErrorKind.Dial:
+      logos_delivery_store_errors.inc(labelValues = [DialFailure])
+      return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
+    of NetErrorKind.Write:
+      return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: error.cause))
+    of NetErrorKind.Read:
+      return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.cause))
 
   let res = StoreQueryResponse.decode(buf).valueOr:
     logos_delivery_store_errors.inc(labelValues = [DecodeRpcFailure])
@@ -80,12 +84,7 @@ proc query*(
   if request.paginationCursor.isSome() and request.paginationCursor.get() == EmptyCursor:
     return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: "invalid cursor"))
 
-  let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-    logos_delivery_store_errors.inc(labelValues = [DialFailure])
-
-    return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
-
-  return await self.sendStoreRequest(request, connection)
+  return await self.sendStoreRequest(request, peer)
 
 proc queryToAny*(
     self: WakuStoreClient, request: StoreQueryRequest, peerId = Opt.none(PeerId)
@@ -107,13 +106,7 @@ proc queryToAny*(
 
   var lastError: StoreError
   for peer in peersToTry:
-    let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-      logos_delivery_store_errors.inc(labelValues = [DialFailure])
-      debug "Failed to dial store peer, trying next"
-      lastError = StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer)
-      continue
-
-    let response = (await self.sendStoreRequest(request, connection)).valueOr:
+    let response = (await self.sendStoreRequest(request, peer)).valueOr:
       debug "Store query failed, trying next peer", peerId = peer.peerId, error = $error
       lastError = error
       continue

--- a/logos_delivery/waku/waku_store/common.nim
+++ b/logos_delivery/waku/waku_store/common.nim
@@ -11,6 +11,9 @@ const
 
   MaxPageSize*: uint64 = 100
 
+  MaxStoreResponseSize* =
+    MaxPageSize * DefaultMaxWakuMessageSize + DefaultSafetyBufferProtocolOverhead
+
   EmptyCursor*: WakuMessageHash = EmptyWakuMessageHash
 
 type WakuStoreResult*[T] = Result[T, string]

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -41,7 +41,6 @@ import
   ./waku_store/test_waku_store,
   ./waku_store/test_wakunode_store
 
-# Net backend test suite
 import ./waku_net/test_net_backend
 
 # Waku store sync suite

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -41,6 +41,9 @@ import
   ./waku_store/test_waku_store,
   ./waku_store/test_wakunode_store
 
+# Net backend test suite
+import ./waku_net/test_net_backend
+
 # Waku store sync suite
 import ./waku_store_sync/test_all
 

--- a/tests/waku_net/test_net_backend.nim
+++ b/tests/waku_net/test_net_backend.nim
@@ -5,15 +5,25 @@ import libp2p/[multiaddress, peerid]
 import libp2p/protocols/protocol
 
 import
-  logos_delivery/waku/[node/peer_manager, waku_core], ../testlib/[wakucore, testasync]
+  logos_delivery/waku/[net/net_backend, node/peer_manager, waku_core, waku_core/codecs],
+  ../testlib/[wakucore, testasync]
 
-const TestCodec = "/waku/test/1.0.0"
+const
+  TestCodec = "/waku/test/1.0.0"
+  EchoCodec = "/waku/test-echo/1.0.0"
+
+const StubAnswer = @[byte 9, 9, 9]
 
 type StubNetBackend = ref object of NetBackend
   dials: int
+  connects: int
+  requests: int
+  lastPeerId: PeerId
+  lastAddrs: seq[MultiAddress]
   lastProto: string
+  lastPayload: seq[byte]
 
-method dial*(
+method dial(
     backend: StubNetBackend,
     peerId: PeerId,
     addrs: seq[MultiAddress],
@@ -21,9 +31,31 @@ method dial*(
     timeout: Duration,
 ): Future[Opt[Connection]] {.async: (raises: []).} =
   backend.dials.inc()
+  backend.lastPeerId = peerId
+  backend.lastAddrs = addrs
   backend.lastProto = proto
 
   return Opt.none(Connection)
+
+method connect(
+    backend: StubNetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
+): Future[Result[void, string]] {.async: (raises: []).} =
+  backend.connects.inc()
+  backend.lastPeerId = peerId
+  backend.lastAddrs = addrs
+
+  return err("the stub connects to nobody")
+
+method request(
+    backend: StubNetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  backend.requests.inc()
+  backend.lastPeerId = req.peerId
+  backend.lastAddrs = req.addrs
+  backend.lastProto = req.proto
+  backend.lastPayload = req.payload
+
+  return ok(StubAnswer)
 
 suite "Net backend":
   var serverSwitch {.threadvar.}: Switch
@@ -37,10 +69,22 @@ suite "Net backend":
     proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       await conn.close()
 
+    proc echoBack(
+        conn: Connection, proto: string
+    ) {.async: (raises: [CancelledError]).} =
+      try:
+        let request = await conn.readLp(DefaultNetMaxResponseSize)
+        await conn.writeLP(request & request)
+      except CatchableError as e:
+        error "echo handler failed", err = e.msg
+
+      await conn.close()
+
     serverSwitch.mount(LPProtocol.new(@[TestCodec], handle))
+    serverSwitch.mount(LPProtocol.new(@[EchoCodec], echoBack))
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
-    await sleepAsync(500.millis)
+    await sleepAsync(500.millis) # the listener is not ready on macos CI without it
 
     serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
 
@@ -49,6 +93,8 @@ suite "Net backend":
 
   asyncTest "the default backend dials over the switch":
     let peerManager = PeerManager.new(clientSwitch)
+
+    check peerManager.netBackend of SwitchNetBackend
 
     let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
 
@@ -64,4 +110,97 @@ suite "Net backend":
     check:
       conn.isNone()
       backend.dials == 1
+      backend.lastPeerId == serverPeerInfo.peerId
+      backend.lastAddrs == serverPeerInfo.addrs
       backend.lastProto == TestCodec
+
+  asyncTest "a request writes one frame and reads the answer":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response = await peerManager.request(serverPeerInfo, EchoCodec, @[byte 1, 2, 3])
+
+    check:
+      response.isOk()
+      response.get() == @[byte 1, 2, 3, 1, 2, 3]
+
+  asyncTest "a request to an undialable peer fails with a dial error":
+    let peerManager = PeerManager.new(clientSwitch)
+    let unreachable = RemotePeerInfo.init(
+      serverPeerInfo.peerId, @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+    )
+
+    let response = await peerManager.request(unreachable, TestCodec, @[byte 1])
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+
+  asyncTest "an answer over maxSize fails with a read error":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response =
+      await peerManager.request(serverPeerInfo, EchoCodec, @[byte 1, 2, 3], maxSize = 2)
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Read
+
+  asyncTest "a request to self is refused without a dial":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(
+      clientSwitch.peerInfo.toRemotePeerInfo(), TestCodec, @[byte 1]
+    )
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+      backend.requests == 0
+
+  asyncTest "the default backend connects over the switch":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    check (await peerManager.connectPeer(serverPeerInfo))
+
+  asyncTest "a connect to an unreachable peer fails":
+    let peerManager = PeerManager.new(clientSwitch)
+    let unreachable = RemotePeerInfo.init(
+      serverPeerInfo.peerId, @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+    )
+
+    check not (await peerManager.connectPeer(unreachable, dialTimeout = 2.seconds))
+
+  asyncTest "a backend of its own takes every connect":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    check not (await peerManager.connectPeer(serverPeerInfo))
+    check backend.connects == 1
+
+  asyncTest "a request never reaches the relay codec":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(serverPeerInfo, WakuRelayCodec, @[byte 1])
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+      backend.requests == 0
+
+  asyncTest "a backend of its own answers a request without dialing":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(serverPeerInfo, TestCodec, @[byte 1, 2, 3])
+
+    check:
+      response.isOk()
+      response.get() == StubAnswer
+      backend.requests == 1
+      backend.dials == 0
+      backend.lastPeerId == serverPeerInfo.peerId
+      backend.lastAddrs == serverPeerInfo.addrs
+      backend.lastProto == TestCodec
+      backend.lastPayload == @[byte 1, 2, 3]

--- a/tests/waku_net/test_net_backend.nim
+++ b/tests/waku_net/test_net_backend.nim
@@ -1,0 +1,67 @@
+{.used.}
+
+import results, testutils/unittests, chronos, chronicles
+import libp2p/[multiaddress, peerid]
+import libp2p/protocols/protocol
+
+import
+  logos_delivery/waku/[node/peer_manager, waku_core], ../testlib/[wakucore, testasync]
+
+const TestCodec = "/waku/test/1.0.0"
+
+type StubNetBackend = ref object of NetBackend
+  dials: int
+  lastProto: string
+
+method dial*(
+    backend: StubNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  backend.dials.inc()
+  backend.lastProto = proto
+
+  return Opt.none(Connection)
+
+suite "Net backend":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var serverPeerInfo {.threadvar.}: RemotePeerInfo
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+      await conn.close()
+
+    serverSwitch.mount(LPProtocol.new(@[TestCodec], handle))
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+    serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "the default backend dials over the switch":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
+
+    check conn.isSome()
+    await conn.get().close()
+
+  asyncTest "a backend of its own takes every dial":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
+
+    check:
+      conn.isNone()
+      backend.dials == 1
+      backend.lastProto == TestCodec


### PR DESCRIPTION
Follow up to #4152, dial through a NetBackend seam.

## Description

- #4152's seam is a dial: it returns a `Connection`, and each Edge client then repeats dial, `writeLP`, `readLp`, `closeWithEof` by hand.
- A backend that owns the libp2p node answers a whole exchange in one crossing. Serving four stream ops instead would cost four crossings.
- So this raises the seam from a stream to a frame.
- `NetBackend.request` defaults to the same dial-write-read-close body the clients carried, so the switch-backed path keeps the same wire format.

## Changes

- `net_backend.nim`: `NetRequest`, `NetError` with a `kind` of `Dial` / `Write` / `Read`, and the `request`, `dial` and `connect` methods. A backend that implements none of them fails the call instead of aborting the process.
- `PeerManager`: two `request` overloads that mirror the `dialPeer` ones. `checkStreamTarget` holds the self-dial and relay-codec guards for both paths, and `rememberPeer` holds the peer-store insert.
- Store, lightpush, filter and peer exchange clients branch on `error.kind` instead of driving streams themselves.
- `SwitchNetBackend.connect` applies the dial timeout itself, so `connectPeer` no longer races a `sleepAsync` deadline of its own.

## Behavior changes

- Store and lightpush now read their response with a real size cap. Both passed `DefaultMaxRpcSize = -1`, which libp2p reads as `int.high`, so a remote peer could name any frame length. Store caps at `MaxPageSize * DefaultMaxWakuMessageSize` plus the standard 64 KiB buffer, and lightpush caps at 64 KiB.
- `logos_delivery_peers_dials` recorded the failure reason in its `outcome` label. That reason is a raw exception string driven by a remote peer, so the label value was unbounded. It is a fixed `failed` now, and the reason stays in the log line.
- Filter put `getCurrentExceptionMsg()` into a metric label value for the same reason. It uses a fixed `request_failure` label now.
- Peer exchange reported an exception as `BAD_RESPONSE` on the peer path and `SERVICE_UNAVAILABLE` on the connection path. They agree on `SERVICE_UNAVAILABLE` now.
- The store client counts an active store request from the moment the request starts, so the dial falls inside that window.
- `connectPeer` cancelled its `sleepAsync` deadline only on success. A backend that returns a refusal rather than raising makes the failure path the common one, and every one of those used to leave the timer pending.

## Open

`NetBackend.dial` still hands back a `Connection`, and store sync, rendezvous, ping, legacy lightpush and `api/peer_manager` still call `dialPeer`. A backend that owns a libp2p node in another process cannot serve those callers. Whether `dial` belongs on `NetBackend` at all is still open.
