### PR TITLE
test(filter): cover the relay-to-filter bridge over a real gossipsub hop

### DIFF
--- a/tests/node/test_wakunode_filter.nim
+++ b/tests/node/test_wakunode_filter.nim
@@ -143,7 +143,7 @@ suite "Waku Filter - End to End":
     check:
       not await pushHandlerFuture.withTimeout(FUTURE_TIMEOUT)
 
-  asyncTest "Client Node can't receive Push from Server Node, via Relay":
+  asyncTest "Client Node receives no Push when the Server Node is not subscribed to the pubsub topic":
     # Given the server node has Relay enabled
     (await server.mountRelay()).isOkOr:
       assert false, "error mounting relay: " & $error
@@ -280,7 +280,7 @@ suite "Waku Filter - End to End":
       pushedMsgPubsubTopic == pubsubTopic
       pushedMsg == msg
 
-  asyncTest "Filter Client Node can't receive messages after subscribing and restarting, via Relay":
+  asyncTest "Filter Client Node receives no Push after restarting when the Server Node is not subscribed to the pubsub topic":
     (await server.mountRelay()).isOkOr:
       assert false, "error mounting relay: " & $error
 

--- a/tests/node/test_wakunode_filter.nim
+++ b/tests/node/test_wakunode_filter.nim
@@ -22,6 +22,18 @@ import
   ../testlib/[common, wakucore, wakunode, testasync, futures, testutils],
   ../waku_filter_v2/waku_filter_utils
 
+proc waitForTopicPeer(
+    node: WakuNode, topic: PubsubTopic, peer: PeerId, timeout = FUTURE_TIMEOUT_LONG
+) {.async.} =
+  ## Waits until node's gossipsub has learnt that peer subscribes to topic.
+  let deadline = Moment.now() + timeout
+  while Moment.now() < deadline:
+    for p in node.wakuRelay.gossipsub.getOrDefault(topic):
+      if p.peerId == peer:
+        return
+    await sleepAsync(10.milliseconds)
+  raiseAssert $peer & " never announced a subscription to " & topic
+
 proc generateRequestId(rng: crypto.Rng): string =
   var bytes: array[10, byte]
   rng.generate(bytes)
@@ -150,6 +162,53 @@ suite "Waku Filter - End to End":
 
     # Then the message is not sent to the client's filter push handler
     check (not await pushHandlerFuture.withTimeout(FUTURE_TIMEOUT))
+
+  asyncTest "Client Node receives Push for a message the Server Node got via Relay":
+    # Given the server node relays and is subscribed to the pubsub topic
+    (await server.mountRelay()).isOkOr:
+      assert false, "error mounting relay: " & $error
+
+    proc dummyHandler(
+        topic: PubsubTopic, msg: WakuMessage
+    ): Future[void] {.async, gcsafe.} =
+      discard
+
+    server.subscribe((kind: PubsubSub, topic: pubsubTopic), dummyHandler).isOkOr:
+      assert false, "error subscribing to relay: " & $error
+
+    # And a separate publisher node with Relay mounted
+    let
+      publisherKey = generateSecp256k1Key()
+      publisher = newTestWakuNode(publisherKey)
+    await publisher.start()
+    defer:
+      await publisher.stop()
+
+    (await publisher.mountRelay()).isOkOr:
+      assert false, "error mounting relay: " & $error
+
+    # And a valid filter subscription
+    let subscribeResponse = await client.filterSubscribe(
+      Opt.some(pubsubTopic), contentTopicSeq, serverRemotePeerInfo
+    )
+    require:
+      subscribeResponse.isOk()
+      server.wakuFilter.subscriptions.subscribedPeerCount() == 1
+
+    await publisher.connectToNodes(@[serverRemotePeerInfo])
+    await publisher.waitForTopicPeer(pubsubTopic, serverRemotePeerInfo.peerId)
+
+    # When the publisher relays a message to the server
+    let msg = fakeWakuMessage(contentTopic = contentTopic)
+    let publishRes = await publisher.publish(Opt.some(pubsubTopic), msg)
+    assert publishRes.isOk(), $publishRes.error
+    assert publishRes.get() == 1, "publish selected no relay peer"
+
+    # Then the server pushes it to the filter client
+    let pushed = await pushHandlerFuture.waitForResult(FUTURE_TIMEOUT_MEDIUM)
+    check:
+      pushed.isOk()
+      pushed.value() == (pubsubTopic, msg)
 
   asyncTest "Client Node can't subscribe to Server Node without Filter":
     # Given a server node with Relay without Filter


### PR DESCRIPTION
## What

Every positive filter test either calls `filterHandleMessage` directly, or publishes
on the filter server itself — where `triggerSelf` delivers in-process and bypasses the
relay validators (`waku_relay/protocol.nim:608`). No test covered a message that reaches
the filter server **from another node over the wire** and is then pushed to a subscriber.

To be precise about the gap: the relay→filter handoff itself *is* covered, by the Edge
test in `tests/api/test_api_subscription.nim:477`. What was not covered is that handoff
being fed by the receive path — dial, mesh announcement, gossipsub delivery, validators.

## What this adds

A three-node test in `tests/node/test_wakunode_filter.nim`:

```
publisher (relay) --gossipsub--> server (relay + filter) --filter push--> client (filter client only)
```

Plus `waitForTopicPeer`, which polls the gossipsub announcement table rather than the
mesh: `floodPublish = true` with `publishThreshold = -1000` makes that table the publish
set, and the publisher never subscribes to the topic, so it never grafts into the mesh.

Cost: **+1.3 s** on a 46 s suite. Suite goes 12 tests / 11 OK → 13 / 12 OK.
`tests/node/test_all.nim`: 120 tests, 113 OK, 0 FAILED.

Second commit: two neighbouring tests renamed
`"Client Node can't receive Push from Server Node, via Relay"` and its restart variant
mount relay on the server but never subscribe it and give it no relay peers, so
`server.publish` returns `err(NoPeersToPublish)` and the `discard` hides it. A full-suite
log shows exactly three such lines and exactly one successful publish — the new test's.

They verify "a publish that goes nowhere produces no filter push", not "relay-delivered
messages are withheld from filter clients" — which the new test disproves. Left side by
side, the file read as self-contradictory. Renamed to say what they check; making them
non-vacuous (asserting `NoPeersToPublish`) is left as follow-up.