### PR TITLE
feat(net): create a node that runs on a registered backend

### DIFF
--- a/docs/api/net-backend.md
+++ b/docs/api/net-backend.md
@@ -1,0 +1,73 @@
+# Running the Edge protocols over another module's libp2p node
+
+A node normally owns its libp2p stack. When another module in the same process
+already runs a libp2p node, that module can register a *net backend* with
+`liblogosdelivery`, and a node created with `"libp2pProvider": "<name>"` then
+runs its Edge protocols over that node. The process then holds one identity and
+one socket set.
+
+```json
+{
+  "mode": "Edge",
+  "preset": "logos.test",
+  "kernelConf": { "nodekey": "<hex private key>" },
+  "libp2pProvider": "libp2p_module"
+}
+```
+
+Both sides must hold the same private key, or the two peer IDs diverge.
+
+## C ABI
+
+`library/liblogosdelivery.h` declares both symbols. The ABI version is 1.
+
+```c
+int logosdelivery_register_net_backend(const char *name,
+                                       const LogosDeliveryNetBackendTable *table,
+                                       void *userData);
+int logosdelivery_net_backend_respond(uint64_t requestId, int ok,
+                                      const char *data, size_t len);
+```
+
+Register the backend before you create the node. The library then calls
+`table->submit(requestId, opJson, opLen, userData)` on its own thread with
+`{"op": "<name>", "args": {...}}`. `submit` must return at once, and every
+request must get exactly one `logosdelivery_net_backend_respond`, from any
+thread: `ok != 0` carries the result JSON, `ok == 0` the error text. An op with
+no answer within its timeout fails on the library side and its answer is then
+dropped.
+
+## Ops
+
+| op | args | result |
+| --- | --- | --- |
+| `connectPeer` | `{peerId, multiaddrs, timeoutMs}` | `{}` |
+| `dial` | `{peerId, proto}` | the stream id |
+| `protocolRequest` | `{peerId, proto, multiaddrs, requestB64, timeoutMs, maxSize, expectResponse}` | `{responseB64}` |
+| `mountProtocol` | `{proto}` | `{}` |
+| `protocolAcceptStream` | `{proto, timeoutMs}` | `{streamId, proto, peerId}` |
+| `streamReadLp` | `{streamId, maxSize, timeoutMs}` | `{dataB64}` |
+| `streamWriteLp` | `{streamId, dataB64}` | `{}` |
+| `streamClose` / `streamRelease` | `{streamId}` | `{}` |
+
+A request/response exchange costs one `protocolRequest`. An inbound stream costs
+one `protocolAcceptStream` plus one op per frame, so a long poll holds one worker
+on the backend side for its whole timeout.
+
+## Limits
+
+- Edge protocols only. `createNode` rejects a config that enables relay, because
+  gossipsub needs a real `PubSub` object mounted on a switch.
+- discv5 stays off. It owns a UDP socket and signs with the node key, so
+  `createNode` turns it off and says so in the log. Use entry nodes and peer
+  exchange.
+- The local switch is built but never started, and it serves the peer store
+  alone. That store and the backend's own peer store drift apart: a bridged node
+  answers `getPeersByProtocol` from peers it was told about, not from peers the
+  backend knows. Give a service peer explicitly until the peer store ops exist.
+- The node still advertises the addresses it was configured with, in its ENR and
+  in peer exchange, and nothing listens on them. The backend's own addresses are
+  the reachable ones.
+- A backend restart invalidates every stream id. Create the node again.
+- A bridged stream carries whole length-prefixed frames. A raw `write` or
+  `readOnce` on it fails.

--- a/logos_delivery/api/conf/logos_delivery_conf_json.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf_json.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import std/[json, strutils, tables]
+import std/[json, sequtils, strutils, tables]
 import results
 
 import tools/confutils/conf_from_json
@@ -14,6 +14,7 @@ const
   KeyKernelConf = "kernelconf"
   KeyMessagingOverrides = "messagingoverrides"
   KeyChannelsOverrides = "channelsoverrides"
