### PR TITLE
feat(library): C ABI for registering a net backend

### DIFF
--- a/library/liblogosdelivery.h
+++ b/library/liblogosdelivery.h
@@ -61,6 +61,40 @@ extern "C"
   int logosdelivery_remove_event_listener(void *ctx,
                                           uint64_t listenerId);
 
+// Net backend ABI. A module that owns a libp2p node registers a backend under a
+// name, and a node created with "libp2pProvider": "<name>" runs its Edge
+// protocols over that node instead of its own libp2p stack.
+#define LOGOSDELIVERY_NET_BACKEND_ABI_VERSION 1
+
+  // Called on the library thread with {"op": "<name>", "args": {...}} and must
+  // return at once. Every request gets exactly one
+  // logosdelivery_net_backend_respond, from any thread.
+  typedef void (*LogosDeliveryNetSubmitFn)(uint64_t requestId,
+                                           const char *opJson,
+                                           size_t opLen,
+                                           void *userData);
+
+  typedef struct
+  {
+    uint32_t version;
+    LogosDeliveryNetSubmitFn submit;
+  } LogosDeliveryNetBackendTable;
+
+  // Registers (or replaces) the backend named `name`. Returns 0 on success, and
+  // non-zero for a null argument, an unsupported version, a name longer than 63
+  // characters, or a full backend registry.
+  int logosdelivery_register_net_backend(const char *name,
+                                         const LogosDeliveryNetBackendTable *table,
+                                         void *userData);
+
+  // Answers one submitted op. `ok != 0` carries the result JSON in `data`, and
+  // `ok == 0` carries the error text. The library copies `data` before
+  // returning. Returns 0 when the answer reaches the library thread.
+  int logosdelivery_net_backend_respond(uint64_t requestId,
+                                        int ok,
+                                        const char *data,
+                                        size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/liblogosdelivery.nim
+++ b/library/liblogosdelivery.nim
@@ -15,6 +15,7 @@ import
 ## Include different APIs, i.e. all procs with {.ffi.} pragma
 
 include
+  ./network_bridge_api,
   ./logos_delivery_api/node_api,
   ./logos_delivery_api/messaging_api,
   ./logos_delivery_api/debug_api,

--- a/library/network_bridge_api.nim
+++ b/library/network_bridge_api.nim
@@ -1,0 +1,15 @@
+import logos_delivery/waku/net/net_bridge
+
+proc logosdelivery_register_net_backend(
+    name: cstring, table: ptr NetBackendTable, userData: pointer
+): cint {.dynlib, exportc, cdecl.} =
+  registerNetBackend(name, table, userData)
+
+proc logosdelivery_net_backend_respond(
+    requestId: uint64, ok: cint, data: cstring, len: csize_t
+): cint {.dynlib, exportc, cdecl.} =
+  ## The caller's thread owns `data` and may free it once this returns.
+  if len > csize_t(int.high):
+    return 1
+
+  netBackendRespond(requestId, ok != 0, cast[pointer](data), int(len))

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -1,5 +1,5 @@
-## The one funnel every outbound protocol stream goes through, so a node can
-## dial over its own switch or over a libp2p node another process owns.
+## Abstracts the libp2p operations the Edge protocol clients need, so a node can
+## run them over its own switch or over a libp2p node another process owns.
 
 {.push raises: [].}
 
@@ -8,11 +8,59 @@ import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
 logScope:
   topics = "waku net backend"
 
+const
+  DefaultNetDialTimeout* = chronos.seconds(10)
+  DefaultNetMaxResponseSize* = 1024 * 1024
+
 type
+  NetErrorKind* {.pure.} = enum
+    Dial
+    Write
+    Read
+
+  NetError* = object
+    kind*: NetErrorKind
+    cause*: string
+
+  NetRequest* = object
+    peerId*: PeerId
+    addrs*: seq[MultiAddress]
+    proto*: string
+    payload*: seq[byte]
+    maxSize*: int
+    timeout*: Duration
+    expectResponse*: bool
+
   NetBackend* = ref object of RootObj
 
   SwitchNetBackend* = ref object of NetBackend
     switch: Switch
+
+func init*(
+    T: type NetRequest,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultNetDialTimeout,
+    expectResponse = true,
+): NetRequest =
+  NetRequest(
+    peerId: peerId,
+    addrs: addrs,
+    proto: proto,
+    payload: payload,
+    maxSize: maxSize,
+    timeout: timeout,
+    expectResponse: expectResponse,
+  )
+
+func dialError*(cause: string): NetError =
+  NetError(kind: NetErrorKind.Dial, cause: cause)
+
+func `$`*(err: NetError): string =
+  $err.kind & " failed: " & err.cause
 
 method dial*(
     backend: NetBackend,
@@ -23,8 +71,53 @@ method dial*(
 ): Future[Opt[Connection]] {.base, async: (raises: []).} =
   raiseAssert "[NetBackend.dial] abstract method not implemented"
 
+method connect*(
+    backend: NetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
+): Future[Result[void, string]] {.base, async: (raises: []).} =
+  raiseAssert "[NetBackend.connect] abstract method not implemented"
+
+method request*(
+    backend: NetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.base, async: (raises: []).} =
+  ## One length-prefixed frame out, one back, over a stream of its own.
+  let connection = (await backend.dial(req.peerId, req.addrs, req.proto, req.timeout)).valueOr:
+    return err(dialError($req.peerId))
+
+  defer:
+    await connection.closeWithEof()
+
+  let writeRes = catch:
+    await connection.writeLP(req.payload)
+  if writeRes.isErr():
+    return err(NetError(kind: NetErrorKind.Write, cause: writeRes.error.msg))
+
+  if not req.expectResponse:
+    return ok(newSeq[byte]())
+
+  let readRes = catch:
+    await connection.readLp(req.maxSize)
+
+  let buffer = readRes.valueOr:
+    return err(NetError(kind: NetErrorKind.Read, cause: error.msg))
+
+  return ok(buffer)
+
 func new*(T: type SwitchNetBackend, switch: Switch): T =
   SwitchNetBackend(switch: switch)
+
+method connect*(
+    backend: SwitchNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    timeout: Duration,
+): Future[Result[void, string]] {.async: (raises: []).} =
+  let res = catch:
+    await backend.switch.connect(peerId, addrs)
+
+  if res.isErr():
+    return err(res.error.msg)
+
+  return ok()
 
 method dial*(
     backend: SwitchNetBackend,

--- a/logos_delivery/waku/net/net_bridge.nim
+++ b/logos_delivery/waku/net/net_bridge.nim
@@ -1,0 +1,324 @@
+## Carries net ops to a backend registered over the C ABI, and carries the
+## answers back. A backend answers from a foreign thread, so a response crosses
+## on shared memory and wakes the library thread through a signal.
+
+{.push raises: [].}
+
+import std/[json, locks, tables]
+import results, chronicles, chronos, chronos/threadsync, metrics
+import ./net_transport
+
+declarePublicCounter logos_delivery_net_bridge_ops,
+  "number of net backend ops by outcome", ["op", "outcome"]
+
+logScope:
+  topics = "waku net bridge"
+
+const
+  NetBackendAbiVersion* = 1'u32
+  MaxNetBackends = 8
+  MaxBackendNameLen = 63
+
+type
+  NetSubmitFn* = proc(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+  ) {.cdecl, gcsafe, raises: [].}
+
+  NetBackendTable* = object
+    version*: uint32
+    submit*: NetSubmitFn
+
+  BackendSlot = object
+    name: array[MaxBackendNameLen + 1, char]
+    submit: NetSubmitFn
+    userData: pointer
+    used: bool
+
+  Response = object
+    next: ptr Response
+    requestId: uint64
+    ok: bool
+    len: int
+    data: ptr UncheckedArray[byte]
+
+  OpAnswer = object
+    ok: bool
+    data: string
+
+  NetBridgeTransport* = ref object of NetTransport
+    name*: string
+    submitFn: NetSubmitFn
+    userData: pointer
+
+var
+  bridgeLock: Lock
+  backends: array[MaxNetBackends, BackendSlot]
+  responseHead: ptr Response
+  responseTail: ptr Response
+  responseSignal: ThreadSignalPtr
+  signalReady: bool
+  drainClaimed: bool
+
+var nextRequestId: uint64
+
+var
+  pending {.threadvar.}: Table[uint64, Future[OpAnswer]]
+  drainFut {.threadvar.}: Future[void]
+
+initLock(bridgeLock)
+
+proc slotFor(name: cstring): int =
+  ## Caller holds the lock. A free slot when the name is new, else the match.
+  var free = -1
+  for i in 0 ..< MaxNetBackends:
+    if not backends[i].used:
+      if free < 0:
+        free = i
+      continue
+    if cast[cstring](addr backends[i].name[0]) == name:
+      return i
+  return free
+
+proc registerNetBackend*(
+    name: cstring, table: ptr NetBackendTable, userData: pointer
+): cint {.gcsafe.} =
+  if name.isNil() or table.isNil() or table.submit.isNil():
+    return 1
+  if table.version != NetBackendAbiVersion:
+    return 2
+  ## Read once: the caller owns that buffer, so a second `len` could size the
+  ## copy past the array the first one cleared.
+  let nameLen = len(name)
+  if nameLen > MaxBackendNameLen:
+    return 3
+
+  acquire(bridgeLock)
+  defer:
+    release(bridgeLock)
+
+  let slot = slotFor(name)
+  if slot < 0:
+    return 4
+
+  zeroMem(addr backends[slot].name[0], MaxBackendNameLen + 1)
+  copyMem(addr backends[slot].name[0], cast[pointer](name), nameLen)
+  backends[slot].submit = table.submit
+  backends[slot].userData = userData
+  backends[slot].used = true
+
+  return 0
+
+proc freeResponse(node: ptr Response) =
+  if not node.data.isNil():
+    deallocShared(node.data)
+  deallocShared(node)
+
+proc netBackendRespond*(
+    requestId: uint64, ok: bool, data: pointer, len: int
+): cint {.gcsafe.} =
+  ## Runs on the backend's thread: it may touch no Nim heap and must not block.
+  if len < 0:
+    return 1
+
+  let node = cast[ptr Response](allocShared0(sizeof(Response)))
+  node.requestId = requestId
+  node.ok = ok
+
+  if len > 0 and not data.isNil():
+    node.data = cast[ptr UncheckedArray[byte]](allocShared(len))
+    copyMem(node.data, data, len)
+    node.len = len
+
+  acquire(bridgeLock)
+
+  ## No drain means nothing waits on this and nothing would ever free it.
+  if not signalReady:
+    release(bridgeLock)
+    freeResponse(node)
+    return 1
+
+  if responseTail.isNil():
+    responseHead = node
+  else:
+    responseTail.next = node
+  responseTail = node
+
+  ## Fired under the lock, because a drain on its way out closes the signal
+  ## under the same lock. Outside it, this could write to a closed handle.
+  discard responseSignal.fireSync()
+
+  release(bridgeLock)
+
+  return 0
+
+proc takeResponses(): ptr Response =
+  acquire(bridgeLock)
+  let head = responseHead
+  responseHead = nil
+  responseTail = nil
+  release(bridgeLock)
+
+  return head
+
+proc answerOf(node: ptr Response): OpAnswer =
+  var answer = OpAnswer(ok: node.ok)
+  if node.len > 0:
+    answer.data = newString(node.len)
+    copyMem(addr answer.data[0], node.data, node.len)
+
+  return answer
+
+proc dispatchResponses() =
+  var node = takeResponses()
+  while not node.isNil():
+    let next = node.next
+
+    pending.withValue(node.requestId, fut):
+      if not fut[].finished():
+        fut[].complete(answerOf(node))
+    pending.del(node.requestId)
+
+    freeResponse(node)
+
+    node = next
+
+proc releaseDrain() =
+  acquire(bridgeLock)
+  let signal = responseSignal
+  let hadSignal = signalReady
+  var queued = responseHead
+
+  responseHead = nil
+  responseTail = nil
+  signalReady = false
+  drainClaimed = false
+  release(bridgeLock)
+
+  while not queued.isNil():
+    let next = queued.next
+    freeResponse(queued)
+    queued = next
+
+  if hadSignal:
+    discard signal.close()
+
+proc drainLoop() {.async: (raises: []).} =
+  while true:
+    try:
+      await responseSignal.wait()
+    except CancelledError:
+      break
+    except AsyncError as e:
+      error "the net bridge signal failed, so no answer can reach this thread",
+        err = e.msg
+      break
+
+    dispatchResponses()
+
+  drainFut = nil
+  releaseDrain()
+
+proc startDrain(): Result[void, string] =
+  if not drainFut.isNil():
+    return ok()
+
+  ## `pending` and the loop are per thread, the signal and the queue are not.
+  ## A second thread taking them over would strand every future the first one
+  ## is still holding, so it is refused instead.
+  acquire(bridgeLock)
+  let taken = drainClaimed
+  if not taken:
+    drainClaimed = true
+  release(bridgeLock)
+
+  if taken:
+    return err("the net bridge already belongs to another thread")
+
+  let signal = ThreadSignalPtr.new().valueOr:
+    acquire(bridgeLock)
+    drainClaimed = false
+    release(bridgeLock)
+
+    return err("failed to create the net bridge signal: " & error)
+
+  acquire(bridgeLock)
+  responseSignal = signal
+  signalReady = true
+  release(bridgeLock)
+
+  drainFut = drainLoop()
+
+  return ok()
+
+proc getNetTransport*(name: string): Result[NetTransport, string] =
+  ## Runs on the library thread, where the returned transport is used.
+  acquire(bridgeLock)
+  var found = -1
+  for i in 0 ..< MaxNetBackends:
+    if backends[i].used and $cast[cstring](addr backends[i].name[0]) == name:
+      found = i
+      break
+  let slot =
+    if found < 0:
+      BackendSlot()
+    else:
+      backends[found]
+  release(bridgeLock)
+
+  if found < 0:
+    return err("no net backend named '" & name & "' is registered")
+
+  ?startDrain()
+
+  return ok(
+    NetTransport(
+      NetBridgeTransport(name: name, submitFn: slot.submit, userData: slot.userData)
+    )
+  )
+
+method submit*(
+    transport: NetBridgeTransport, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let payload =
+    try:
+      $(%*{"op": op, "args": args})
+    except CatchableError as e:
+      return err("failed to encode op " & op & ": " & e.msg)
+
+  inc(nextRequestId)
+  let requestId = nextRequestId
+  let fut = Future[OpAnswer].Raising([CancelledError]).init("netbridge.op")
+  pending[requestId] = fut
+
+  transport.submitFn(
+    requestId, cstring(payload), csize_t(payload.len), transport.userData
+  )
+
+  var answer: OpAnswer
+  try:
+    if not await fut.withTimeout(timeout):
+      pending.del(requestId)
+      logos_delivery_net_bridge_ops.inc(labelValues = [op, "timeout"])
+      return err("op " & op & " timed out")
+    answer = fut.read()
+  except CatchableError as e:
+    pending.del(requestId)
+    logos_delivery_net_bridge_ops.inc(labelValues = [op, "failed"])
+    return err("op " & op & " failed: " & e.msg)
+
+  if not answer.ok:
+    logos_delivery_net_bridge_ops.inc(labelValues = [op, "error"])
+    return err(answer.data)
+
+  let node =
+    try:
+      parseJson(answer.data)
+    except CatchableError as e:
+      logos_delivery_net_bridge_ops.inc(labelValues = [op, "failed"])
+      return err("op " & op & " returned invalid JSON: " & e.msg)
+
+  logos_delivery_net_bridge_ops.inc(labelValues = [op, "ok"])
+
+  return ok(node)
+
+{.pop.}

--- a/logos_delivery/waku/net/net_transport.nim
+++ b/logos_delivery/waku/net/net_transport.nim
@@ -1,0 +1,15 @@
+## One crossing to the process that owns the libp2p node: an op name, a JSON
+## argument object, and a JSON answer.
+
+{.push raises: [].}
+
+import std/json, results, chronos
+
+type NetTransport* = ref object of RootObj
+
+method submit*(
+    transport: NetTransport, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.base, async: (raises: []).} =
+  raiseAssert "[NetTransport.submit] abstract method not implemented"
+
+{.pop.}

--- a/logos_delivery/waku/node/peer_manager/peer_manager.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_manager.nim
@@ -349,28 +349,37 @@ proc connectPeer*(
     wireAddr = peer.addrs, peerId = peerId, failedAttempts = failedAttempts
 
   var deadline = sleepAsync(dialTimeout)
-  let workfut = pm.switch.connect(peerId, peer.addrs)
+  let workfut = pm.netBackend.connect(peerId, peer.addrs, dialTimeout)
 
   # Can't use catch: with .withTimeout() in this case
   let res = catch:
     await workfut or deadline
 
+  let timedOut = not workfut.finished()
+
+  # The race is over either way, so the losing half must not outlive it. A
+  # backend that reports a refusal instead of raising now takes the common
+  # failure path, and every one of them used to leave this timer pending.
+  if not deadline.finished():
+    await deadline.cancelAndWait()
+
   let reasonFailed =
-    if not workfut.finished():
+    if timedOut:
       await workfut.cancelAndWait()
       "timed out"
     elif res.isErr():
       res.error.msg
     else:
-      if not deadline.finished():
-        await deadline.cancelAndWait()
+      let connected = workfut.read()
+      if connected.isErr():
+        connected.error
+      else:
+        logos_delivery_peers_dials.inc(labelValues = ["successful"])
+        logos_delivery_node_conns_initiated.inc(labelValues = [source])
 
-      logos_delivery_peers_dials.inc(labelValues = ["successful"])
-      logos_delivery_node_conns_initiated.inc(labelValues = [source])
+        peerStore[NumberFailedConnBook][peerId] = 0
 
-      peerStore[NumberFailedConnBook][peerId] = 0
-
-      return true
+        return true
 
   # Dial failed
   peerStore[NumberFailedConnBook][peerId] = peerStore[NumberFailedConnBook][peerId] + 1
@@ -487,6 +496,50 @@ proc dialPeer*(
 
   let addrs = pm.switch.peerStore[AddressBook][peerId]
   return await pm.dialPeer(peerId, addrs, proto, dialTimeout, source)
+
+proc request*(
+    pm: PeerManager,
+    remotePeerInfo: RemotePeerInfo,
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultDialTimeout,
+    expectResponse = true,
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  ## Sends one length-prefixed frame to `proto` on `peer` and reads the answer.
+  if remotePeerInfo.peerId == pm.switch.peerInfo.peerId:
+    return err(dialError("could not dial self"))
+
+  if proto == WakuRelayCodec:
+    return err(dialError("request shall not be used to reach relays"))
+
+  if not pm.switch.peerStore.hasPeer(remotePeerInfo.peerId, proto):
+    pm.addPeer(remotePeerInfo)
+
+  return await pm.netBackend.request(
+    NetRequest.init(
+      peerId = remotePeerInfo.peerId,
+      addrs = remotePeerInfo.addrs,
+      proto = proto,
+      payload = payload,
+      maxSize = maxSize,
+      timeout = timeout,
+      expectResponse = expectResponse,
+    )
+  )
+
+proc request*(
+    pm: PeerManager,
+    peerId: PeerId,
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultDialTimeout,
+    expectResponse = true,
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  let peer = RemotePeerInfo.init(peerId, pm.switch.peerStore[AddressBook][peerId])
+
+  return await pm.request(peer, proto, payload, maxSize, timeout, expectResponse)
 
 proc canBeConnected*(pm: PeerManager, peerId: PeerId): bool =
   # Returns if we can try to connect to this peer, based on past failed attempts

--- a/logos_delivery/waku/waku_filter_v2/client.nim
+++ b/logos_delivery/waku/waku_filter_v2/client.nim
@@ -40,42 +40,22 @@ proc sendSubscribeRequest(
   trace "Sending filter subscribe request",
     peerId = servicePeer.peerId, filterSubscribeRequest
 
-  var connOpt: Opt[Connection]
-  try:
-    connOpt = await wfc.peerManager.dialPeer(servicePeer, WakuFilterSubscribeCodec)
-    if connOpt.isNone():
+  let respBuf = (
+    await wfc.peerManager.request(
+      servicePeer,
+      WakuFilterSubscribeCodec,
+      filterSubscribeRequest.encode().buffer,
+      DefaultMaxSubscribeResponseSize,
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
       trace "Failed to dial filter service peer", servicePeer
       logos_delivery_filter_errors.inc(labelValues = [dialFailure])
       return err(FilterSubscribeError.peerDialFailure($servicePeer))
-  except CatchableError:
-    let errMsg = "failed to dialPeer: " & getCurrentExceptionMsg()
-    trace "failed to dialPeer", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
 
-  let connection = connOpt.get()
-
-  defer:
-    await connection.closeWithEOF()
-
-  try:
-    await connection.writeLP(filterSubscribeRequest.encode().buffer)
-  except CatchableError:
-    let errMsg =
-      "exception in waku_filter_v2 client writeLP: " & getCurrentExceptionMsg()
-    trace "exception in waku_filter_v2 client writeLP", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
-
-  var respBuf: seq[byte]
-  try:
-    respBuf = await connection.readLp(DefaultMaxSubscribeResponseSize)
-  except CatchableError:
-    let errMsg =
-      "exception in waku_filter_v2 client readLp: " & getCurrentExceptionMsg()
-    trace "exception in waku_filter_v2 client readLp", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
+    trace "filter subscribe request failed", error = $error
+    logos_delivery_filter_errors.inc(labelValues = [requestFailure])
+    return err(FilterSubscribeError.badResponse(error.cause))
 
   let response = FilterSubscribeResponse.decode(respBuf).valueOr:
     trace "Failed to decode filter subscribe response", servicePeer

--- a/logos_delivery/waku/waku_filter_v2/protocol_metrics.nim
+++ b/logos_delivery/waku/waku_filter_v2/protocol_metrics.nim
@@ -26,3 +26,4 @@ const
   requestIdMismatch* = "request_id_mismatch"
   errorResponse* = "error_response"
   pushTimeoutFailure* = "push_timeout_failure"
+  requestFailure* = "request_failure"

--- a/logos_delivery/waku/waku_lightpush/client.nim
+++ b/logos_delivery/waku/waku_lightpush/client.nim
@@ -30,20 +30,23 @@ func shortPeerId(peer: PeerId): string =
 func shortPeerId(peer: RemotePeerInfo): string =
   shortLog(peer.peerId)
 
-proc sendPushRequest(
-    wl: WakuLightPushClient,
-    req: LightPushRequest,
-    peer: PeerId | RemotePeerInfo,
-    conn: Opt[Connection] = Opt.none(Connection),
-): Future[WakuLightPushResult] {.async.} =
-  let connection = conn.valueOr:
-    (await wl.peerManager.dialPeer(peer, WakuLightPushCodec)).valueOr:
-      logos_delivery_lightpush_v3_errors.inc(labelValues = [dialFailure])
-      return lighpushErrorResult(
-        LightPushErrorCode.NO_PEERS_TO_RELAY,
-        dialFailure & ": " & $peer & " is not accessible",
-      )
+proc parsePushResponse(req: LightPushRequest, buffer: seq[byte]): WakuLightPushResult =
+  let response = LightpushResponse.decode(buffer).valueOr:
+    debug "Failed to decode response"
+    logos_delivery_lightpush_v3_errors.inc(labelValues = [decodeRpcFailure])
+    return lightpushResultInternalError(decodeRpcFailure)
 
+  if response.requestId != req.requestId and
+      response.statusCode != LightPushErrorCode.TOO_MANY_REQUESTS:
+    debug "Response failure, requestId mismatch",
+      requestId = req.requestId, responseRequestId = response.requestId
+    return lightpushResultInternalError("response failure, requestId mismatch")
+
+  return toPushResult(response)
+
+proc sendPushRequestOverConn(
+    wl: WakuLightPushClient, req: LightPushRequest, connection: Connection
+): Future[WakuLightPushResult] {.async.} =
   defer:
     await connection.closeWithEOF()
 
@@ -58,18 +61,26 @@ proc sendPushRequest(
       "Failed to read response from peer: " & getCurrentExceptionMsg()
     )
 
-  let response = LightpushResponse.decode(buffer).valueOr:
-    debug "Failed to decode response"
-    logos_delivery_lightpush_v3_errors.inc(labelValues = [decodeRpcFailure])
-    return lightpushResultInternalError(decodeRpcFailure)
+  return parsePushResponse(req, buffer)
 
-  if response.requestId != req.requestId and
-      response.statusCode != LightPushErrorCode.TOO_MANY_REQUESTS:
-    debug "Response failure, requestId mismatch",
-      requestId = req.requestId, responseRequestId = response.requestId
-    return lightpushResultInternalError("response failure, requestId mismatch")
+proc sendPushRequest(
+    wl: WakuLightPushClient, req: LightPushRequest, peer: PeerId | RemotePeerInfo
+): Future[WakuLightPushResult] {.async.} =
+  let buffer = (
+    await wl.peerManager.request(
+      peer, WakuLightPushCodec, req.encode().buffer, DefaultMaxRpcSize.int
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
+      logos_delivery_lightpush_v3_errors.inc(labelValues = [dialFailure])
+      return lighpushErrorResult(
+        LightPushErrorCode.NO_PEERS_TO_RELAY,
+        dialFailure & ": " & $peer & " is not accessible",
+      )
+    debug "Lightpush request failed", error = $error
+    return lightpushResultInternalError($error)
 
-  return toPushResult(response)
+  return parsePushResponse(req, buffer)
 
 proc publish*(
     wl: WakuLightPushClient,
@@ -99,7 +110,7 @@ proc publish*(
 
   let relayPeerCount =
     when dest is Connection:
-      ?await wl.sendPushRequest(request, dest.peerId, Opt.some(dest))
+      ?await wl.sendPushRequestOverConn(request, dest)
     else:
       ?await wl.sendPushRequest(request, dest)
 

--- a/logos_delivery/waku/waku_peer_exchange/client.nim
+++ b/logos_delivery/waku/waku_peer_exchange/client.nim
@@ -25,6 +25,26 @@ type WakuPeerExchangeClient* = ref object
 proc new*(T: type WakuPeerExchangeClient, peerManager: PeerManager): T =
   WakuPeerExchangeClient(peerManager: peerManager)
 
+proc decodeResponse(buffer: seq[byte]): WakuPeerExchangeResult[PeerExchangeResponse] =
+  let decoded = PeerExchangeRpc.decode(buffer).valueOr:
+    debug "Peer exchange request error decoding buffer", error = $error
+    return err(
+      (
+        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
+        status_desc: Opt.some($error),
+      )
+    )
+  if decoded.response.status_code != PeerExchangeResponseStatusCode.SUCCESS:
+    debug "Peer exchange request error", status_code = decoded.response.status_code
+    return err(
+      (
+        status_code: decoded.response.status_code,
+        status_desc: decoded.response.status_desc,
+      )
+    )
+
+  return ok(decoded.response)
+
 proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, conn: Connection
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
@@ -53,31 +73,19 @@ proc request*(
     debug "Peer exchange request failed", status_code = callResult.status_code
     return err(callResult)
 
-  let decoded = PeerExchangeRpc.decode(buffer).valueOr:
-    debug "Peer exchange request error decoding buffer", error = $error
-    return err(
-      (
-        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
-        status_desc: Opt.some($error),
-      )
-    )
-  if decoded.response.status_code != PeerExchangeResponseStatusCode.SUCCESS:
-    debug "Peer exchange request error", status_code = decoded.response.status_code
-    return err(
-      (
-        status_code: decoded.response.status_code,
-        status_desc: decoded.response.status_desc,
-      )
-    )
-
-  return ok(decoded.response)
+  return decodeResponse(buffer)
 
 proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, peer: RemotePeerInfo
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
-  try:
-    let connOpt = await wpx.peerManager.dialPeer(peer, WakuPeerExchangeCodec)
-    if connOpt.isNone():
+  let rpc = PeerExchangeRpc.makeRequest(numPeers)
+
+  let buffer = (
+    await wpx.peerManager.request(
+      peer, WakuPeerExchangeCodec, rpc.encode().buffer, DefaultMaxRpcSize.int
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
       debug "Peer exchange request dial failed, no connection"
       return err(
         (
@@ -85,15 +93,19 @@ proc request*(
           status_desc: Opt.some(dialFailure),
         )
       )
-    return await wpx.request(numPeers, connOpt.get())
-  except CatchableError:
-    debug "Peer exchange request exception", error = getCurrentExceptionMsg()
+
+    debug "Peer exchange request failed", error = $error
+    logos_delivery_px_client_errors.inc(
+      labelValues = ["error_sending_or_receiving_px_req"]
+    )
     return err(
       (
-        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
-        status_desc: Opt.some("exception dialing peer: " & getCurrentExceptionMsg()),
+        status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+        status_desc: Opt.some(error.cause),
       )
     )
+
+  return decodeResponse(buffer)
 
 proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq

--- a/logos_delivery/waku/waku_store/client.nim
+++ b/logos_delivery/waku/waku_store/client.nim
@@ -30,28 +30,32 @@ proc new*(
   WakuStoreClient(peerManager: peerManager, rng: rng)
 
 proc sendStoreRequest(
-    self: WakuStoreClient, request: StoreQueryRequest, connection: Connection
+    self: WakuStoreClient, request: StoreQueryRequest, peer: RemotePeerInfo | PeerId
 ): Future[StoreQueryResult] {.async, gcsafe.} =
   var req = request
 
-  self.peerManager.addActiveStoreRequest(connection.peerId)
+  let peerId = when peer is PeerId: peer else: peer.peerId
+
+  self.peerManager.addActiveStoreRequest(peerId)
   defer:
-    self.peerManager.removeActiveStoreRequest(connection.peerId)
-    await connection.closeWithEof()
+    self.peerManager.removeActiveStoreRequest(peerId)
 
   if req.requestId == "":
     req.requestId = generateRequestId(self.rng)
 
-  let writeRes = catch:
-    await connection.writeLP(req.encode().buffer)
-  if writeRes.isErr():
-    return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: writeRes.error.msg))
-
-  let readRes = catch:
-    await connection.readLp(DefaultMaxRpcSize.int)
-
-  let buf = readRes.valueOr:
-    return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.msg))
+  let buf = (
+    await self.peerManager.request(
+      peer, WakuStoreCodec, req.encode().buffer, DefaultMaxRpcSize.int
+    )
+  ).valueOr:
+    case error.kind
+    of NetErrorKind.Dial:
+      logos_delivery_store_errors.inc(labelValues = [DialFailure])
+      return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peerId))
+    of NetErrorKind.Write:
+      return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: error.cause))
+    of NetErrorKind.Read:
+      return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.cause))
 
   let res = StoreQueryResponse.decode(buf).valueOr:
     logos_delivery_store_errors.inc(labelValues = [DecodeRpcFailure])
@@ -80,12 +84,7 @@ proc query*(
   if request.paginationCursor.isSome() and request.paginationCursor.get() == EmptyCursor:
     return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: "invalid cursor"))
 
-  let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-    logos_delivery_store_errors.inc(labelValues = [DialFailure])
-
-    return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
-
-  return await self.sendStoreRequest(request, connection)
+  return await self.sendStoreRequest(request, peer)
 
 proc queryToAny*(
     self: WakuStoreClient, request: StoreQueryRequest, peerId = Opt.none(PeerId)
@@ -107,13 +106,7 @@ proc queryToAny*(
 
   var lastError: StoreError
   for peer in peersToTry:
-    let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-      logos_delivery_store_errors.inc(labelValues = [DialFailure])
-      debug "Failed to dial store peer, trying next"
-      lastError = StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer)
-      continue
-
-    let response = (await self.sendStoreRequest(request, connection)).valueOr:
+    let response = (await self.sendStoreRequest(request, peer)).valueOr:
       debug "Store query failed, trying next peer", peerId = peer.peerId, error = $error
       lastError = error
       continue

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -42,7 +42,7 @@ import
   ./waku_store/test_wakunode_store
 
 # Net backend test suite
-import ./waku_net/test_net_backend
+import ./waku_net/test_net_backend, ./waku_net/test_net_bridge
 
 # Waku store sync suite
 import ./waku_store_sync/test_all

--- a/tests/waku_net/test_net_backend.nim
+++ b/tests/waku_net/test_net_backend.nim
@@ -5,9 +5,12 @@ import libp2p/[multiaddress, peerid]
 import libp2p/protocols/protocol
 
 import
-  logos_delivery/waku/[node/peer_manager, waku_core], ../testlib/[wakucore, testasync]
+  logos_delivery/waku/[node/peer_manager, waku_core, waku_core/codecs],
+  ../testlib/[wakucore, testasync]
 
-const TestCodec = "/waku/test/1.0.0"
+const
+  TestCodec = "/waku/test/1.0.0"
+  EchoCodec = "/waku/test-echo/1.0.0"
 
 type StubNetBackend = ref object of NetBackend
   dials: int
@@ -37,7 +40,19 @@ suite "Net backend":
     proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       await conn.close()
 
+    proc echoBack(
+        conn: Connection, proto: string
+    ) {.async: (raises: [CancelledError]).} =
+      try:
+        let request = await conn.readLp(DefaultNetMaxResponseSize)
+        await conn.writeLP(request & request)
+      except CatchableError:
+        discard
+
+      await conn.close()
+
     serverSwitch.mount(LPProtocol.new(@[TestCodec], handle))
+    serverSwitch.mount(LPProtocol.new(@[EchoCodec], echoBack))
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
     await sleepAsync(500.millis)
@@ -65,3 +80,69 @@ suite "Net backend":
       conn.isNone()
       backend.dials == 1
       backend.lastProto == TestCodec
+
+  asyncTest "a request writes one frame and reads the answer":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response = await peerManager.request(serverPeerInfo, EchoCodec, @[byte 1, 2, 3])
+
+    check:
+      response.isOk()
+      response.get() == @[byte 1, 2, 3, 1, 2, 3]
+
+  asyncTest "a request that expects no answer returns as soon as it is written":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response = await peerManager.request(
+      serverPeerInfo, EchoCodec, @[byte 1, 2, 3], expectResponse = false
+    )
+
+    check:
+      response.isOk()
+      response.get().len == 0
+
+  asyncTest "a request to an undialable peer fails with a dial error":
+    let peerManager = PeerManager.new(clientSwitch)
+    let unreachable = RemotePeerInfo.init(
+      serverPeerInfo.peerId, @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+    )
+
+    let response = await peerManager.request(unreachable, TestCodec, @[byte 1])
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+
+  asyncTest "an answer over maxSize fails with a read error":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response =
+      await peerManager.request(serverPeerInfo, EchoCodec, @[byte 1, 2, 3], maxSize = 2)
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Read
+
+  asyncTest "a request to self is refused without a dial":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(
+      clientSwitch.peerInfo.toRemotePeerInfo(), TestCodec, @[byte 1]
+    )
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+      backend.dials == 0
+
+  asyncTest "a request never reaches the relay codec":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(serverPeerInfo, WakuRelayCodec, @[byte 1])
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+      backend.dials == 0

--- a/tests/waku_net/test_net_bridge.nim
+++ b/tests/waku_net/test_net_bridge.nim
@@ -1,0 +1,118 @@
+{.used.}
+
+import std/[json, os, strutils]
+import results, testutils/unittests, chronos
+
+import logos_delivery/waku/net/[net_bridge, net_transport]
+
+var worker {.threadvar.}: Thread[uint64]
+
+proc submitNever(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  discard
+
+proc submitInline(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let op = $cast[cstring](opJson)
+  let answer = "{\"echo\":" & escapeJson(op) & "}"
+  discard netBackendRespond(requestId, true, cast[pointer](cstring(answer)), answer.len)
+
+proc respondFromThread(requestId: uint64) {.thread.} =
+  sleep(20)
+  let answer = "{\"late\":true}"
+  discard netBackendRespond(requestId, true, cast[pointer](cstring(answer)), answer.len)
+
+proc submitThreaded(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  try:
+    createThread(worker, respondFromThread, requestId)
+  except ResourceExhaustedError:
+    discard
+
+const
+  LongestName = "b".repeat(63)
+  TooLongName = "b".repeat(64)
+
+suite "Net backend ABI":
+  test "a table of another ABI version is refused":
+    var table = NetBackendTable(version: NetBackendAbiVersion + 1, submit: submitNever)
+
+    check:
+      registerNetBackend("wrong-version", addr table, nil) != 0
+      registerNetBackend("no-table", nil, nil) != 0
+
+  test "an unknown backend has no transport":
+    check getNetTransport("nobody").isErr()
+
+  asyncTest "a backend answers on the calling thread":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitInline)
+    check registerNetBackend("inline", addr table, nil) == 0
+
+    let transport = getNetTransport("inline").valueOr:
+      raiseAssert "no transport: " & error
+
+    let answer =
+      await transport.submit("getNodeInfo", %*{"field": "PeerId"}, chronos.seconds(5))
+
+    check:
+      answer.isOk()
+      answer.get(){"echo"}.getStr().contains("\"op\":\"getNodeInfo\"")
+
+  asyncTest "a backend answers from a foreign thread":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitThreaded)
+    check registerNetBackend("threaded", addr table, nil) == 0
+
+    let transport = getNetTransport("threaded").valueOr:
+      raiseAssert "no transport: " & error
+
+    let answer =
+      await transport.submit("pingPeer", %*{"peerId": "x"}, chronos.seconds(5))
+
+    joinThread(worker)
+
+    check:
+      answer.isOk()
+      answer.get(){"late"}.getBool()
+
+  asyncTest "an op with no answer times out":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitNever)
+    check registerNetBackend("silent", addr table, nil) == 0
+
+    let transport = getNetTransport("silent").valueOr:
+      raiseAssert "no transport: " & error
+
+    let answer =
+      await transport.submit("dial", %*{"peerId": "x"}, chronos.milliseconds(200))
+
+    check:
+      answer.isErr()
+      answer.error.contains("timed out")
+
+  test "a name is kept whole up to the length limit":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitInline)
+
+    check:
+      registerNetBackend(cstring(LongestName), addr table, nil) == 0
+      registerNetBackend(cstring(TooLongName), addr table, nil) != 0
+      getNetTransport(LongestName).isOk()
+      getNetTransport(TooLongName).isErr()
+
+  asyncTest "an answer nobody waits for does not wedge the drain":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitInline)
+    check registerNetBackend("inline", addr table, nil) == 0
+
+    let transport = getNetTransport("inline").valueOr:
+      raiseAssert "no transport: " & error
+
+    let stray = "{}"
+    check netBackendRespond(
+      high(uint64), true, cast[pointer](cstring(stray)), stray.len
+    ) == 0
+
+    let answer =
+      await transport.submit("getNodeInfo", %*{"field": "PeerId"}, chronos.seconds(5))
+
+    check answer.isOk()


### PR DESCRIPTION
## Stack

Each PR targets the branch below it, so review and merge in order.

1. #4152 — dial through a NetBackend seam
2. #4153 — send Edge requests through the net backend
3. #4154 — a C ABI for registering a net backend
4. #4155 — run the Edge protocols over a registered backend
5. #4156 — create a node that runs on a registered backend

**This is #4154.**

## Description

- `logos-delivery-module` #89 implements the consumer half of this bridge. The library half does not exist: `liblogosdelivery` exports neither symbol, so the module resolves both to null and reports "liblogosdelivery has no net backend ABI".
- This exports both. Nothing here reads a config or builds a node — the transport has no consumer until #4155.
- `submit` runs on the chronos thread and must return at once. `respond` comes from a foreign C++ worker thread and may not touch the Nim heap.
- So a response crosses on shared memory and wakes the library through a `ThreadSignalPtr`, the pattern nim-ffi already uses for its event queue.

## Changes

- `net_transport.nim`: an abstract `submit(op, args, timeout)`. Kept out of `net_bridge.nim` so #4155's tests can drive the backend from a plain switch.
- `net_bridge.nim`: the registry, the shared-memory response queue, and the drain task that completes pending futures. An op with no answer times out and drops its entry.
- `network_bridge_api.nim` and `liblogosdelivery.h`: the two exported symbols, matching `src/net_bridge.h` in the module.

Cross-thread details worth review:

- The response is enqueued and the signal fired under the same lock the drain closes it under.
- The drain has one owner. A second claim is refused, and a drain that dies hands back the claim, the signal and the queue.
- `strlen(name)` is read once. The caller owns that buffer, and a second read could size the copy past the array the first one length-checked.
- `MaxNetBackends` is 8. The contract has no unregister call, so slots are never returned.

## Checks

- 7/7: refused ABI version, null table, unknown name, a name at and over the limit, inline and foreign-thread answers, a stray request id, a timeout.
- `make liblogosdelivery` links, both symbols appear in `nm -D`, and a C caller compiles against the checked-in header and registers a table. That is the call the module fails on today.
