### PR TITLE
feat(net): run the Edge protocols over a registered backend

### DIFF
--- a/logos_delivery/waku/net/bridged_backend.nim
+++ b/logos_delivery/waku/net/bridged_backend.nim
@@ -1,0 +1,343 @@
+## Runs the Edge protocols over a libp2p node another module owns. Every op
+## crosses the process boundary as JSON, so a request/response exchange goes in
+## one crossing and a stream costs one crossing per frame.
+
+{.push raises: [].}
+
+import std/[json, sequtils, strutils]
+import results, chronicles, chronos
+import libp2p/[multiaddress, peerid]
+import libp2p/protocols/protocol
+import libp2p/stream/connection
+import ../common/base64, ./net_backend, ./net_transport
+
+logScope:
+  topics = "waku bridged backend"
+
+const
+  AcceptPollTimeout = chronos.seconds(10)
+  PollRetryDelay = chronos.milliseconds(250)
+  OpSlack = chronos.seconds(5)
+  FramesOnly = "a bridged stream carries whole frames only"
+
+type
+  InboundProtocol = object
+    proto: string
+    handler: LPProtoHandler
+
+  BridgedNetBackend* = ref object of NetBackend
+    transport: NetTransport
+    inbound: seq[InboundProtocol]
+    acceptFuts: seq[Future[void]]
+    running: bool
+
+  BridgedConnection* = ref object of Connection
+    transport: NetTransport
+    streamId*: uint64
+
+func new*(T: type BridgedNetBackend, transport: NetTransport): T =
+  BridgedNetBackend(transport: transport)
+
+proc streamIdOf(node: JsonNode): Opt[uint64] =
+  if node.isNil():
+    return Opt.none(uint64)
+
+  case node.kind
+  of JInt:
+    Opt.some(uint64(node.getBiggestInt()))
+  of JString:
+    try:
+      Opt.some(uint64(parseBiggestUInt(node.getStr())))
+    except ValueError:
+      Opt.none(uint64)
+  else:
+    Opt.none(uint64)
+
+proc fieldStr(node: JsonNode, key: string): string =
+  if node.isNil() or node.kind != JObject:
+    return ""
+
+  let field = node.getOrDefault(key)
+  if field.isNil() or field.kind != JString:
+    return ""
+
+  return field.getStr()
+
+proc bytesOf(node: JsonNode, key: string): Result[seq[byte], string] =
+  let encoded = node.fieldStr(key)
+  if encoded.len == 0:
+    return ok(newSeq[byte]())
+
+  return base64.decode(Base64String(encoded))
+
+proc call(
+    backend: BridgedNetBackend, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  return await backend.transport.submit(op, args, timeout + OpSlack)
+
+proc newBridgedConnection(
+    transport: NetTransport,
+    streamId: uint64,
+    peerId: PeerId,
+    proto: string,
+    dir: Direction,
+): BridgedConnection =
+  let conn = BridgedConnection(transport: transport, streamId: streamId, peerId: peerId)
+  conn.protocol = proto
+  conn.dir = dir
+  conn.transportDir = dir
+  conn.objName = "BridgedConnection"
+  conn.initStream()
+
+  return conn
+
+proc isPollTimeout(error: string): bool =
+  error.contains("timeout") or error.contains("timed out")
+
+proc streamOp(
+    conn: BridgedConnection, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  return await conn.transport.submit(op, args, timeout + OpSlack)
+
+method readLp*(
+    conn: BridgedConnection, maxSize: int
+): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
+  let args = %*{
+    "streamId": conn.streamId,
+    "maxSize": maxSize,
+    "timeoutMs": DefaultConnectionTimeout.milliseconds,
+  }
+
+  while true:
+    let answer = (await conn.streamOp("streamReadLp", args, DefaultConnectionTimeout)).valueOr:
+      if not conn.isClosed and error.isPollTimeout():
+        continue
+      conn.isEof = true
+      raise newException(LPStreamError, error)
+
+    let data = answer.bytesOf("dataB64").valueOr:
+      conn.isEof = true
+      raise newException(LPStreamError, error)
+
+    if data.len > maxSize:
+      conn.isEof = true
+      raise (ref MaxSizeError)(msg: "Message exceeds maximum length")
+
+    conn.activity = true
+
+    return data
+
+proc writeFrame(
+    conn: BridgedConnection, msg: seq[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
+  let args = %*{"streamId": conn.streamId, "dataB64": $base64.encode(msg)}
+
+  discard (await conn.streamOp("streamWriteLp", args, DefaultConnectionTimeout)).valueOr:
+    raise newException(LPStreamError, error)
+
+  conn.activity = true
+
+method writeLp*(
+    conn: BridgedConnection, msg: openArray[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  conn.writeFrame(@msg)
+
+method writeLp*(
+    conn: BridgedConnection, msg: string
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  conn.writeFrame(toSeq(msg.toOpenArrayByte(0, msg.high)))
+
+method write*(
+    conn: BridgedConnection, msg: sink seq[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  let fut = Future[void].Raising([CancelledError, LPStreamError]).init(
+      "bridgedconnection.write"
+    )
+  fut.fail(newException(LPStreamError, FramesOnly))
+
+  return fut
+
+method readOnce*(
+    conn: BridgedConnection, pbytes: pointer, nbytes: int
+): Future[int] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  let fut = Future[int].Raising([CancelledError, LPStreamError]).init(
+      "bridgedconnection.readOnce"
+    )
+  fut.fail(newException(LPStreamError, FramesOnly))
+
+  return fut
+
+method closeImpl*(conn: BridgedConnection): Future[void] {.async: (raises: []).} =
+  let args = %*{"streamId": conn.streamId}
+  discard await conn.streamOp("streamClose", args, DefaultConnectionTimeout)
+  discard await conn.streamOp("streamRelease", args, DefaultConnectionTimeout)
+
+  conn.isEof = true
+
+  await procCall Connection(conn).closeImpl()
+
+method dial*(
+    backend: BridgedNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  if addrs.len > 0:
+    let connectArgs = %*{
+      "peerId": $peerId,
+      "multiaddrs": addrs.mapIt($it),
+      "timeoutMs": timeout.milliseconds,
+    }
+    let connected = await backend.call("connectPeer", connectArgs, timeout)
+    if connected.isErr():
+      trace "Bridged connect failed",
+        peerId = peerId, proto = proto, reason = connected.error
+      return Opt.none(Connection)
+
+  let answer = (
+    await backend.call("dial", %*{"peerId": $peerId, "proto": proto}, timeout)
+  ).valueOr:
+    trace "Bridged dial failed", peerId = peerId, proto = proto, reason = error
+    return Opt.none(Connection)
+
+  let streamId = streamIdOf(answer).valueOr:
+    trace "Bridged dial returned no stream", peerId = peerId, proto = proto
+    return Opt.none(Connection)
+
+  return Opt.some(
+    Connection(
+      newBridgedConnection(backend.transport, streamId, peerId, proto, Direction.Out)
+    )
+  )
+
+proc requestErrorKind(cause: string): NetErrorKind =
+  ## One crossing covers connect, dial, write and read, so only the error prefix tells the stages apart.
+  if cause.contains("dial failed") or cause.contains("connect failed"):
+    NetErrorKind.Dial
+  elif cause.contains("write failed"):
+    NetErrorKind.Write
+  else:
+    NetErrorKind.Read
+
+method request*(
+    backend: BridgedNetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  let args = %*{
+    "peerId": $req.peerId,
+    "proto": req.proto,
+    "multiaddrs": req.addrs.mapIt($it),
+    "requestB64": $base64.encode(req.payload),
+    "timeoutMs": req.timeout.milliseconds,
+    "maxSize": req.maxSize,
+    "expectResponse": req.expectResponse,
+  }
+
+  let answer = (await backend.call("protocolRequest", args, req.timeout)).valueOr:
+    return err(NetError(kind: requestErrorKind(error), cause: error))
+
+  if not req.expectResponse:
+    return ok(newSeq[byte]())
+
+  let data = answer.bytesOf("responseB64").valueOr:
+    return err(NetError(kind: NetErrorKind.Read, cause: error))
+
+  if data.len > req.maxSize:
+    return
+      err(NetError(kind: NetErrorKind.Read, cause: "response exceeds maximum length"))
+
+  return ok(data)
+
+proc serveInbound(
+    handler: LPProtoHandler, conn: Connection, proto: string
+) {.async: (raises: []).} =
+  try:
+    await handler(conn, proto)
+  except CancelledError:
+    discard
+
+  await conn.close()
+
+proc acceptLoop(
+    backend: BridgedNetBackend, entry: InboundProtocol
+) {.async: (raises: []).} =
+  let args = %*{"proto": entry.proto, "timeoutMs": AcceptPollTimeout.milliseconds}
+
+  while backend.running:
+    let answer = (await backend.call("protocolAcceptStream", args, AcceptPollTimeout)).valueOr:
+      ## A poll that saw no stream is the ordinary outcome, so it goes straight
+      ## back in. Anything else backs off and says so.
+      if error.isPollTimeout():
+        continue
+
+      debug "Inbound accept poll failed", proto = entry.proto, reason = error
+
+      try:
+        await sleepAsync(PollRetryDelay)
+      except CancelledError:
+        return
+
+      continue
+
+    let streamId = streamIdOf(answer.getOrDefault("streamId")).valueOr:
+      continue
+
+    let peerId = PeerId.init(answer.fieldStr("peerId")).valueOr:
+      trace "Inbound stream has no usable peer id", proto = entry.proto
+      continue
+
+    let conn = newBridgedConnection(
+      backend.transport, streamId, peerId, entry.proto, Direction.In
+    )
+
+    asyncSpawn serveInbound(entry.handler, Connection(conn), entry.proto)
+
+proc mountOne(
+    backend: BridgedNetBackend, entry: InboundProtocol
+) {.async: (raises: []).} =
+  let mounted = await backend.call("mountProtocol", %*{"proto": entry.proto}, OpSlack)
+  if mounted.isErr():
+    error "failed to mount an inbound protocol on the net backend",
+      proto = entry.proto, error = mounted.error
+    return
+
+  ## A stop can land while the mount op is still crossing, and a loop added
+  ## after that one would never be cancelled by anybody.
+  if not backend.running:
+    return
+
+  backend.acceptFuts.add(backend.acceptLoop(entry))
+
+proc mountInboundProtocols(backend: BridgedNetBackend) {.async: (raises: []).} =
+  for entry in backend.inbound:
+    await backend.mountOne(entry)
+
+method mountInbound*(
+    backend: BridgedNetBackend, proto: string, handler: LPProtoHandler
+) {.gcsafe.} =
+  let entry = InboundProtocol(proto: proto, handler: handler)
+  backend.inbound.add(entry)
+
+  ## Mounted after the node started, so it needs its own loop now: nothing is
+  ## going to walk `inbound` a second time.
+  if backend.running:
+    asyncSpawn backend.mountOne(entry)
+
+method start*(backend: BridgedNetBackend) {.async: (raises: []).} =
+  if backend.running:
+    return
+
+  backend.running = true
+
+  ## Spawned rather than awaited: a backend that never answers `mountProtocol`
+  ## would otherwise hold up the whole node start.
+  asyncSpawn backend.mountInboundProtocols()
+
+method stop*(backend: BridgedNetBackend) {.async: (raises: []).} =
+  backend.running = false
+  let futs = backend.acceptFuts
+  backend.acceptFuts = @[]
+
+  await allFutures(futs.mapIt(cancelAndWait(it)))
+
+{.pop.}

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -4,6 +4,7 @@
 {.push raises: [].}
 
 import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
+import libp2p/protocols/protocol
 
 logScope:
   topics = "waku net backend"
@@ -75,6 +76,18 @@ method connect*(
     backend: NetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
 ): Future[Result[void, string]] {.base, async: (raises: []).} =
   raiseAssert "[NetBackend.connect] abstract method not implemented"
+
+method mountInbound*(
+    backend: NetBackend, proto: string, handler: LPProtoHandler
+) {.base, gcsafe.} =
+  ## A switch dispatches an inbound stream to the mounted protocol on its own.
+  discard
+
+method start*(backend: NetBackend) {.base, async: (raises: []).} =
+  discard
+
+method stop*(backend: NetBackend) {.base, async: (raises: []).} =
+  discard
 
 method request*(
     backend: NetBackend, req: NetRequest

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -620,6 +620,8 @@ proc start*(node: WakuNode) {.async.} =
   ## NOTE: This will dispatch gossipsub start to the WakuRelay.start method override
   await node.switch.start()
 
+  await node.peerManager.netBackend.start()
+
   # Reconnect to known relay peers in the background; it waits a prune backoff
   # and must not block startup.
   node.relayReconnectFut = node.reconnectRelayPeers()
@@ -665,6 +667,7 @@ proc stop*(node: WakuNode) {.async.} =
   ## NOTE: This will dispatch gossipsub stop to the WakuRelay.stop method override
   await node.switch.stop()
 
+  await node.peerManager.netBackend.stop()
   node.peerManager.stop()
 
   if not node.rln.isNil():

--- a/logos_delivery/waku/node/waku_node/filter.nim
+++ b/logos_delivery/waku/node/waku_node/filter.nim
@@ -97,6 +97,10 @@ proc mountFilterClient*(node: WakuNode) {.async: (raises: []).} =
   except LPError:
     error "failed to mount wakuFilterClient", error = getCurrentExceptionMsg()
 
+  node.peerManager.netBackend.mountInbound(
+    WakuFilterPushCodec, node.wakuFilterClient.handler
+  )
+
 proc filterSubscribe*(
     node: WakuNode,
     pubsubTopic: Opt[PubsubTopic],

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -42,7 +42,10 @@ import
   ./waku_store/test_wakunode_store
 
 # Net backend test suite
-import ./waku_net/test_net_backend, ./waku_net/test_net_bridge
+import
+  ./waku_net/test_net_backend,
+  ./waku_net/test_net_bridge,
+  ./waku_net/test_bridged_backend
 
 # Waku store sync suite
 import ./waku_store_sync/test_all

--- a/tests/waku_net/switch_transport.nim
+++ b/tests/waku_net/switch_transport.nim
@@ -1,0 +1,183 @@
+{.used.}
+
+## A net transport that answers the op vocabulary from its own switch.
+
+import std/[json, tables]
+import results, chronos, libp2p/[multiaddress, peerid, switch]
+import libp2p/protocols/protocol
+import logos_delivery/waku/common/base64, logos_delivery/waku/net/net_transport
+
+type SwitchTransport* = ref object of NetTransport
+  switch: Switch
+  streams: Table[uint64, Connection]
+  inbound: Table[string, seq[uint64]]
+  nextStreamId: uint64
+
+func new*(T: type SwitchTransport, switch: Switch): T =
+  SwitchTransport(switch: switch)
+
+proc track(transport: SwitchTransport, conn: Connection): uint64 =
+  inc(transport.nextStreamId)
+  transport.streams[transport.nextStreamId] = conn
+
+  return transport.nextStreamId
+
+proc streamOf(transport: SwitchTransport, args: JsonNode): Result[Connection, string] =
+  let streamId = uint64(args{"streamId"}.getBiggestInt())
+  transport.streams.withValue(streamId, conn):
+    return ok(conn[])
+
+  return err("unknown stream")
+
+proc addrsOf(args: JsonNode): seq[MultiAddress] =
+  var addrs: seq[MultiAddress]
+  for entry in args{"multiaddrs"}.getElems():
+    let address = MultiAddress.init(entry.getStr())
+    if address.isOk():
+      addrs.add(address.get())
+
+  return addrs
+
+proc dialStream(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[uint64, string]] {.async: (raises: []).} =
+  let peerId = PeerId.init(args{"peerId"}.getStr()).valueOr:
+    return err("bad peer id")
+
+  let addrs = addrsOf(args)
+
+  let conn =
+    try:
+      if addrs.len > 0:
+        await transport.switch.dial(peerId, addrs, args{"proto"}.getStr())
+      else:
+        await transport.switch.dial(peerId, args{"proto"}.getStr())
+    except CatchableError as e:
+      return err("dial failed: " & e.msg)
+
+  return ok(transport.track(conn))
+
+proc connectPeer(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let peerId = PeerId.init(args{"peerId"}.getStr()).valueOr:
+    return err("bad peer id")
+
+  try:
+    await transport.switch.connect(peerId, addrsOf(args))
+  except CatchableError as e:
+    return err("connect failed: " & e.msg)
+
+  return ok(newJObject())
+
+proc protocolRequest(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let streamId = ?await transport.dialStream(args)
+  let conn = transport.streams.getOrDefault(streamId)
+
+  defer:
+    transport.streams.del(streamId)
+    await conn.closeWithEof()
+
+  let payload = base64.decode(Base64String(args{"requestB64"}.getStr())).valueOr:
+    return err("bad requestB64")
+
+  try:
+    await conn.writeLP(payload)
+  except CatchableError as e:
+    return err("write failed: " & e.msg)
+
+  if not args{"expectResponse"}.getBool(true):
+    return ok(newJObject())
+
+  let response =
+    try:
+      await conn.readLp(int(args{"maxSize"}.getBiggestInt()))
+    except CatchableError as e:
+      return err("read failed: " & e.msg)
+
+  return ok(%*{"responseB64": $base64.encode(response)})
+
+proc mountProtocol(
+    transport: SwitchTransport, proto: string
+): Result[JsonNode, string] =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    let streamId = transport.track(conn)
+    transport.inbound.mgetOrPut(proto, @[]).add(streamId)
+    await conn.join()
+
+  let lp = LPProtocol.new(@[proto], handle)
+
+  try:
+    transport.switch.mount(lp)
+  except LPError as e:
+    return err("mount failed: " & e.msg)
+
+  return ok(newJObject())
+
+proc acceptStream(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let proto = args{"proto"}.getStr()
+  let deadline = Moment.now() + chronos.milliseconds(args{"timeoutMs"}.getBiggestInt())
+
+  while Moment.now() < deadline:
+    var queue = transport.inbound.getOrDefault(proto)
+    if queue.len > 0:
+      let streamId = queue[0]
+      queue.delete(0)
+      transport.inbound[proto] = queue
+      let conn = transport.streams.getOrDefault(streamId)
+
+      return ok(%*{"streamId": streamId, "proto": proto, "peerId": $conn.peerId})
+
+    try:
+      await sleepAsync(chronos.milliseconds(10))
+    except CancelledError:
+      return err("cancelled")
+
+  return err("timeout waiting for inbound stream")
+
+method submit*(
+    transport: SwitchTransport, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  case op
+  of "getNodeInfo":
+    return ok(%($transport.switch.peerInfo.peerId))
+  of "connectPeer":
+    return await transport.connectPeer(args)
+  of "dial":
+    return ok(%(?await transport.dialStream(args)))
+  of "protocolRequest":
+    return await transport.protocolRequest(args)
+  of "mountProtocol":
+    return transport.mountProtocol(args{"proto"}.getStr())
+  of "protocolAcceptStream":
+    return await transport.acceptStream(args)
+  of "streamReadLp":
+    let conn = ?transport.streamOf(args)
+    let data =
+      try:
+        await conn.readLp(int(args{"maxSize"}.getBiggestInt()))
+      except CatchableError as e:
+        return err("read failed: " & e.msg)
+    return ok(%*{"dataB64": $base64.encode(data)})
+  of "streamWriteLp":
+    let conn = ?transport.streamOf(args)
+    let payload = base64.decode(Base64String(args{"dataB64"}.getStr())).valueOr:
+      return err("bad dataB64")
+    try:
+      await conn.writeLP(payload)
+    except CatchableError as e:
+      return err("write failed: " & e.msg)
+    return ok(newJObject())
+  of "streamClose":
+    let conn = ?transport.streamOf(args)
+    await conn.close()
+    return ok(newJObject())
+  of "streamRelease":
+    transport.streams.del(uint64(args{"streamId"}.getBiggestInt()))
+    return ok(newJObject())
+  else:
+    return err("unknown libp2p op: " & op)

--- a/tests/waku_net/test_bridged_backend.nim
+++ b/tests/waku_net/test_bridged_backend.nim
@@ -1,0 +1,198 @@
+{.used.}
+
+import results, testutils/unittests, chronos, libp2p/crypto/crypto
+
+import
+  logos_delivery/waku/[
+    node/peer_manager,
+    net/bridged_backend,
+    waku_core,
+    waku_filter_v2,
+    waku_filter_v2/client,
+    waku_filter_v2/rpc,
+    waku_filter_v2/rpc_codec,
+    waku_store,
+    waku_store/client,
+    waku_store/rpc_codec,
+    common/paging,
+  ],
+  ../testlib/[common, wakucore, testasync],
+  ../waku_store/store_utils,
+  ./switch_transport
+
+suite "Bridged net backend":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var client {.threadvar.}: WakuStoreClient
+  var handlerFuture {.threadvar.}: Future[StoreQueryRequest]
+  var serverPeerInfo {.threadvar.}: RemotePeerInfo
+  var messageSeq {.threadvar.}: seq[WakuMessageKeyValue]
+
+  asyncSetup:
+    let message = fakeWakuMessage(contentTopic = DefaultContentTopic)
+    messageSeq = @[
+      WakuMessageKeyValue(
+        messageHash: computeMessageHash(DefaultPubsubTopic, message),
+        message: Opt.some(message),
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    ]
+
+    handlerFuture = newFuture[StoreQueryRequest]()
+    let handler = proc(
+        req: StoreQueryRequest
+    ): Future[StoreQueryResult] {.async, gcsafe.} =
+      var request = req
+      request.requestId = ""
+      handlerFuture.complete(request)
+      return ok(StoreQueryResponse(messages: messageSeq))
+
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+
+    discard await newTestWakuStore(serverSwitch, handler = handler)
+
+    let peerManager = PeerManager.new(
+      clientSwitch,
+      netBackend = BridgedNetBackend.new(SwitchTransport.new(clientSwitch)),
+    )
+    client = WakuStoreClient.new(peerManager, common.rng())
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+    serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "a store query crosses the bridge":
+    let storeQuery = StoreQueryRequest(
+      pubsubTopic: Opt.some(DefaultPubsubTopic),
+      contentTopics: @[DefaultContentTopic],
+      paginationForward: PagingDirection.FORWARD,
+    )
+
+    let queryResponse = await client.query(storeQuery, peer = serverPeerInfo)
+
+    assert await handlerFuture.withTimeout(chronos.seconds(5))
+    check:
+      handlerFuture.read().contentTopics == @[DefaultContentTopic]
+      queryResponse.get().messages == messageSeq
+
+  asyncTest "a query to an unreachable peer fails to dial":
+    let unreachable = RemotePeerInfo.init(
+      PeerId.init(generateEcdsaKey().getPublicKey().get()).get(),
+      @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").get()],
+    )
+
+    let queryResponse = await client.query(
+      StoreQueryRequest(contentTopics: @[DefaultContentTopic]), peer = unreachable
+    )
+
+    check:
+      queryResponse.isErr()
+      queryResponse.error.kind == ErrorCode.PEER_DIAL_FAILURE
+
+suite "Bridged connection":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var backend {.threadvar.}: BridgedNetBackend
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+    backend = BridgedNetBackend.new(SwitchTransport.new(clientSwitch))
+
+    let handler = proc(
+        req: StoreQueryRequest
+    ): Future[StoreQueryResult] {.async, gcsafe.} =
+      return ok(StoreQueryResponse(statusCode: uint32(StatusCode.SUCCESS)))
+
+    discard await newTestWakuStore(serverSwitch, handler = handler)
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "frames cross a dialled stream":
+    let peer = serverSwitch.peerInfo.toRemotePeerInfo()
+
+    let conn = (
+      await backend.dial(peer.peerId, peer.addrs, WakuStoreCodec, chronos.seconds(5))
+    ).valueOr:
+      raiseAssert "dial over the bridge failed"
+
+    await conn.writeLP(StoreQueryRequest(requestId: "1").encode().buffer)
+    let response = StoreQueryResponse.decode(await conn.readLp(DefaultMaxRpcSize.int))
+
+    await conn.close()
+
+    check:
+      response.isOk()
+      response.get().statusCode == uint32(StatusCode.SUCCESS)
+
+  asyncTest "a raw write is refused":
+    let peer = serverSwitch.peerInfo.toRemotePeerInfo()
+
+    let conn = (
+      await backend.dial(peer.peerId, peer.addrs, WakuStoreCodec, chronos.seconds(5))
+    ).valueOr:
+      raiseAssert "dial over the bridge failed"
+
+    var refused = false
+    try:
+      await conn.write(@[1'u8, 2, 3])
+    except LPStreamError:
+      refused = true
+
+    await conn.close()
+
+    check refused
+
+suite "Bridged inbound streams":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var backend {.threadvar.}: BridgedNetBackend
+  var pushed {.threadvar.}: Future[WakuMessage]
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+    backend = BridgedNetBackend.new(SwitchTransport.new(clientSwitch))
+
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+    let filterClient = WakuFilterClient.new(peerManager, common.rng())
+
+    pushed = newFuture[WakuMessage]()
+    filterClient.registerPushHandler(
+      proc(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe.} =
+        if not pushed.finished():
+          pushed.complete(message)
+    )
+
+    backend.mountInbound(WakuFilterPushCodec, filterClient.handler)
+    await backend.start()
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+  asyncTeardown:
+    await backend.stop()
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "a push reaches the filter client":
+    let message = fakeWakuMessage(contentTopic = DefaultContentTopic)
+    let push = MessagePush(pubsubTopic: DefaultPubsubTopic, wakuMessage: message)
+
+    let conn = await serverSwitch.dial(
+      clientSwitch.peerInfo.peerId, clientSwitch.peerInfo.addrs, WakuFilterPushCodec
+    )
+    await conn.writeLP(push.encode().buffer)
+
+    check await pushed.withTimeout(chronos.seconds(5))
+    check pushed.read() == message
+
+    await conn.close()


### PR DESCRIPTION
## Stack

Each PR targets the branch below it, so review and merge in order.

1. #4152 — dial through a NetBackend seam
2. #4153 — send Edge requests through the net backend
3. #4154 — a C ABI for registering a net backend
4. #4155 — run the Edge protocols over a registered backend
5. #4156 — create a node that runs on a registered backend

**This is #4155.**

## Description

- The backend behind the seam: it answers `dial` and `request` from the ops a registered backend serves.
- Outbound costs one `protocolRequest` crossing.
- Inbound needs its own machinery. Filter v2 push is service-initiated and a bridged node owns no listener, so the codec is mounted on the backend and served from a long poll over `protocolAcceptStream`.
- No config reaches any of this yet. `usesLocalSwitch` and the headless switch are in #4156.

## Changes

- `BridgedNetBackend`: `request` in one crossing, `dial` returning a `BridgedConnection`.
- `BridgedConnection` overrides `readLp` and `writeLp`. Both are methods in libp2p 2.0.0, so every existing caller is reached without being touched.
- `write` and `readOnce` fail deliberately: the op vocabulary carries whole frames, not bytes.
- `closeImpl` sets `isEof`, which is what makes `closeWithEOF` short-circuit rather than attempt a raw read.
- `mountInbound`, plus one poll task per codec. `mountFilterClient` mounts `WakuFilterPushCodec`; `WakuNode.start` and `stop` drive the lifecycle.

From self-review:

- An empty long poll is the ordinary outcome, not a failure. The loop paid a 250 ms backoff for it, which every inbound push then waited on, and retried a genuinely broken backend silently forever at the same rate.
- `NetBackend.start` and `stop` are async. `stop` used to `asyncSpawn` the cancellations and return, so the node tore the switch down with accept loops still mid-op.
- `mountInbound` called after `start` was dropped on the floor.

## Checks

- `switch_transport.nim` answers the whole op vocabulary from a real switch, so the backend is driveable without the C ABI in the picture.
- `test_bridged_backend.nim`: a store query across the bridge, an unreachable peer, frames on a dialled stream, a refused raw `write`, and a real filter push into the client's handler.
- **Not compiled or run.** Treat the test descriptions as intent, not results.
