### PR TITLE
revert: pin boringssl v0.0.11 (#4150), which broke dependency resolution

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -72,11 +72,8 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
 requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
-# v0.0.11: pins nim-lsquic's floating "nim-boringssl >= 0.0.4" range. Earlier
-# releases export the bundled BoringSSL symbols from shared libraries, letting
-# a host-process OpenSSL interpose them (issue #4085). Spelled exactly as
-# nim-lsquic spells it: a different spelling makes a second package for the solver.
-requires "https://github.com/vacp2p/nim-boringssl >= 0.0.11"
+# boringssl (v0.0.11, issue #4085) is pinned in nimble.lock only: a requires
+# here, in any spelling, leaves the solver unable to reconcile it with lsquic's.
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -74,8 +74,9 @@ requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
 # v0.0.11: pins nim-lsquic's floating "nim-boringssl >= 0.0.4" range. Earlier
 # releases export the bundled BoringSSL symbols from shared libraries, letting
-# a host-process OpenSSL interpose them (issue #4085).
-requires "https://github.com/vacp2p/nim-boringssl#346429e4cda48e775f2d1eb3ccb8757edf4f3648"
+# a host-process OpenSSL interpose them (issue #4085). By name, not by URL: a URL
+# makes a second package the solver cannot reconcile with lsquic's "boringssl".
+requires "boringssl >= 0.0.11"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -74,9 +74,9 @@ requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
 # v0.0.11: pins nim-lsquic's floating "nim-boringssl >= 0.0.4" range. Earlier
 # releases export the bundled BoringSSL symbols from shared libraries, letting
-# a host-process OpenSSL interpose them (issue #4085). By name, not by URL: a URL
-# makes a second package the solver cannot reconcile with lsquic's "boringssl".
-requires "boringssl >= 0.0.11"
+# a host-process OpenSSL interpose them (issue #4085). Spelled exactly as
+# nim-lsquic spells it: a different spelling makes a second package for the solver.
+requires "https://github.com/vacp2p/nim-boringssl >= 0.0.11"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -72,8 +72,6 @@ requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb
 requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
 requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
-# boringssl (v0.0.11, issue #4085) is pinned in nimble.lock only: a requires
-# here, in any spelling, leaves the solver unable to reconcile it with lsquic's.
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 
@@ -132,9 +130,15 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
       " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
       cBindingsFlags & getMyCPU() & getNimParams() & srcDir & "/" & srcFile
   else:
+    # -Bsymbolic binds the library's references to its own symbols at link
+    # time. Without it, a host process that already loads OpenSSL (e.g.
+    # Node.js) interposes our statically linked BoringSSL functions and data
+    # (ASN1_ITEM tables), and QUIC startup crashes in lsquic setupSSLContext
+    # (issue #4085).
+    let elfFlags = when defined(linux): "--passL:-Wl,-Bsymbolic " else: ""
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
+      elfFlags & cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
   buildLibrary libName & ".dll", folderName,
@@ -190,8 +194,9 @@ proc buildMobileAndroid(srcDir = ".", params = "") =
   if not dirExists outDir:
     mkDir outDir
 
+  # -Bsymbolic: see buildLibrary's dynamic branch (issue #4085).
   exec "nim c" & " --out:" & outDir &
-    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-L" &
+    "/liblogosdelivery.so --threads:on --app:lib --opt:speed --noMain --mm:refc -d:chronicles_sinks=textlines[dynamic] --header -d:chronosEventEngine=epoll --passL:-Wl,-Bsymbolic --passL:-L" &
     outdir & " --passL:-lrln --passL:-llog --cpu:" & cpu & " --nimMainPrefix:liblogosdelivery --os:android -d:androidNDK " & params &
     getNimParams() & " " & srcDir & "/liblogosdelivery.nim"
 

--- a/nimble.lock
+++ b/nimble.lock
@@ -659,15 +659,15 @@
       }
     },
     "boringssl": {
-      "version": "0.0.11",
-      "vcsRevision": "346429e4cda48e775f2d1eb3ccb8757edf4f3648",
+      "version": "0.0.8",
+      "vcsRevision": "e77caabae78fbc9aa5b78a0a521181b077c82571",
       "url": "https://github.com/vacp2p/nim-boringssl",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "49acb43d56a26b30587c9758edb34e3c44b63d8f"
+        "sha1": "2f603bb6d70683393bbb091bf6bd325d9c52be9f"
       }
     },
     "protobuf_serialization": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -292,8 +292,8 @@
 
   boringssl = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "346429e4cda48e775f2d1eb3ccb8757edf4f3648";