+  KeyLibp2pProvider = "libp2pprovider"
   # [Legacy flat JSON config] Keys that left the kernel and so must be lifted out of
   # a flat blob before the WakuNodeConf walker sees them (it would reject them).
   KeyReliabilityEnabled = "reliabilityenabled"
@@ -99,15 +100,38 @@ proc parseFlatConf(
     )
   )
 
-proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
-  var node: JsonNode
-  try:
-    node = parseJson(jsonStr)
-  except CatchableError as e:
-    return err("invalid JSON: " & e.msg)
-  if node.kind != JObject:
-    return err("configuration JSON must be an object")
+proc takeLibp2pProvider(node: JsonNode): Result[string, string] =
+  ## The key names a net backend the library owns, so it never reaches the
+  ## kernel field walker under its JSON name. Every spelling of it goes, or the
+  ## one left behind would be rejected as an unknown kernel field.
+  var provider = Opt.none(string)
 
+  for key in toSeq(node.keys):
+    if key.toLowerAscii() != KeyLibp2pProvider:
+      continue
+
+    let value = node.getOrDefault(key)
+    if value.isNil() or value.kind != JString:
+      return err("libp2pProvider must be a string")
+
+    try:
+      node.delete(key)
+    except KeyError:
+      return err("failed to read libp2pProvider")
+
+    provider = Opt.some(value.getStr().strip())
+
+  let name = provider.valueOr:
+    return ok("")
+
+  ## Asking for a backend by no name is a mistake, not a request for the
+  ## node's own libp2p stack. Leave the key out for that.
+  if name.len == 0:
+    return err("libp2pProvider must name a registered net backend")
+
+  return ok(name)
+
+proc parseConfNode(node: JsonNode): ConfResult[LogosDeliveryConf] =
   var top = ?collectJsonFields(node)
 
   var mode = LogosDeliveryMode.Core
@@ -186,5 +210,24 @@ proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
     messagingOverrides = messagingOverrides,
     channelsOverrides = channelsOverrides,
   )
+
+proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
+  var node: JsonNode
+  try:
+    node = parseJson(jsonStr)
+  except CatchableError as e:
+    return err("invalid JSON: " & e.msg)
+  if node.kind != JObject:
+    return err("configuration JSON must be an object")
+
+  let libp2pProvider = ?takeLibp2pProvider(node)
+
+  var conf = ?parseConfNode(node)
+  if libp2pProvider.len > 0:
+    var kernel = WakuNodeConf(conf.kernelConf)
+    kernel.libp2pProvider = libp2pProvider
+    conf.kernelConf = KernelConf(kernel)
+
+  return ok(conf)
 
 {.pop.}

--- a/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
@@ -164,6 +164,7 @@ type WakuConfBuilder* = object
   colocationLimit: Opt[int]
 
   agentString: Opt[string]
+  libp2pProvider: Opt[string]
 
   maxRelayPeers: Opt[int]
   relayShardedPeerManagement: Opt[bool]
@@ -293,6 +294,10 @@ proc withNatStrategy*(b: var WakuConfBuilder, natStrategy: string) =
 
 proc withAgentString*(b: var WakuConfBuilder, agentString: string) =
   b.agentString = Opt.some(agentString)
+
+proc withLibp2pProvider*(b: var WakuConfBuilder, libp2pProvider: string) =
+  if libp2pProvider.len > 0:
+    b.libp2pProvider = Opt.some(libp2pProvider)
 
 proc withColocationLimit*(b: var WakuConfBuilder, colocationLimit: int) =
   b.colocationLimit = Opt.some(colocationLimit)