-    sha256 = "0x46sdq75zp84qahwh472qr33xw38adrsp41fksh7xwwd6384fl3";
+    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
+    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
     fetchSubmodules = true;
   };
 

--- a/tests/ffi/test_ffi_persistency_lifecycle.nim
+++ b/tests/ffi/test_ffi_persistency_lifecycle.nim
@@ -42,6 +42,8 @@
 ##     --out:build/liblogosdelivery.dylib --app:lib --noMain --threads:on \
 ##     --mm:refc --opt:speed --passL:librln_v2.0.2.a --passL:-lm \
 ##     -d:chronicles_log_level=INFO library/liblogosdelivery.nim
+## On Linux add `--passL:-Wl,-Bsymbolic` (as the repo's own Linux target
+## does) so the driver's Nim runtime does not interpose the library's.
 ## Override the location with LIBLOGOSDELIVERY=<path>.
 ##
 ## Not registered in an aggregate -- it needs the shared library built


### PR DESCRIPTION
## Description

`master` has not installed its dependencies since #4150. Every job fails at **Install nimble deps** with `Couldn't find a solution for the packages`, and the bindings repo fails the same way because its gate builds `liblogosdelivery` from `master`.

That step is gated on `hashFiles('nimble.lock', ...)`, so it only runs when the lock changes. It last ran, and passed, on 17829419 (#4135). #4150 is the next commit to touch the lock, and it has failed ever since.

The `requires` #4150 added is not the whole problem. Removing it alone still fails, and so does either alternative spelling:

| `logos_delivery.nimble` | `nimble.lock` | Install nimble deps |
|---|---|---|
| no boringssl requires | 0.0.8 | passed, on 17829419 |
| `...nim-boringssl#346429e4` (#4150) | 0.0.11 | fails |
| `boringssl >= 0.0.11` | 0.0.11 | fails |
| `...nim-boringssl >= 0.0.11` | 0.0.11 | fails |
| no boringssl requires | 0.0.11 | fails |

The solver ends up with two identities for one package — `boringssl`, which the lock keys by name, and `https://github.com/vacp2p/nim-boringssl`, which nim-lsquic requires by URL — and at 0.0.11 it can select neither.

## Changes

1. Reverted #4150.

This puts back the `-Bsymbolic` link flags and boringssl 0.0.8, so #4085 is open again. Worth redoing on top of a lock that resolves.

## Issue

closes #

<details>
<summary>AI-made decisions</summary>

- Went after the `requires` spelling first, on the theory that the URL/name split was new in #4150. Three CI rounds disproved it: the split predates #4150 and is tolerable at 0.0.8, so the lock bump is what actually cannot be satisfied.
- Not reproducible locally: `nimble setup --localdeps --useSystemNim` fails here even on commits CI resolved fine, because this machine is arm64 on Nim 2.2.10 against CI's x86_64 on 2.2.4, and the workflow already notes the locked checksums differ across platforms. Every conclusion above comes from CI runs.
- Reverting restores a lock whose cache entry still exists, so the step goes back to being skipped rather than proven. That is the pre-#4150 status quo, not a fix for the underlying resolve — regenerating the lock with a working `nimble lock`, or getting nim-lsquic to stop requiring boringssl by URL, is the durable fix.
- A one-line `changes` job failure on the first run of this branch was GitHub failing to download `dorny/paths-filter`, not the change; re-ran it.

</details>