@@ -834,6 +839,7 @@ proc build*(
     peerStoreCapacity: builder.peerStoreCapacity,
     maxConnections: maxConnections,
     agentString: agentString,
+    libp2pProvider: builder.libp2pProvider,
     colocationLimit: colocationLimit,
     maxRelayPeers: builder.maxRelayPeers,
     relayServiceRatio: builder.relayServiceRatio.get(DefaultRelayServiceRatio),

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -21,6 +21,9 @@ import
   ../waku_enr/sharding,
   ../waku_node,
   ../net/net_config,
+  ../net/net_backend,
+  ../net/bridged_backend,
+  ../net/net_bridge,
   ../waku_core,
   ../waku_core/codecs,
   ../rln,
@@ -55,6 +58,18 @@ proc setupPeerStorage(): Result[Opt[WakuPeerStorage], string] =
   return ok(Opt.some(res))
 
 ## Init waku node instance
+
+proc netBackendFor(conf: WakuConf): Result[NetBackend, string] =
+  ## Nil unless the config names a backend that owns the libp2p node.
+  let provider = conf.libp2pProvider.valueOr:
+    return ok(nil)
+
+  if conf.relay:
+    return err("libp2pProvider serves the Edge protocols only, so relay must be off")
+
+  let transport = ?getNetTransport(provider)
+
+  return ok(BridgedNetBackend.new(transport))
 
 proc initNode(
     conf: WakuConf,
@@ -126,6 +141,14 @@ proc initNode(
     )
   builder.withRateLimit(conf.rateLimit)
   builder.withCircuitRelay(relay)
+
+  let netBackend = ?netBackendFor(conf)
+  if not netBackend.isNil():
+    builder.withNetBackend(netBackend)
+    if conf.discv5Conf.isSome():
+      info "the net backend owns the node key and the sockets, so discv5 stays off",
+        provider = conf.libp2pProvider.get()
+      conf.discv5Conf = Opt.none(Discv5Conf)
 
   let node = ?builder.build().mapErr(
     proc(err: string): string =

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -123,6 +123,7 @@ type WakuConf* {.requiresInit.} = ref object
 
   dnsAddrsNameServers*: seq[IpAddress]
   endpointConf*: EndpointConf
+  libp2pProvider*: Opt[string]
   wakuFlags*: CapabilitiesBitfield
 
   # TODO: could probably make it a `PeerRemoteInfo`

--- a/logos_delivery/waku/net/bridged_backend.nim
+++ b/logos_delivery/waku/net/bridged_backend.nim
@@ -176,6 +176,9 @@ method closeImpl*(conn: BridgedConnection): Future[void] {.async: (raises: []).}
 
   await procCall Connection(conn).closeImpl()
 
+method usesLocalSwitch*(backend: BridgedNetBackend): bool {.gcsafe.} =
+  false
+
 method dial*(
     backend: BridgedNetBackend,
     peerId: PeerId,

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -83,6 +83,11 @@ method mountInbound*(
   ## A switch dispatches an inbound stream to the mounted protocol on its own.
   discard
 
+method usesLocalSwitch*(backend: NetBackend): bool {.base, gcsafe.} =
+  ## False when another process owns the libp2p node, so the local switch
+  ## keeps the peer store alone and never listens.
+  true
+
 method start*(backend: NetBackend) {.base, async: (raises: []).} =
   discard
 

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -618,7 +618,10 @@ proc start*(node: WakuNode) {.async.} =
 
   ## The switch will update addresses after start using the addressMapper
   ## NOTE: This will dispatch gossipsub start to the WakuRelay.start method override
-  await node.switch.start()
+  if node.peerManager.netBackend.usesLocalSwitch():
+    await node.switch.start()
+  else:
+    info "net backend owns the libp2p node, the local switch stays idle"
 
   await node.peerManager.netBackend.start()
 
@@ -665,7 +668,8 @@ proc stop*(node: WakuNode) {.async.} =
     await node.wakuKademlia.stop()
 
   ## NOTE: This will dispatch gossipsub stop to the WakuRelay.stop method override
-  await node.switch.stop()
+  if node.peerManager.netBackend.usesLocalSwitch():
+    await node.switch.stop()
 
   await node.peerManager.netBackend.stop()
   node.peerManager.stop()

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -446,3 +446,32 @@ suite "parseLogosDeliveryConf - flat WakuNodeConf shape (interop compatibility)"
     # not flip to flat; the leftover bare field (relay) then has no structured home and
     # is rejected. Guards against the discriminator silently splitting a mixed object.
     check parseLogosDeliveryConf("""{"messagingOverrides": {}, "relay": true}""").isErr()
+
+suite "parseLogosDeliveryConf - libp2pProvider":
+  test "the provider reaches the kernel conf and leaves the field walker alone":
+    let conf = parseLogosDeliveryConf(
+      """{"mode": "Edge", "libp2pProvider": "libp2p_module"}"""
+    ).valueOr:
+      raiseAssert error
+
+    check WakuNodeConf(conf.kernelConf).libp2pProvider == "libp2p_module"
+
+  test "no provider leaves the node on its own libp2p stack":
+    let conf = parseLogosDeliveryConf("""{"mode": "Edge"}""").valueOr:
+      raiseAssert error
+
+    check WakuNodeConf(conf.kernelConf).libp2pProvider == ""
+
+  test "the key is taken under any spelling":
+    let conf = parseLogosDeliveryConf(
+      """{"mode": "Edge", "LIBP2PPROVIDER": "libp2p_module"}"""
+    ).valueOr:
+      raiseAssert error
+
+    check WakuNodeConf(conf.kernelConf).libp2pProvider == "libp2p_module"
+
+  test "a provider that is not a string is refused":
+    check parseLogosDeliveryConf("""{"libp2pProvider": 7}""").isErr()
+
+  test "a provider with no name is refused":
+    check parseLogosDeliveryConf("""{"libp2pProvider": "   "}""").isErr()

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -202,6 +202,13 @@ type WakuNodeConf* = object
     nodekey* {.desc: "P2P node private key as 64 char hex string.", name: "nodekey".}:
       Opt[PrivateKey]
 
+    libp2pProvider* {.
+      desc:
+        "Name of a registered net backend that owns the libp2p node. Empty runs the node's own libp2p stack.",
+      defaultValue: "",
+      name: "libp2p-provider"
+    .}: string
+
     listenAddress* {.
       defaultValue: defaultListenAddress(),
       desc: "Listening address for LibP2P (and Discovery v5, if enabled) traffic.",
@@ -1046,6 +1053,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
     b.withClusterId(n.clusterId.get())
 
   b.withAgentString(n.agentString)
+  b.withLibp2pProvider(n.libp2pProvider)
 
   if n.nodeKey.isSome():
     b.withNodeKey(n.nodeKey.get())


### PR DESCRIPTION
## Stack

Each PR targets the branch below it, so review and merge in order.

1. #4152 — dial through a NetBackend seam
2. #4153 — send Edge requests through the net backend
3. #4154 — a C ABI for registering a net backend
4. #4155 — run the Edge protocols over a registered backend
5. #4156 — create a node that runs on a registered backend

**This is #4156.**

## Description

- `"libp2pProvider": "<name>"` builds the node on the backend registered under that name instead of on its own libp2p stack.
- The local switch is still built and still serves `peerStore`, but never starts, so the process holds one identity and one socket set.

## Changes

- `libp2pProvider` runs from the JSON config through `WakuNodeConf`, `WakuConfBuilder` and `WakuConf` to `node_factory`, plus a `--libp2p-provider` flag. It is handled ahead of the kernel field walker, which would reject the key.
- `netBackendFor` resolves the name through `getNetTransport`.
- Relay is a hard error: gossipsub needs a real `PubSub` mounted on a switch.
- discv5 turns itself off with a log line: it owns a UDP socket and signs with the node key.
- `usesLocalSwitch` is what `WakuNode.start` and `stop` read.
- `docs/api/net-backend.md`: config shape, ABI, op table, limits.

From self-review:

- The key given under two spellings left one behind for the field walker to reject.
- `"libp2pProvider": ""` was silently treated as no provider. It is refused now.

## Checks

- Five cases in `tests/api/test_conf.nim`.
- **Not compiled or run.**
- No test for `netBackendFor`. The acceptance test the plan asks for — a delivery node and a `libp2p_module` node completing a store query in one process — is not in this series, and is the real gate on it.

## Known gaps

- Peer selection does not go through the dial funnel. `queryToAny` and the filter and lightpush pickers read `switch.peerStore.getPeersByProtocol` directly, a store the backend never writes to, so a bridged node only queries peers it was told about explicitly. The six peerstore ops that would close this exist in `logos-libp2p-module` and are missing from the delivery module's allow-list.
- The node still advertises its configured addresses, in its ENR and through peer exchange, and nothing listens on them.
- A backend restart invalidates every stream id. Create the node again.
