### PR TITLE
fix(build): constrain and verify Nimble dependency setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bump_dependencies.md
+++ b/.github/ISSUE_TEMPLATE/bump_dependencies.md
@@ -12,7 +12,8 @@ assignees: ''
 ### Bumped items
 - [ ] Update nimble dependencies
   1. Edit manually logos_delivery.nimble. For some dependencies, we want to bump versions manually and use a pinned version, f.e., nim-libp2p and all its dependencies.
-  2. Run `nimble lock` (make sure `nimble --version` shows the Nimble version pinned in logos_delivery.nimble)
+  2. Run `nimble lock` (make sure `nimble --version` shows the Nimble version pinned in logos_delivery.nimble). `nimble lock` is the canonical lock writer; `tools/sync-nimble-lock.sh` predates Nimble 0.24 and is legacy
   3. Run `./tools/gen-nix-deps.sh nimble.lock nix/deps.nix` to update nix deps
+  4. Build: the audit (scripts/audit_deps.nims) must report that every installed package matches nimble.lock
 
 - [ ] Update vendor/zerokit dependency.

--- a/.github/actions/nimble-deps/action.yml
+++ b/.github/actions/nimble-deps/action.yml
@@ -1,0 +1,74 @@
+name: 'Install nimble deps'
+description: >
+  Installs the pinned Nimble, generates the requires string, restores the
+  nimbledeps cache unless disabled, and runs the Makefile rules that
+  materialize and audit the dependencies from nimble.lock.
+
+inputs:
+  nimble-version:
+    description: 'The Nimble version to install (RequiredNimbleVersion).'
+    required: true
+  nim-version:
+    description: 'The Nim version on PATH. A cache key component: the compiler builds the cached native libraries.'
+    required: true
+  cache:
+    description: 'Restore and save the nimbledeps cache. Set "false" to disable.'
+    default: 'true'
+  make-args:
+    description: 'Extra arguments for the C library rebuild make calls.'
+    default: ''
+  extra-path:
+    description: 'A PATH prefix for the steps of this action.'
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nimble ${{ inputs.nimble-version }}
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.extra-path }}" ]; then
+          export PATH="${{ inputs.extra-path }}:$PATH"
+        fi
+        scripts/install_nimble.sh "${{ inputs.nimble-version }}"
+        echo "$HOME/.nimble/bin" >> $GITHUB_PATH
+        echo "$HOME/.local/nimble-${{ inputs.nimble-version }}/bin" >> $GITHUB_PATH
+
+    - name: Generate requires string
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.extra-path }}" ]; then
+          export PATH="${{ inputs.extra-path }}:$PATH"
+        fi
+        make requires.generated
+
+    - name: Cache nimble deps
+      id: cache
+      if: ${{ inputs.cache != 'false' }}
+      uses: actions/cache@v3
+      with:
+        path: |
+          nimbledeps/
+          nimble.paths
+        key: ${{ runner.os }}-${{ runner.arch }}-nimbledeps-v5-nim${{ inputs.nim-version }}-nimble${{ inputs.nimble-version }}-${{ hashFiles('requires.generated', 'nimble.lock', 'logos_delivery.nimble', 'BearSSL.mk', 'Nat.mk') }}
+
+    - name: Install nimble deps
+      shell: bash
+      # No cache condition: the cache is an accelerator and decides
+      # nothing. The Makefile owns materialization and auditing. On a
+      # cache hit its setup rule runs once against the restored packages,
+      # constrained by the same requires string, and the audits bracket
+      # the result.
+      run: |
+        if [ -n "${{ inputs.extra-path }}" ]; then
+          export PATH="${{ inputs.extra-path }}:$PATH"
+        fi
+        make build-deps ${{ inputs.make-args }}
+
+    - name: Audit installed deps
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.extra-path }}" ]; then
+          export PATH="${{ inputs.extra-path }}:$PATH"
+        fi
+        make audit-deps

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -11,9 +11,29 @@ env:
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
   NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 jobs:
+  deps-freshness:
+    name: "nix/deps.nix freshness"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+
+      - name: Regenerate nix/deps.nix and compare
+        run: |
+          # The generator reads repository revisions from nimble.lock; it
+          # does not select newer package versions or follow current release
+          # tags. The diff detects differences between the generated Nix
+          # expressions and the committed file. Unfetchable revisions,
+          # generator failures, and tool or environment incompatibilities
+          # also fail this step.
+          nix-shell -p nix-prefetch-git --run './tools/gen-nix-deps.sh nimble.lock /tmp/deps.nix.fresh'
+          diff /tmp/deps.nix.fresh nix/deps.nix
+
   build:
     strategy:
       fail-fast: false
@@ -34,11 +54,6 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-        run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
       - name: Get submodules hash
         id: submodules
         run: |
@@ -52,28 +67,17 @@ jobs:
             .git/modules
           key: ${{ runner.os }}-vendor-modules-${{ steps.submodules.outputs.hash }}
 
-      - name: Cache nimble deps
-        id: cache-nimbledeps
-        uses: actions/cache@v3
-        with:
-          path: |
-            nimbledeps/
-            nimble.paths
-          key: ${{ runner.os }}-nimbledeps-v2-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
-
       - name: Install nimble deps
-        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
-        run: |
-          # nim's source tree checksums differently across platforms, so its
-          # locked checksum is unreliable. --useSystemNim uses the CI nim and
-          # skips that check, while still verifying every other locked dep.
-          nimble setup --localdeps -y --useSystemNim
-          make rebuild-nat-libs-nimbledeps
-          make rebuild-bearssl-nimbledeps
-          touch nimbledeps/.nimble-setup
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
 
       - name: Build binaries
         run: make V=1 examples tools
+
+      - name: Audit installed deps
+        run: make audit-deps
 
       - name: Notify Discord
         if: always()

--- a/.github/workflows/ci-rln-simulator.yml
+++ b/.github/workflows/ci-rln-simulator.yml
@@ -53,7 +53,7 @@ env:
   NPROC: 2
   MAKEFLAGS: "-j2"
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 jobs:
   rln-e2e:
@@ -122,33 +122,20 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-        run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
-      - name: Cache nimble deps
-        id: cache-nimbledeps
-        uses: actions/cache@v3
-        with:
-          path: |
-            nimbledeps/
-            nimble.paths
-          key: ${{ runner.os }}-nimbledeps-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
-
       - name: Install nimble deps
-        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
-        run: |
-          nimble setup --localdeps -y
-          make rebuild-nat-libs-nimbledeps
-          make rebuild-bearssl-nimbledeps
-          touch nimbledeps/.nimble-setup
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
 
       - name: Build wakunode2
         run: |
           make -j${NPROC} V=1 POSTGRES=1 \
             NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" \
             wakunode2
+
+      - name: Audit installed deps
+        run: make audit-deps
 
       - name: Build local Docker image
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
   NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 jobs:
   changes: # changes detection
@@ -33,6 +33,10 @@ jobs:
         filters: |
           common:
           - '.github/workflows/**'
+          - '.github/actions/**'
+          - 'BearSSL.mk'
+          - 'Nat.mk'
+          - 'nix/**'
           - 'nimble.lock'
           - 'logos_delivery.nimble'
           - 'Makefile'
@@ -76,30 +80,11 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-        run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
-      - name: Cache nimble deps
-        id: cache-nimbledeps
-        uses: actions/cache@v3
-        with:
-          path: |
-            nimbledeps/
-            nimble.paths
-          key: ${{ runner.os }}-nimbledeps-v2-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
-
       - name: Install nimble deps
-        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
-        run: |
-          # nim's source tree checksums differently across platforms, so its
-          # locked checksum is unreliable. --useSystemNim uses the CI nim and
-          # skips that check, while still verifying every other locked dep.
-          nimble setup --localdeps -y --useSystemNim
-          make rebuild-nat-libs-nimbledeps
-          make rebuild-bearssl-nimbledeps
-          touch nimbledeps/.nimble-setup
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
 
       - name: Build binaries
         # -j1: `all` builds wakunode2 and liblogosdelivery, each via `nimble
@@ -110,6 +95,9 @@ jobs:
         # own --parallelBuild still parallelizes compilation. Mirrors the test
         # job, which already forces -j1.
         run: make V=1 -j1 all
+
+      - name: Audit installed deps
+        run: make audit-deps
 
       # Publish the freshly built shared library so the interop-tests workflow
       # can run the wrapper suite against it without rebuilding. Only the Linux
@@ -150,30 +138,11 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-        run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
-      - name: Cache nimble deps
-        id: cache-nimbledeps
-        uses: actions/cache@v3
-        with:
-          path: |
-            nimbledeps/
-            nimble.paths
-          key: ${{ runner.os }}-nimbledeps-v2-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
-
       - name: Install nimble deps
-        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
-        run: |
-          # nim's source tree checksums differently across platforms, so its
-          # locked checksum is unreliable. --useSystemNim uses the CI nim and
-          # skips that check, while still verifying every other locked dep.
-          nimble setup --localdeps -y --useSystemNim
-          make rebuild-nat-libs-nimbledeps
-          make rebuild-bearssl-nimbledeps
-          touch nimbledeps/.nimble-setup
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
 
       - name: Run tests
         run: |
@@ -189,6 +158,9 @@ jobs:
 
           make V=1 POSTGRES=$postgres_enabled test
           make V=1 POSTGRES=$postgres_enabled testwakunode2
+
+      - name: Audit installed deps
+        run: make audit-deps
 
   build-docker-image:
     needs: changes
@@ -242,30 +214,11 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-        run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
-      - name: Cache nimble deps
-        id: cache-nimbledeps
-        uses: actions/cache@v3
-        with:
-          path: |
-            nimbledeps/
-            nimble.paths
-          key: ${{ runner.os }}-nimbledeps-v2-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
-
       - name: Install nimble deps
-        if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
-        run: |
-          # nim's source tree checksums differently across platforms, so its
-          # locked checksum is unreliable. --useSystemNim uses the CI nim and
-          # skips that check, while still verifying every other locked dep.
-          nimble setup --localdeps -y --useSystemNim
-          make rebuild-nat-libs-nimbledeps
-          make rebuild-bearssl-nimbledeps
-          touch nimbledeps/.nimble-setup
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
 
       - name: Build nph
         run: |
@@ -278,3 +231,6 @@ jobs:
           echo "using nph at ${NPH}"
           "${NPH}" examples logos_delivery tests tools apps *.@(nim|nims|nimble)
           git diff --exit-code
+
+      - name: Audit installed deps
+        run: make audit-deps

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -20,7 +20,7 @@ env:
   # secp256k1 fails to compile.
   NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 # This workflow should not run for outside contributors
 # If org secrets are not available, we'll avoid building and publishing the docker image and we'll pass the workflow
@@ -59,32 +59,14 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-        if: ${{ steps.secrets.outcome == 'success' }}
-        run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-          echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
-      - name: Cache nimble deps
-        if: ${{ steps.secrets.outcome == 'success' }}
-        id: cache-nimbledeps
-        uses: actions/cache@v3
-        with:
-          path: |
-            nimbledeps/
-            nimble.paths
-          key: ${{ runner.os }}-nimbledeps-nimble${{ env.NIMBLE_VERSION }}-${{ hashFiles('nimble.lock', 'BearSSL.mk', 'Nat.mk') }}
-
       - name: Install nimble deps
-        if: ${{ steps.secrets.outcome == 'success' && steps.cache-nimbledeps.outputs.cache-hit != 'true' }}
-        run: |
-          nimble setup --localdeps -y
-          make rebuild-nat-libs-nimbledeps
-          make rebuild-bearssl-nimbledeps
-          touch nimbledeps/.nimble-setup
+        if: ${{ steps.secrets.outcome == 'success' }}
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
 
       - name: Build binaries
-        id: build
         if: ${{ steps.secrets.outcome == 'success' }}
         # Sequential make invocations: wakunode2 and logosdeliverynode each run
         # via `nimble <task>`. Under a single `make -j` the two nimble
@@ -97,6 +79,14 @@ jobs:
           make -j${NPROC} V=1 POSTGRES=1 NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" wakunode2
           make -j${NPROC} V=1 POSTGRES=1 NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" logosdeliverynode
 
+      - name: Audit installed deps
+        if: ${{ steps.secrets.outcome == 'success' }}
+        run: make audit-deps
+
+      - name: Build and push images
+        id: build
+        if: ${{ steps.secrets.outcome == 'success' }}
+        run: |
           SHORT_REF=$(git rev-parse --short HEAD)
 
           TAG=$([ "${PR_NUMBER}" == "" ] && echo "${SHORT_REF}" || echo "${PR_NUMBER}")

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,7 +18,7 @@ env:
   MAKEFLAGS: "-j${NPROC}"
   NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 jobs:
   tag-name:
@@ -66,8 +66,9 @@ jobs:
 
       - name: Install Nimble ${{ env.NIMBLE_VERSION }}
         run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
+          scripts/install_nimble.sh "${{ env.NIMBLE_VERSION }}"
           echo "$HOME/.nimble/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/nimble-${{ env.NIMBLE_VERSION }}/bin" >> $GITHUB_PATH
 
       - name: prep variables
         id: vars
@@ -89,9 +90,11 @@ jobs:
           # -j1: each target starts one nimble process. Two parallel nimble
           # processes corrupt the shared package metadata (nimblemeta.json).
           make V=1 -j1 CI=false POSTGRES=1 $NODE_BINARIES tools
-
           tar -cvzf ${{steps.vars.outputs.nwaku}} $(printf './build/%s ' $NODE_BINARIES)
           tar -cvzf ${{steps.vars.outputs.nwakutools}} $(printf './build/%s ' $TOOLS_BINARIES)
+
+      - name: Audit installed deps
+        run: make audit-deps
 
       # Each matrix job must use a unique artifact name. With one shared
       # name, download-artifact@v4 keeps only the last upload and the release

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -11,7 +11,7 @@ env:
   NPROC: 2
   NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 jobs:
   # Release gate: the pushed tag MUST exactly match logos_delivery.nimble's version,
@@ -69,8 +69,9 @@ jobs:
 
       - name: Install Nimble ${{ env.NIMBLE_VERSION }}
         run: |
-          cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
+          scripts/install_nimble.sh "${{ env.NIMBLE_VERSION }}"
           echo "$HOME/.nimble/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/nimble-${{ env.NIMBLE_VERSION }}/bin" >> $GITHUB_PATH
 
       - name: Get submodules hash
         id: submodules
@@ -132,6 +133,9 @@ jobs:
 
           make -j${NPROC} POSTGRES=1 CI=false liblogosdelivery
           make -j${NPROC} POSTGRES=1 CI=false STATIC=1 liblogosdelivery
+
+      - name: Audit installed deps
+        run: make audit-deps
 
       - name: Create distributable liblogosdelivery package
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ on:
 env:
   NPROC: 4
   NIM_VERSION: '2.2.4'
-  NIMBLE_VERSION: '0.22.3'
+  NIMBLE_VERSION: '0.24.1'
 
 jobs:
   build:
@@ -92,25 +92,14 @@ jobs:
         nim-version: ${{ env.NIM_VERSION }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install Nimble ${{ env.NIMBLE_VERSION }}
-      run: |
-        export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$PATH"
-        cd /tmp && nimble install "nimble@${{ env.NIMBLE_VERSION }}" -y
-        echo "$HOME/.nimble/bin" >> $GITHUB_PATH
-
     - name: Install nimble deps
-      if: steps.cache-nimbledeps.outputs.cache-hit != 'true'
-      run: |
-        export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$HOME/.nimble/bin:$PATH"
-        # nim's source tree checks out differently per platform (its own
-        # .gitattributes forces line endings), so its locked checksum never
-        # matches on Windows — even with autocrlf disabled. --useSystemNim
-        # uses the CI-installed nim and skips that check, while still
-        # verifying every other locked dependency.
-        nimble setup --localdeps -y --useSystemNim
-        make rebuild-nat-libs-nimbledeps CC=gcc
-        make rebuild-bearssl-nimbledeps CC=gcc
-        touch nimbledeps/.nimble-setup
+      uses: ./.github/actions/nimble-deps
+      with:
+        nimble-version: ${{ env.NIMBLE_VERSION }}
+        nim-version: ${{ env.NIM_VERSION }}
+        cache: 'false'
+        extra-path: ${{ github.workspace }}/.nim_runtime/bin
+        make-args: CC=gcc
 
     - name: Creating tmp directory
       run: mkdir -p tmp
@@ -129,6 +118,9 @@ jobs:
       run: |
         export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$HOME/.nimble/bin:$PATH"
         make liblogosdelivery STATIC=0 V=1 -j
+
+    - name: Audit installed deps
+      run: make audit-deps
 
     - name: Check Executable
       run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -120,7 +120,9 @@ jobs:
         make liblogosdelivery STATIC=0 V=1 -j
 
     - name: Audit installed deps
-      run: make audit-deps
+      run: |
+        export PATH="$GITHUB_WORKSPACE/.nim_runtime/bin:$PATH"
+        make audit-deps
 
     - name: Check Executable
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ __pycache__/
 
 # Emitted by genBindings() during the liblogosdelivery build.
 library/generated/
+requires.generated
+observed.generated

--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,6 @@ NPH := $(HOME)/.nimble/bin/nph
 
 NIMBLE := nimble
 
-# Nimble 0.24.1 custom tasks perform dependency solving. Global options
-# placed after the task name are parsed by Nimble (parseFlag/actionCustom,
-# src/nimblepkg/options.nim:895). Because nimble.lock has no `nim` entry,
-# --useSystemNim tells those solves to use the compiler on PATH instead of
-# installing another compatible Nim package into nimbledeps/. Task
-# solves receive the same --requires string as setup; the post-task
-# audit verifies the installed revisions. The variable is recursively
-# expanded: the file is read when a task runs, after the setup rule
-# wrote it.
-# Every target that runs a task depends on build-deps, so make wrote
-# requires.generated before any task reads it.
 NIMBLE_TASK_FLAGS = --useSystemNim --requires "$$(cat requires.generated)"
 
 NIMBLEDEPS_STAMP := nimbledeps/.nimble-setup

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,33 @@ ifneq (,$(findstring MINGW,$(detected_OS)))
   detected_OS := Windows
 endif
 
-# Ensure the nim/nimble installed by install-nim/install-nimble are found first
-export PATH := $(HOME)/.nimble/bin:$(PATH)
+REQUIRED_NIMBLE_VERSION := $(shell grep -E '^const RequiredNimbleVersion\s*=' logos_delivery.nimble | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"')
+
+# Put the version-specific Nimble directory before ~/.nimble/bin.
+# `nimble setup` may update package links under ~/.nimble/bin, including
+# the `nimble` link. The version-specific directory is outside that update
+# path. Keep ~/.nimble/bin later on PATH for tools such as nph.
+NIMBLE_TOOLDIR := $(HOME)/.local/nimble-$(REQUIRED_NIMBLE_VERSION)/bin
+export PATH := $(NIMBLE_TOOLDIR):$(HOME)/.nimble/bin:$(PATH)
 
 # NIM binary location
 NIM_BINARY := $(shell which nim 2>/dev/null)
 NPH := $(HOME)/.nimble/bin/nph
 
 NIMBLE := nimble
-ifeq ($(detected_OS),Windows)
-# Resolve nimble via PATH (Windows has no $(HOME)/.nimble/bin); --useSystemNim
-# reuses the nim on PATH so nimble never re-clones the locked nim.
-	NIMBLE := nimble --useSystemNim
-endif
+
+# Nimble 0.24.1 custom tasks perform dependency solving. Global options
+# placed after the task name are parsed by Nimble (parseFlag/actionCustom,
+# src/nimblepkg/options.nim:895). Because nimble.lock has no `nim` entry,
+# --useSystemNim tells those solves to use the compiler on PATH instead of
+# installing another compatible Nim package into nimbledeps/. Task
+# solves receive the same --requires string as setup; the post-task
+# audit verifies the installed revisions. The variable is recursively
+# expanded: the file is read when a task runs, after the setup rule
+# wrote it.
+# Every target that runs a task depends on build-deps, so make wrote
+# requires.generated before any task reads it.
+NIMBLE_TASK_FLAGS = --useSystemNim --requires "$$(cat requires.generated)"
 
 NIMBLEDEPS_STAMP := nimbledeps/.nimble-setup
 
@@ -78,9 +92,45 @@ endif
 logos_delivery.nims:
 	ln -s logos_delivery.nimble $@
 
-$(NIMBLEDEPS_STAMP): nimble.lock | install-nimble build-nph logos_delivery.nims
-	$(NIMBLE) setup --localdeps
+# Generate supplemental requirements for `nimble setup` from:
+# - package versions and revisions recorded in nimble.lock;
+# - URLs already declared in logos_delivery.nimble, which are omitted from
+#   the generated string to avoid adding a second constraint; and
+# - registry URL and version-tag refs observed by the generator.
+#
+# When the registry URL and version tag both match the lock entry, the
+# generator emits "name == version" (e.g. chronos == 4.2.4). Otherwise it
+# emits "url#revision" (e.g. nim-secp256k1: no usable version tag).
+# Nimble 0.24.1 can still discard a URL revision when it merges competing
+# requirements for the same package. The audit after setup detects that
+# case.
+#
+# This ignored file is regenerated when absent or older than a listed
+# prerequisite. `make clean` removes it. CI invokes the generator directly
+# on every dependency-setup run.
+requires.generated: nimble.lock logos_delivery.nimble nix/deps.nix scripts/gen_requires.nims | install-nimble
+	nim e --hints:off scripts/gen_requires.nims
+
+$(NIMBLEDEPS_STAMP): requires.generated logos_delivery.nimble | install-nimble build-nph logos_delivery.nims
+	# Options come after the command: Nimble reads pre-command options on
+	# custom tasks as compilation options. --useSystemNim uses the Nim
+	# compiler on PATH and omits Nim from the local dependency installation.
+	# Custom task invocations use the same option through NIMBLE_TASK_FLAGS.
+	$(NIMBLE) setup --localdeps -y --useSystemNim --requires "$$(cat requires.generated)"
+
+	$(MAKE) audit-deps
+
 	touch $@
+
+# Compare the installed package set and vcsRevision metadata with
+# nimble.lock. This detects the observed Nimble 0.24.1 case where a
+# solve exits successfully after selecting a different special revision.
+# The setup rule runs it after `nimble setup`, and CI runs it again after
+# the build and test steps, because custom tasks also solve and can
+# install. See scripts/audit_deps.nims for the matching rules.
+.PHONY: audit-deps
+audit-deps:
+	nim e --hints:off scripts/audit_deps.nims
 
 # Must be phony so the recipe always runs and the sub-make re-evaluates
 # BEARSSL_NIMBLEDEPS_DIR / NAT_TRAVERSAL_NIMBLEDEPS_DIR (parse-time variables)
@@ -90,6 +140,7 @@ build-deps: | $(NIMBLEDEPS_STAMP)
 	$(MAKE) rebuild-bearssl-nimbledeps rebuild-nat-libs-nimbledeps
 
 clean:
+	rm -f requires.generated observed.generated 2> /dev/null || true
 	rm -rf build 2> /dev/null || true
 	rm -rf nimbledeps 2> /dev/null || true
 	rm -fr nimcache 2> /dev/null || true
@@ -97,7 +148,6 @@ clean:
 	nimble clean
 
 REQUIRED_NIM_VERSION    := $(shell grep -E '^const RequiredNimVersion\s*=' logos_delivery.nimble | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"')
-REQUIRED_NIMBLE_VERSION := $(shell grep -E '^const RequiredNimbleVersion\s*=' logos_delivery.nimble | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"')
 
 install-nim:
 ifneq ($(detected_OS),Windows)
@@ -214,7 +264,7 @@ clean: | clean-librln
 
 testcommon: | build-deps build
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) testcommon
+		$(NIMBLE) testcommon $(NIMBLE_TASK_FLAGS)
 
 ##########
 ## Waku ##
@@ -223,7 +273,7 @@ testcommon: | build-deps build
 
 testwaku: | build-deps build rln-deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) test
+		$(NIMBLE) test $(NIMBLE_TASK_FLAGS)
 
 # Windows: build with nim directly — `nimble <task>` re-clones git deps every
 # build and they intermittently hang on the MSYS2 runner. Flags mirror logos_delivery.nimble.
@@ -233,7 +283,7 @@ ifeq ($(detected_OS),Windows)
 		nim c --out:build/wakunode2 --mm:refc --cpu:amd64 $(NIM_PARAMS) -d:chronicles_log_level=TRACE apps/wakunode2/wakunode2.nim
 else
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) wakunode2
+		$(NIMBLE) wakunode2 $(NIMBLE_TASK_FLAGS)
 endif
 
 # Windows: build with nim directly — `nimble <task>` re-clones git deps every
@@ -244,44 +294,44 @@ ifeq ($(detected_OS),Windows)
 		nim c --out:build/logosdeliverynode --mm:refc --cpu:amd64 $(NIM_PARAMS) -d:chronicles_log_level=TRACE apps/logos_delivery_node/logosdeliverynode.nim
 else
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) logosdeliverynode
+		$(NIMBLE) logosdeliverynode $(NIMBLE_TASK_FLAGS)
 endif
 
 benchmarks: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) benchmarks
+		$(NIMBLE) benchmarks $(NIMBLE_TASK_FLAGS)
 
 testwakunode2: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) testwakunode2
+		$(NIMBLE) testwakunode2 $(NIMBLE_TASK_FLAGS)
 
 example2: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) example2
+		$(NIMBLE) example2 $(NIMBLE_TASK_FLAGS)
 
 chat2: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) chat2
+		$(NIMBLE) chat2 $(NIMBLE_TASK_FLAGS)
 
 chat2mix: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) chat2mix
+		$(NIMBLE) chat2mix $(NIMBLE_TASK_FLAGS)
 
 rln-db-inspector: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) rln_db_inspector
+		$(NIMBLE) rln_db_inspector $(NIMBLE_TASK_FLAGS)
 
 chat2bridge: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) chat2bridge
+		$(NIMBLE) chat2bridge $(NIMBLE_TASK_FLAGS)
 
 liteprotocoltester: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) liteprotocoltester
+		$(NIMBLE) liteprotocoltester $(NIMBLE_TASK_FLAGS)
 
 lightpushwithmix: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) lightpushwithmix
+		$(NIMBLE) lightpushwithmix $(NIMBLE_TASK_FLAGS)
 
 api_example: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
@@ -289,12 +339,12 @@ api_example: | build-deps build deps librln
 
 build/%: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$*" && \
-		$(NIMBLE) buildone $*
+		$(NIMBLE) buildone $* $(NIMBLE_TASK_FLAGS)
 
 compile-test: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "$(TEST_FILE)" "\"$(TEST_NAME)\"" && \
-		$(NIMBLE) buildTest $(TEST_FILE) && \
-		$(NIMBLE) execTest $(TEST_FILE) "\"$(TEST_NAME)\""
+		$(NIMBLE) buildTest $(TEST_FILE) $(NIMBLE_TASK_FLAGS) && \
+		$(NIMBLE) execTest $(TEST_FILE) "\"$(TEST_NAME)\"" $(NIMBLE_TASK_FLAGS)
 
 ################
 ## Waku tools ##
@@ -305,11 +355,11 @@ tools: networkmonitor wakucanary
 
 wakucanary: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) wakucanary
+		$(NIMBLE) wakucanary $(NIMBLE_TASK_FLAGS)
 
 networkmonitor: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) networkmonitor
+		$(NIMBLE) networkmonitor $(NIMBLE_TASK_FLAGS)
 
 ############
 ## Format ##
@@ -353,9 +403,9 @@ clean:
 ###################
 .PHONY: docs coverage
 
-docs: | build deps
+docs: | build-deps build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(NIMBLE) doc --run --index:on --project --out:.gh-pages logos-delivery/logos-delivery.nim logos_delivery.nims
+		$(NIMBLE) doc --run --index:on --project --out:.gh-pages logos-delivery/logos-delivery.nim logos_delivery.nims $(NIMBLE_TASK_FLAGS)
 
 coverage:
 	echo -e $(BUILD_MSG) "build/$@" && \
@@ -470,7 +520,7 @@ liblogosdelivery: | build-deps $(LIBLOGOSDELIVERY_RLN_DEP)
 ifeq ($(detected_OS),Windows)
 	nim c --out:build/liblogosdelivery.dll --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:liblogosdelivery --skipParentCfg:off -d:discv5_protocol_id=d5waku --cpu:amd64 $(NIM_PARAMS) library/liblogosdelivery.nim
 else
-	$(NIMBLE) --verbose liblogosdelivery$(BUILD_COMMAND) logos_delivery.nimble
+	$(NIMBLE) --verbose liblogosdelivery$(BUILD_COMMAND) logos_delivery.nimble $(NIMBLE_TASK_FLAGS)
 endif
 
 logosdelivery_example: | build liblogosdelivery
@@ -546,7 +596,7 @@ endif
 build-liblogosdelivery-for-android-arch:
 ifneq ($(findstring /nix/store,$(LIBRLN_FILE)),)
 	mkdir -p $(CURDIR)/build/android/$(ABIDIR)/
-	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid
+	CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_ARCH=$(ANDROID_ARCH) ANDROID_COMPILER=$(ANDROID_COMPILER) ANDROID_TOOLCHAIN_DIR=$(ANDROID_TOOLCHAIN_DIR) $(NIMBLE) libLogosDeliveryAndroid $(NIMBLE_TASK_FLAGS)
 else
 	./scripts/build_rln_android.sh $(CURDIR)/build $(LIBRLN_BUILDDIR) $(LIBRLN_VERSION) $(CROSS_TARGET) $(ABIDIR)
 endif
@@ -555,25 +605,25 @@ endif
 liblogosdelivery-android-arm64: ANDROID_ARCH=aarch64-linux-android
 liblogosdelivery-android-arm64: CPU=arm64
 liblogosdelivery-android-arm64: ABIDIR=arm64-v8a
-liblogosdelivery-android-arm64: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-arm64: | liblogosdelivery-android-precheck build-deps build deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-amd64: ANDROID_ARCH=x86_64-linux-android
 liblogosdelivery-android-amd64: CPU=amd64
 liblogosdelivery-android-amd64: ABIDIR=x86_64
-liblogosdelivery-android-amd64: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-amd64: | liblogosdelivery-android-precheck build-deps build deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-x86: ANDROID_ARCH=i686-linux-android
 liblogosdelivery-android-x86: CPU=i386
 liblogosdelivery-android-x86: ABIDIR=x86
-liblogosdelivery-android-x86: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-x86: | liblogosdelivery-android-precheck build-deps build deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=$(ANDROID_ARCH) CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android-arm: ANDROID_ARCH=armv7a-linux-androideabi
 liblogosdelivery-android-arm: CPU=arm
 liblogosdelivery-android-arm: ABIDIR=armeabi-v7a
-liblogosdelivery-android-arm: | liblogosdelivery-android-precheck build deps
+liblogosdelivery-android-arm: | liblogosdelivery-android-precheck build-deps build deps
 	$(MAKE) build-liblogosdelivery-for-android-arch ANDROID_ARCH=$(ANDROID_ARCH) CROSS_TARGET=armv7-linux-androideabi CPU=$(CPU) ABIDIR=$(ABIDIR) ANDROID_COMPILER=$(ANDROID_ARCH)$(ANDROID_TARGET)-clang
 
 liblogosdelivery-android:
@@ -603,18 +653,18 @@ else
 endif
 
 build-liblogosdelivery-for-ios-arch:
-	IOS_SDK=$(IOS_SDK) IOS_ARCH=$(IOS_ARCH) IOS_SDK_PATH=$(IOS_SDK_PATH) $(NIMBLE) libLogosDeliveryIOS
+	IOS_SDK=$(IOS_SDK) IOS_ARCH=$(IOS_ARCH) IOS_SDK_PATH=$(IOS_SDK_PATH) $(NIMBLE) libLogosDeliveryIOS $(NIMBLE_TASK_FLAGS)
 
 liblogosdelivery-ios-device: IOS_ARCH=arm64
 liblogosdelivery-ios-device: IOS_SDK=iphoneos
 liblogosdelivery-ios-device: IOS_SDK_PATH=$(call get_ios_sdk_path,iphoneos)
-liblogosdelivery-ios-device: | liblogosdelivery-ios-precheck build deps
+liblogosdelivery-ios-device: | liblogosdelivery-ios-precheck build-deps build deps
 	$(MAKE) build-liblogosdelivery-for-ios-arch IOS_ARCH=$(IOS_ARCH) IOS_SDK=$(IOS_SDK) IOS_SDK_PATH=$(IOS_SDK_PATH)
 
 liblogosdelivery-ios-simulator: IOS_ARCH=arm64
 liblogosdelivery-ios-simulator: IOS_SDK=iphonesimulator
 liblogosdelivery-ios-simulator: IOS_SDK_PATH=$(call get_ios_sdk_path,iphonesimulator)
-liblogosdelivery-ios-simulator: | liblogosdelivery-ios-precheck build deps
+liblogosdelivery-ios-simulator: | liblogosdelivery-ios-precheck build-deps build deps
 	$(MAKE) build-liblogosdelivery-for-ios-arch IOS_ARCH=$(IOS_ARCH) IOS_SDK=$(IOS_SDK) IOS_SDK_PATH=$(IOS_SDK_PATH)
 
 liblogosdelivery-ios:

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,6 @@ logos_delivery.nims:
 # When the registry URL and version tag both match the lock entry, the
 # generator emits "name == version" (e.g. chronos == 4.2.4). Otherwise it
 # emits "url#revision" (e.g. nim-secp256k1: no usable version tag).
-# Nimble 0.24.1 can still discard a URL revision when it merges competing
-# requirements for the same package. The audit after setup detects that
-# case.
 #
 # This ignored file is regenerated when absent or older than a listed
 # prerequisite. `make clean` removes it. CI invokes the generator directly

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -79,8 +79,7 @@ requires "https://github.com/logos-messaging/nim-ffi#07ee8e1d6500762bab290465457
 # No tag at pinning time; revision was 19 commits after v0.3.1-rc.0.
 requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb948b32a4ade1de3b5"
 
-# v3.3.0: https://github.com/NagyZoltanPeter/nim-brokers/releases/tag/v3.3.0
-requires "https://github.com/NagyZoltanPeter/nim-brokers.git#19565dd80621e33f6da396ef3fb07c379d55c324"
+requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
 
 # v0.5.1: https://github.com/vacp2p/nim-lsquic/releases/tag/v0.5.1
 # libp2p requires "lsquic >= 0.4.1" by name. With Nimble 0.24.1, a

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -19,23 +19,6 @@ const RequiredNimbleVersion = "0.24.1"
   ## Enforced nimble version to ensure a reproducible flow
 
 ### Dependencies
-#
-# Dependency declarations use two forms:
-#
-# 1. Name requirements are exported to consumers of this package. Their
-#    ranges describe the versions those consumers may select. nimble.lock
-#    records the exact revisions used by this repository's builds.
-#    scripts/gen_requires.nims derives additional setup constraints from the
-#    lock; those generated constraints are not part of this package metadata.
-#    Exact `== version` requirements in this block are also exported to
-#    consumers, and their reasons are documented inline.
-#
-# 2. URL requirements identify dependencies by repository URL. A commit hash
-#    identifies a revision independently of tag movement, but availability
-#    still depends on the upstream repository retaining that object and
-#    history. For lsquic and boringssl, exact numeric versions are used
-#    because Nimble 0.24.1 has been observed to discard a special `#commit`
-#    constraint when merging it with another package's name-based range.
 requires "nim >= 2.2.4",
   "chronos >= 4.2.0 & < 4.4.0",
   "taskpools",

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -15,10 +15,27 @@ installDirs = @["library", "migrations", "tools"]
 
 const RequiredNimVersion = "2.2.4"
   ## This is the nim compiler version that we are working on. Other versions may behave differently.
-const RequiredNimbleVersion = "0.22.3"
+const RequiredNimbleVersion = "0.24.1"
   ## Enforced nimble version to ensure a reproducible flow
 
 ### Dependencies
+#
+# Dependency declarations use two forms:
+#
+# 1. Name requirements are exported to consumers of this package. Their
+#    ranges describe the versions those consumers may select. nimble.lock
+#    records the exact revisions used by this repository's builds.
+#    scripts/gen_requires.nims derives additional setup constraints from the
+#    lock; those generated constraints are not part of this package metadata.
+#    Exact `== version` requirements in this block are also exported to
+#    consumers, and their reasons are documented inline.
+#
+# 2. URL requirements identify dependencies by repository URL. A commit hash
+#    identifies a revision independently of tag movement, but availability
+#    still depends on the upstream repository retaining that object and
+#    history. For lsquic and boringssl, exact numeric versions are used
+#    because Nimble 0.24.1 has been observed to discard a special `#commit`
+#    constraint when merging it with another package's name-based range.
 requires "nim >= 2.2.4",
   "chronos >= 4.2.0 & < 4.4.0",
   "taskpools",
@@ -31,7 +48,6 @@ requires "nim >= 2.2.4",
   "toml_serialization",
   "faststreams",
   # Networking & P2P
-  "https://github.com/vacp2p/nim-libp2p.git#v2.0.0",
   "eth",
   "nat_traversal",
   "dnsdisc",
@@ -43,7 +59,6 @@ requires "nim >= 2.2.4",
   "secp256k1",
   "bearssl",
   # RPC & APIs
-  "https://github.com/status-im/nim-json-rpc.git#v0.6.1",
   "presto",
   "web3",
   # Database
@@ -62,21 +77,43 @@ requires "nim >= 2.2.4",
   "testutils",
   "unittest2"
 
-# Packages not on nimble (use git URLs)
+# URL requirements described above.
+# For commit-pinned releases, the preceding link records the associated
+# upstream release tag at the time the revision was selected.
 
-# v0.3.1-rc.0
+# v2.0.0: https://github.com/vacp2p/nim-libp2p/releases/tag/v2.0.0
+requires "https://github.com/vacp2p/nim-libp2p.git#c43199378f46d0aaf61be1cad1ee1d63e8f665d6"
+
+# v0.6.1: https://github.com/status-im/nim-json-rpc/releases/tag/v0.6.1
+requires "https://github.com/status-im/nim-json-rpc.git#6f1fff8ba685c9192fab153a9d66484ad9066e78"
+
+# v0.3.1-rc.0: https://github.com/logos-messaging/nim-ffi/releases/tag/v0.3.1-rc.0
 requires "https://github.com/logos-messaging/nim-ffi#07ee8e1d6500762bab290465457a8d23559de546"
 
+# No tag at pinning time; revision was 19 commits after v0.3.1-rc.0.
 requires "https://github.com/logos-messaging/nim-sds.git#b12f5ee07c5b764303b51fb948b32a4ade1de3b5"
 
-requires "https://github.com/NagyZoltanPeter/nim-brokers.git#v3.3.0"
+# v3.3.0: https://github.com/NagyZoltanPeter/nim-brokers/releases/tag/v3.3.0
+requires "https://github.com/NagyZoltanPeter/nim-brokers.git#19565dd80621e33f6da396ef3fb07c379d55c324"
 
-requires "https://github.com/vacp2p/nim-lsquic.git#v0.5.1"
-# v0.0.11: pins nim-lsquic's floating "nim-boringssl >= 0.0.4" range. Earlier
-# releases export the bundled BoringSSL symbols from shared libraries, letting
-# a host-process OpenSSL interpose them (issue #4085).
-requires "https://github.com/vacp2p/nim-boringssl#346429e4cda48e775f2d1eb3ccb8757edf4f3648"
+# v0.5.1: https://github.com/vacp2p/nim-lsquic/releases/tag/v0.5.1
+# libp2p requires "lsquic >= 0.4.1" by name. With Nimble 0.24.1, a
+# `#commit` constraint can be discarded while merging these requirements;
+# the exact numeric constraint was observed to select 0.5.1.
+requires "https://github.com/vacp2p/nim-lsquic.git == 0.5.1"
+
+# v0.0.11: https://github.com/vacp2p/nim-boringssl/releases/tag/v0.0.11
+# nim-lsquic requires "nim-boringssl >= 0.0.4". Releases before 0.0.11
+# export bundled BoringSSL symbols from shared libraries, permitting symbol
+# interposition by a host-process OpenSSL (issue #4085). In the tested
+# Nimble 0.24.1 resolution, combining a special `#commit` constraint with
+# lsquic's range selected v0.0.4; the numeric constraint selects 0.0.11.
+requires "https://github.com/vacp2p/nim-boringssl == 0.0.11"
+
+# No tag at pinning time; revision was one commit after v0.2.0.
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
+
+# No tag was recorded for this revision at pinning time.
 requires "https://github.com/logos-co/nim-libp2p-mix#380513117d556bf8f70066f5e72a7fd74fe36ba6"
 
 proc getMyCPU(): string =

--- a/nimble.lock
+++ b/nimble.lock
@@ -1,91 +1,16 @@
 {
   "version": 2,
   "packages": {
-    "nim": {
-      "version": "2.2.4",
-      "vcsRevision": "911e0dbb1f76de61fa0215ab1bb85af5334cc9a8",
-      "url": "https://github.com/nim-lang/Nim.git",
-      "downloadMethod": "git",
-      "dependencies": [],
-      "checksums": {
-        "sha1": "68bb85cbfb1832ce4db43943911b046c3af3caab"
-      }
-    },
-    "unittest2": {
-      "version": "0.2.5",
-      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
-      "url": "https://github.com/status-im/nim-unittest2",
+    "npeg": {
+      "version": "1.3.0",
+      "vcsRevision": "409f6796d0e880b3f0222c964d1da7de6e450811",
+      "url": "https://github.com/zevv/npeg",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
-      }
-    },
-    "bearssl": {
-      "version": "0.2.8",
-      "vcsRevision": "22c6a76ce015bc07e011562bdcfc51d9446c1e82",
-      "url": "https://github.com/status-im/nim-bearssl",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "da4dd7ae96d536bdaf42dca9c85d7aed024b6a86"
-      }
-    },
-    "bearssl_pkey_decoder": {
-      "version": "#21dd3710df9345ed2ad8bf8f882761e07863b8e0",
-      "vcsRevision": "21dd3710df9345ed2ad8bf8f882761e07863b8e0",
-      "url": "https://github.com/vacp2p/bearssl_pkey_decoder",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "bearssl"
-      ],
-      "checksums": {
-        "sha1": "21b42e2e6ddca6c875d3fc50f36a5115abf51714"
-      }
-    },
-    "jwt": {
-      "version": "#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
-      "vcsRevision": "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
-      "url": "https://github.com/vacp2p/nim-jwt.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "bearssl",
-        "bearssl_pkey_decoder"
-      ],
-      "checksums": {
-        "sha1": "3cd368666fd2bc7f99f253452289e827abcac13c"
-      }
-    },
-    "testutils": {
-      "version": "0.8.1",
-      "vcsRevision": "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d",
-      "url": "https://github.com/status-im/nim-testutils",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "96a11cf8b84fa9bd12d4a553afa1cc4b7f9df4e3"
-      }
-    },
-    "db_connector": {
-      "version": "0.1.0",
-      "vcsRevision": "29450a2063970712422e1ab857695c12d80112a6",
-      "url": "https://github.com/nim-lang/db_connector",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "4f2e67d0e4b61af9ac5575509305660b473f01a4"
+        "sha1": "64f15c85a059c889cb11c5fe72372677c50da621"
       }
     },
     "results": {
@@ -113,9 +38,111 @@
         "sha1": "1a376d3e710590ef2c48748a546369755f0a7c97"
       }
     },
+    "unicodedb": {
+      "version": "0.14.1",
+      "vcsRevision": "b70aac15a3fdc7647997bd6cd10bccd8b2c00e54",
+      "url": "https://github.com/nitely/nim-unicodedb",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "a9dc8cfd3c0546957d1a99d2c6ace8fc5034f330"
+      }
+    },
+    "regex": {
+      "version": "0.26.3",
+      "vcsRevision": "4593305ed1e49731fc75af1dc572dd2559aad19c",
+      "url": "https://github.com/nitely/nim-regex",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unicodedb"
+      ],
+      "checksums": {
+        "sha1": "4d24e7d7441137cd202e16f2359a5807ddbdc31f"
+      }
+    },
+    "boringssl": {
+      "version": "0.0.11",
+      "vcsRevision": "346429e4cda48e775f2d1eb3ccb8757edf4f3648",
+      "url": "https://github.com/vacp2p/nim-boringssl",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "49acb43d56a26b30587c9758edb34e3c44b63d8f"
+      }
+    },
+    "unittest2": {
+      "version": "0.2.5",
+      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
+      "url": "https://github.com/status-im/nim-unittest2.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
+      }
+    },
+    "intops": {
+      "version": "1.0.8",
+      "vcsRevision": "ade5d78d60124d1fd50d2109c5eb9416ed147231",
+      "url": "https://github.com/vacp2p/nim-intops",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "e9371f3fa2356d57fd3a5e516ad68e1e611b7b12"
+      }
+    },
+    "bearssl": {
+      "version": "0.2.13",
+      "vcsRevision": "b6c9a38964a574f6bc51f69efaf8fb2fedea905e",
+      "url": "https://github.com/status-im/nim-bearssl",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "e3a004381e8c2ec0d37bebc2e48b42c34353e9cf"
+      }
+    },
+    "bearssl_pkey_decoder": {
+      "version": "#d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368",
+      "vcsRevision": "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368",
+      "url": "https://github.com/vacp2p/bearssl_pkey_decoder",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "bearssl"
+      ],
+      "checksums": {
+        "sha1": "8666edbcb77cb9f97c659114d57c4ba0e7ab74c3"
+      }
+    },
+    "jwt": {
+      "version": "#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
+      "vcsRevision": "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
+      "url": "https://github.com/vacp2p/nim-jwt.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "bearssl",
+        "bearssl_pkey_decoder"
+      ],
+      "checksums": {
+        "sha1": "3cd368666fd2bc7f99f253452289e827abcac13c"
+      }
+    },
     "stew": {
-      "version": "0.5.0",
-      "vcsRevision": "4382b18f04b3c43c8409bfcd6b62063773b2bbaa",
+      "version": "0.5.2",
+      "vcsRevision": "c75502ceedb5ed2a37b7b5e4744fc71313682859",
       "url": "https://github.com/status-im/nim-stew",
       "downloadMethod": "git",
       "dependencies": [
@@ -124,12 +151,26 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "db22942939773ab7d5a0f2b2668c237240c67dd6"
+        "sha1": "02c533a9a3cae4ef9e3969ca0d85374b254f021a"
+      }
+    },
+    "testutils": {
+      "version": "0.8.3",
+      "vcsRevision": "3feb84e206660d5289caefbe7b0f66f97d9ec084",
+      "url": "https://github.com/status-im/nim-testutils",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "stew",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "2aeb2136828691761eb16c73a050938f53477458"
       }
     },
     "zlib": {
-      "version": "0.1.0",
-      "vcsRevision": "e680f269fb01af2c34a2ba879ff281795a5258fe",
+      "version": "0.2.0",
+      "vcsRevision": "190246aa0bb6569781370964fa2faa474203d6dd",
       "url": "https://github.com/status-im/nim-zlib",
       "downloadMethod": "git",
       "dependencies": [
@@ -138,27 +179,27 @@
         "results"
       ],
       "checksums": {
-        "sha1": "bbde4f5a97a84b450fef7d107461e5f35cf2b47f"
+        "sha1": "a8c0c569d82315f3ffc1249ab42b0404e84fddc3"
       }
     },
     "httputils": {
-      "version": "0.4.1",
-      "vcsRevision": "f142cb2e8bd812dd002a6493b6082827bb248592",
+      "version": "0.5.1",
+      "vcsRevision": "7d771ca337bd3bf563f6834569d2a06085ac21f1",
       "url": "https://github.com/status-im/nim-http-utils",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
-        "stew",
         "results",
+        "stew",
         "unittest2"
       ],
       "checksums": {
-        "sha1": "016774ab31c3afff9a423f7d80584905ee59c570"
+        "sha1": "40d99784345633f5c29df4db9a12cca8a9e6d564"
       }
     },
     "chronos": {
-      "version": "4.2.2",
-      "vcsRevision": "45f43a9ad8bd8bcf5903b42f365c1c879bd54240",
+      "version": "4.2.4",
+      "vcsRevision": "90f543e447f6ade46f028bd7bdf882ae7fcb0ba9",
       "url": "https://github.com/status-im/nim-chronos",
       "downloadMethod": "git",
       "dependencies": [
@@ -170,12 +211,12 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0"
+        "sha1": "2161fffc20d6337784b5cee15a486b50f185e6ce"
       }
     },
     "metrics": {
-      "version": "0.2.1",
-      "vcsRevision": "a1296caf3ebb5f30f51a5feae7749a30df2824c2",
+      "version": "0.2.3",
+      "vcsRevision": "b56bfb8656bd135f0be17d4da95680e86f71e8b4",
       "url": "https://github.com/status-im/nim-metrics",
       "downloadMethod": "git",
       "dependencies": [
@@ -185,12 +226,12 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "84bb09873d7677c06046f391c7b473cd2fcff8a2"
+        "sha1": "f6dc5f12e37410e58a0649515520aee0a73ab0b2"
       }
     },
     "faststreams": {
-      "version": "0.5.0",
-      "vcsRevision": "ce27581a3e881f782f482cb66dc5b07a02bd615e",
+      "version": "0.5.2",
+      "vcsRevision": "059bc2f52546ac14b583639c33372c14b1d46fa3",
       "url": "https://github.com/status-im/nim-faststreams",
       "downloadMethod": "git",
       "dependencies": [
@@ -199,12 +240,12 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "ee61e507b805ae1df7ec936f03f2d101b0d72383"
+        "sha1": "589a9cf07e1d978f460f3da7f8de9b37ac3141af"
       }
     },
     "snappy": {
       "version": "0.1.0",
-      "vcsRevision": "00bfcef94f8ef6981df5d5b994897f6695badfb2",
+      "vcsRevision": "da2f0c7b6ce9053106e9bb098204fe5319038387",
       "url": "https://github.com/status-im/nim-snappy",
       "downloadMethod": "git",
       "dependencies": [
@@ -212,25 +253,43 @@
         "faststreams",
         "unittest2",
         "results",
-        "stew"
+        "stew",
+        "testutils"
       ],
       "checksums": {
-        "sha1": "e572d60d6a3178c5b1cde2400c51ad771812cd3d"
+        "sha1": "d02c6657cc4df57c03ec8b84d0dd74007f6ebd07"
       }
     },
     "serialization": {
-      "version": "0.5.2",
-      "vcsRevision": "b0f2fa32960ea532a184394b0f27be37bd80248b",
+      "version": "0.5.4",
+      "vcsRevision": "b5473564e80a4908cf6c5a038e4c4a6ca7de2223",
       "url": "https://github.com/status-im/nim-serialization",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
         "faststreams",
-        "unittest2",
-        "stew"
+        "stew",
+        "unittest2"
       ],
       "checksums": {
-        "sha1": "fa35c1bb76a0a02a2379fe86eaae0957c7527cb8"
+        "sha1": "6a75be38ab6c8a5d49108a54b494ff70d68ea011"
+      }
+    },
+    "protobuf_serialization": {
+      "version": "0.6.2",
+      "vcsRevision": "a671c6d497c7028ed7390b2d5a80c7b62138c586",
+      "url": "https://github.com/status-im/nim-protobuf-serialization",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "faststreams",
+        "npeg",
+        "serialization",
+        "stew",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "6b4e372946039599559ed1efe14c53bc47c32d02"
       }
     },
     "toml_serialization": {
@@ -249,8 +308,8 @@
       }
     },
     "confutils": {
-      "version": "0.1.0",
-      "vcsRevision": "36f3115ca350f40841ac0eecc7dfa5fe7790c864",
+      "version": "0.1.1",
+      "vcsRevision": "cdbac612f0f3d2883e959807d790658854e73cf2",
       "url": "https://github.com/status-im/nim-confutils",
       "downloadMethod": "git",
       "dependencies": [
@@ -260,7 +319,7 @@
         "results"
       ],
       "checksums": {
-        "sha1": "2fbe6418ddd9f79fb11a0addd7666a3e787adbe0"
+        "sha1": "ed737378087132f9bd1e861e35d8b0dfaa02fd1d"
       }
     },
     "cbor_serialization": {
@@ -279,24 +338,24 @@
       }
     },
     "json_serialization": {
-      "version": "0.4.4",
-      "vcsRevision": "c343b0e243d9e17e2c40f3a8a24340f7c4a71d44",
+      "version": "0.4.5",
+      "vcsRevision": "73c37b46591cf3d6a19d39ff0ed14b2e77433778",
       "url": "https://github.com/status-im/nim-json-serialization",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
         "faststreams",
+        "results",
         "serialization",
-        "stew",
-        "results"
+        "stew"
       ],
       "checksums": {
-        "sha1": "8b3115354104858a0ac9019356fb29720529c2bd"
+        "sha1": "d0c27756fdbdf3a83739ba6c0575234755ad8afc"
       }
     },
     "chronicles": {
-      "version": "0.12.2",
-      "vcsRevision": "27ec507429a4eb81edc20f28292ee8ec420be05b",
+      "version": "0.12.4",
+      "vcsRevision": "45c823b8af409f82fa35fd5e1f6a7c9a06fe3137",
       "url": "https://github.com/status-im/nim-chronicles",
       "downloadMethod": "git",
       "dependencies": [
@@ -307,12 +366,12 @@
         "testutils"
       ],
       "checksums": {
-        "sha1": "02febb20d088120b2836d3306cfa21f434f88f65"
+        "sha1": "fcc95d4ff52d5e4288a6549331c25a299d56f5c0"
       }
     },
     "presto": {
-      "version": "0.1.1",
-      "vcsRevision": "d66043dd7ede146442e6c39720c76a20bde5225f",
+      "version": "0.1.3",
+      "vcsRevision": "e07ae5ddfe6ae17e238a0cd7a366e1ee6886bec0",
       "url": "https://github.com/status-im/nim-presto",
       "downloadMethod": "git",
       "dependencies": [
@@ -324,11 +383,11 @@
         "stew"
       ],
       "checksums": {
-        "sha1": "8df97c45683abe2337bdff43b844c4fbcc124ca2"
+        "sha1": "8cd02129aed4ea1916b84d0a4e25f5572413e744"
       }
     },
     "brokers": {
-      "version": "#v3.3.0",
+      "version": "#19565dd80621e33f6da396ef3fb07c379d55c324",
       "vcsRevision": "19565dd80621e33f6da396ef3fb07c379d55c324",
       "url": "https://github.com/NagyZoltanPeter/nim-brokers.git",
       "downloadMethod": "git",
@@ -345,22 +404,52 @@
       }
     },
     "stint": {
-      "version": "0.8.2",
-      "vcsRevision": "470b7892561b5179ab20bd389a69217d6213fe58",
+      "version": "0.9.0",
+      "vcsRevision": "273fcdfa8dce4ceb975b383ffafe5e79e82766e2",
       "url": "https://github.com/status-im/nim-stint",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
         "stew",
+        "intops",
         "unittest2"
       ],
       "checksums": {
-        "sha1": "d8f871fd617e7857192d4609fe003b48942a8ae5"
+        "sha1": "9b292b0d627e6f6132a01e00f14e0f0527c6704a"
+      }
+    },
+    "taskpools": {
+      "version": "0.2.1",
+      "vcsRevision": "7d96007793fdb2d244d392eb7c5cfa4a695d4ecc",
+      "url": "https://github.com/status-im/nim-taskpools",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "4b113319a3145f22a9e51eaf7f89600f6741b88b"
+      }
+    },
+    "ffi": {
+      "version": "#07ee8e1d6500762bab290465457a8d23559de546",
+      "vcsRevision": "07ee8e1d6500762bab290465457a8d23559de546",
+      "url": "https://github.com/logos-messaging/nim-ffi",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "chronos",
+        "chronicles",
+        "taskpools",
+        "cbor_serialization"
+      ],
+      "checksums": {
+        "sha1": "a6ac9d68f58fa6b695ec77452396b99367f774c8"
       }
     },
     "minilru": {
-      "version": "0.1.0",
-      "vcsRevision": "6dd93feb60f4cded3c05e7af7209cf63fb677893",
+      "version": "0.1.1",
+      "vcsRevision": "6a6929edaf365bf032f00e5cd197d0eeb7a0467e",
       "url": "https://github.com/status-im/nim-minilru",
       "downloadMethod": "git",
       "dependencies": [
@@ -369,19 +458,31 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "0be03a5da29fdd4409ea74a60fd0ccce882601b4"
+        "sha1": "eb07b891e97baae2198822a5e2c24c554cebdfea"
+      }
+    },
+    "db_connector": {
+      "version": "0.1.0",
+      "vcsRevision": "29450a2063970712422e1ab857695c12d80112a6",
+      "url": "https://github.com/nim-lang/db_connector",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim"
+      ],
+      "checksums": {
+        "sha1": "4f2e67d0e4b61af9ac5575509305660b473f01a4"
       }
     },
     "sqlite3_abi": {
-      "version": "3.53.0.0",
-      "vcsRevision": "8240e8e2819dfce1b67fa2733135d01b5cc80ae0",
+      "version": "3.53.4.0",
+      "vcsRevision": "9645cad7f8c6d27a322ef48a60722a3f88f44c27",
       "url": "https://github.com/arnetheduck/nim-sqlite3-abi",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "fb7a6e6f36fc4eb4dfa6634dbcbf5cd0dfd0ebf0"
+        "sha1": "c1fadde68fa0f133289975ebe4838f9690b9e118"
       }
     },
     "dnsclient": {
@@ -396,31 +497,6 @@
         "sha1": "65262c7e533ff49d6aca5539da4bc6c6ce132f40"
       }
     },
-    "unicodedb": {
-      "version": "0.13.2",
-      "vcsRevision": "66f2458710dc641dd4640368f9483c8a0ec70561",
-      "url": "https://github.com/nitely/nim-unicodedb",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "739102d885d99bb4571b1955f5f12aee423c935b"
-      }
-    },
-    "regex": {
-      "version": "0.26.3",
-      "vcsRevision": "4593305ed1e49731fc75af1dc572dd2559aad19c",
-      "url": "https://github.com/nitely/nim-regex",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unicodedb"
-      ],
-      "checksums": {
-        "sha1": "4d24e7d7441137cd202e16f2359a5807ddbdc31f"
-      }
-    },
     "nimcrypto": {
       "version": "0.6.4",
       "vcsRevision": "721fb99ee099b632eb86dfad1f0d96ee87583774",
@@ -431,48 +507,6 @@
       ],
       "checksums": {
         "sha1": "f9ab24fa940ed03d0fb09729a7303feb50b7eaec"
-      }
-    },
-    "websock": {
-      "version": "0.4.0",
-      "vcsRevision": "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d",
-      "url": "https://github.com/status-im/nim-websock",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "chronos",
-        "httputils",
-        "chronicles",
-        "stew",
-        "nimcrypto",
-        "bearssl",
-        "results",
-        "zlib"
-      ],
-      "checksums": {
-        "sha1": "fd17a854686d9a19af40aba51f05d06b82fc30ec"
-      }
-    },
-    "json_rpc": {
-      "version": "0.6.1",
-      "vcsRevision": "6f1fff8ba685c9192fab153a9d66484ad9066e78",
-      "url": "https://github.com/status-im/nim-json-rpc.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "stew",
-        "nimcrypto",
-        "stint",
-        "chronos",
-        "httputils",
-        "chronicles",
-        "websock",
-        "serialization",
-        "json_serialization",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "596db0aafcb3c83f5dba6d42993f2276e0d00eb5"
       }
     },
     "lsquic": {
@@ -494,9 +528,51 @@
         "sha1": "959df1a9ac2a574d6fe30a4faf37c37b443e1cfb"
       }
     },
+    "websock": {
+      "version": "0.4.1",
+      "vcsRevision": "0432dc445c500b20963ef4b76e585c1a3943c254",
+      "url": "https://github.com/status-im/nim-websock",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "chronos",
+        "httputils",
+        "chronicles",
+        "stew",
+        "nimcrypto",
+        "bearssl",
+        "results",
+        "zlib"
+      ],
+      "checksums": {
+        "sha1": "7c240c080f618855411bb0ee3984f6062123bcd4"
+      }
+    },
+    "json_rpc": {
+      "version": "#6f1fff8ba685c9192fab153a9d66484ad9066e78",
+      "vcsRevision": "6f1fff8ba685c9192fab153a9d66484ad9066e78",
+      "url": "https://github.com/status-im/nim-json-rpc.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "stew",
+        "nimcrypto",
+        "stint",
+        "chronos",
+        "httputils",
+        "chronicles",
+        "websock",
+        "serialization",
+        "json_serialization",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "596db0aafcb3c83f5dba6d42993f2276e0d00eb5"
+      }
+    },
     "secp256k1": {
       "version": "0.6.0.3.2",
-      "vcsRevision": "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",
+      "vcsRevision": "f44cff901dff2a24fedcf4ef9e12a6f72355d58f",
       "url": "https://github.com/status-im/nim-secp256k1",
       "downloadMethod": "git",
       "dependencies": [
@@ -506,7 +582,75 @@
         "nimcrypto"
       ],
       "checksums": {
-        "sha1": "6618ef9de17121846a8c1d0317026b0ce8584e10"
+        "sha1": "abfc2c1aa621d4ea8716bafda378d3e24bf8f60e"
+      }
+    },
+    "libp2p": {
+      "version": "#c43199378f46d0aaf61be1cad1ee1d63e8f665d6",
+      "vcsRevision": "c43199378f46d0aaf61be1cad1ee1d63e8f665d6",
+      "url": "https://github.com/vacp2p/nim-libp2p.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "nimcrypto",
+        "dnsclient",
+        "bearssl",
+        "boringssl",
+        "chronicles",
+        "chronos",
+        "metrics",
+        "secp256k1",
+        "stew",
+        "unittest2",
+        "results",
+        "serialization",
+        "lsquic",
+        "protobuf_serialization",
+        "websock",
+        "jwt"
+      ],
+      "checksums": {
+        "sha1": "327dc7a0cb7e9d0be3d6083841bd496c4cbc48dc"
+      }
+    },
+    "sds": {
+      "version": "#b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
+      "vcsRevision": "b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
+      "url": "https://github.com/logos-messaging/nim-sds.git",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "chronos",
+        "libp2p",
+        "chronicles",
+        "stew",
+        "stint",
+        "metrics",
+        "results",
+        "ffi"
+      ],
+      "checksums": {
+        "sha1": "175f65038b9877cdf974b07c5f83081f810d5fbe"
+      }
+    },
+    "libp2p_mix": {
+      "version": "#380513117d556bf8f70066f5e72a7fd74fe36ba6",
+      "vcsRevision": "380513117d556bf8f70066f5e72a7fd74fe36ba6",
+      "url": "https://github.com/logos-co/nim-libp2p-mix",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "libp2p",
+        "chronicles",
+        "chronos",
+        "metrics",
+        "nimcrypto",
+        "stew",
+        "results",
+        "unittest2"
+      ],
+      "checksums": {
+        "sha1": "ccfb0f0160ac15ac970471964c730d57edacad91"
       }
     },
     "eth": {
@@ -561,8 +705,8 @@
       }
     },
     "dnsdisc": {
-      "version": "0.1.0",
-      "vcsRevision": "38f2e0f52c0a8f032ef4530835e519d550706d9e",
+      "version": "0.1.1",
+      "vcsRevision": "6cb1b7e3922645275043c68e476cac1501a45e55",
       "url": "https://github.com/status-im/nim-dnsdisc",
       "downloadMethod": "git",
       "dependencies": [
@@ -579,144 +723,7 @@
         "results"
       ],
       "checksums": {
-        "sha1": "055b882a0f6b1d1e57a25a7af99d2e5ac6268154"
-      }
-    },
-    "libp2p": {
-      "version": "2.0.0",
-      "vcsRevision": "c43199378f46d0aaf61be1cad1ee1d63e8f665d6",
-      "url": "https://github.com/vacp2p/nim-libp2p.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "nimcrypto",
-        "dnsclient",
-        "bearssl",
-        "boringssl",
-        "chronicles",
-        "chronos",
-        "metrics",
-        "secp256k1",
-        "stew",
-        "unittest2",
-        "results",
-        "serialization",
-        "lsquic",
-        "protobuf_serialization",
-        "websock",
-        "jwt"
-      ],
-      "checksums": {
-        "sha1": "327dc7a0cb7e9d0be3d6083841bd496c4cbc48dc"
-      }
-    },
-    "taskpools": {
-      "version": "0.1.0",
-      "vcsRevision": "9e8ccc754631ac55ac2fd495e167e74e86293edb",
-      "url": "https://github.com/status-im/nim-taskpools",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "09e1b2fdad55b973724d61227971afc0df0b7a81"
-      }
-    },
-    "sds": {
-      "version": "#b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
-      "vcsRevision": "b12f5ee07c5b764303b51fb948b32a4ade1de3b5",
-      "url": "https://github.com/logos-messaging/nim-sds.git",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "chronos",
-        "libp2p",
-        "chronicles",
-        "stew",
-        "stint",
-        "metrics",
-        "results",
-        "ffi"
-      ],
-      "checksums": {
-        "sha1": "175f65038b9877cdf974b07c5f83081f810d5fbe"
-      }
-    },
-    "ffi": {
-      "version": "0.3.0",
-      "vcsRevision": "07ee8e1d6500762bab290465457a8d23559de546",
-      "url": "https://github.com/logos-messaging/nim-ffi",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "chronos",
-        "chronicles",
-        "taskpools",
-        "cbor_serialization"
-      ],
-      "checksums": {
-        "sha1": "a6ac9d68f58fa6b695ec77452396b99367f774c8"
-      }
-    },
-    "boringssl": {
-      "version": "0.0.11",
-      "vcsRevision": "346429e4cda48e775f2d1eb3ccb8757edf4f3648",
-      "url": "https://github.com/vacp2p/nim-boringssl",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "49acb43d56a26b30587c9758edb34e3c44b63d8f"
-      }
-    },
-    "protobuf_serialization": {
-      "version": "0.4.0",
-      "vcsRevision": "38d24eb3bd93e605fb88199da71d36b1ec0ad60d",
-      "url": "https://github.com/status-im/nim-protobuf-serialization",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "stew",
-        "faststreams",
-        "serialization",
-        "npeg",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "5a7a80fb8cca29e41899ce9540b74e49c874f8fd"
-      }
-    },
-    "npeg": {
-      "version": "1.3.0",
-      "vcsRevision": "409f6796d0e880b3f0222c964d1da7de6e450811",
-      "url": "https://github.com/zevv/npeg",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim"
-      ],
-      "checksums": {
-        "sha1": "64f15c85a059c889cb11c5fe72372677c50da621"
-      }
-    },
-    "libp2p_mix": {
-      "version": "0.1.0",
-      "vcsRevision": "380513117d556bf8f70066f5e72a7fd74fe36ba6",
-      "url": "https://github.com/logos-co/nim-libp2p-mix",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "libp2p",
-        "chronicles",
-        "chronos",
-        "metrics",
-        "nimcrypto",
-        "stew",
-        "results",
-        "unittest2"
-      ],
-      "checksums": {
-        "sha1": "ccfb0f0160ac15ac970471964c730d57edacad91"
+        "sha1": "6451cab35990f334a46927f49f9176579460934d"
       }
     }
   },

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -3,45 +3,10 @@
 { pkgs }:
 
 {
-  unittest2 = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-unittest2";
-    rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
-    sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
-    fetchSubmodules = true;
-  };
-
-  bearssl = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-bearssl";
-    rev = "22c6a76ce015bc07e011562bdcfc51d9446c1e82";
-    sha256 = "1cvdd7lfrpa6asmc39al3g4py5nqhpqmvypc36r5qyv7p5arc8a3";
-    fetchSubmodules = true;
-  };
-
-  bearssl_pkey_decoder = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/bearssl_pkey_decoder";
-    rev = "21dd3710df9345ed2ad8bf8f882761e07863b8e0";
-    sha256 = "0bl3f147zmkazbhdkr4cj1nipf9rqiw3g4hh1j424k9hpl55zdpg";
-    fetchSubmodules = true;
-  };
-
-  jwt = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-jwt.git";
-    rev = "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2";
-    sha256 = "1hnxsl5762fdn80hl4xxfdqrcgmxrrfck66js1iqaqfxc4m0fv63";
-    fetchSubmodules = true;
-  };
-
-  testutils = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-testutils";
-    rev = "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d";
-    sha256 = "1vbkr6i5yxhc2ai3b7rbglhmyc98f99x874fqdp6a152a6kqgwxy";
-    fetchSubmodules = true;
-  };
-
-  db_connector = pkgs.fetchgit {
-    url = "https://github.com/nim-lang/db_connector";
-    rev = "29450a2063970712422e1ab857695c12d80112a6";
-    sha256 = "11dna09ccdhj3pzpqa04j7a95ibx907z6n1ff33yf0n92qa4x59z";
+  npeg = pkgs.fetchgit {
+    url = "https://github.com/zevv/npeg";
+    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
+    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
     fetchSubmodules = true;
   };
 
@@ -59,59 +24,129 @@
     fetchSubmodules = true;
   };
 
+  unicodedb = pkgs.fetchgit {
+    url = "https://github.com/nitely/nim-unicodedb";
+    rev = "b70aac15a3fdc7647997bd6cd10bccd8b2c00e54";
+    sha256 = "00z5z1m14gw266ld7yy3gvnm08d1kgij66cg4h76yllkc1k1xk0s";
+    fetchSubmodules = true;
+  };
+
+  regex = pkgs.fetchgit {
+    url = "https://github.com/nitely/nim-regex";
+    rev = "4593305ed1e49731fc75af1dc572dd2559aad19c";
+    sha256 = "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9";
+    fetchSubmodules = true;
+  };
+
+  boringssl = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-boringssl";
+    rev = "346429e4cda48e775f2d1eb3ccb8757edf4f3648";
+    sha256 = "0x46sdq75zp84qahwh472qr33xw38adrsp41fksh7xwwd6384fl3";
+    fetchSubmodules = true;
+  };
+
+  unittest2 = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-unittest2.git";
+    rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
+    sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
+    fetchSubmodules = true;
+  };
+
+  intops = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-intops";
+    rev = "ade5d78d60124d1fd50d2109c5eb9416ed147231";
+    sha256 = "1q0dg49g8m99m3vrmxxqqhlci62y0mihlp8aq1ssm19597kpvjhz";
+    fetchSubmodules = true;
+  };
+
+  bearssl = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-bearssl";
+    rev = "b6c9a38964a574f6bc51f69efaf8fb2fedea905e";
+    sha256 = "0cv4g2l1pk97qgyy53nqyabpnayr8qx6fw35vjs08zs6af05c4fm";
+    fetchSubmodules = true;
+  };
+
+  bearssl_pkey_decoder = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/bearssl_pkey_decoder";
+    rev = "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368";
+    sha256 = "0200f7lf3x2hypwr2v9gms6qv7wj8m1phwd25025bfa1w9f2nkbg";
+    fetchSubmodules = true;
+  };
+
+  jwt = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-jwt.git";
+    rev = "057ec95eb5af0eea9c49bfe9025b3312c95dc5f2";
+    sha256 = "1hnxsl5762fdn80hl4xxfdqrcgmxrrfck66js1iqaqfxc4m0fv63";
+    fetchSubmodules = true;
+  };
+
   stew = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stew";
-    rev = "4382b18f04b3c43c8409bfcd6b62063773b2bbaa";
-    sha256 = "0mx9g5m636h3sk5pllcpylk51brf7lx91izx3gc23k3ih3hrxyk2";
+    rev = "c75502ceedb5ed2a37b7b5e4744fc71313682859";
+    sha256 = "10vvsghdchwphpwaqzmjixp01645ki5z5fk225f0i3742hpm6xk4";
+    fetchSubmodules = true;
+  };
+
+  testutils = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-testutils";
+    rev = "3feb84e206660d5289caefbe7b0f66f97d9ec084";
+    sha256 = "00x5lhp3zkwsrvr98a237shwafa67j1g5wmqgai2qv1djr2ajxgc";
     fetchSubmodules = true;
   };
 
   zlib = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-zlib";
-    rev = "e680f269fb01af2c34a2ba879ff281795a5258fe";
-    sha256 = "1xw9f1gjsgqihdg7kdkbaq1wankgnx2vn9l3ihc6nqk2jzv5bvk5";
+    rev = "190246aa0bb6569781370964fa2faa474203d6dd";
+    sha256 = "0x5l55gwzb1ay3k9inmi1g25jiv7flry247fcwd8rw3zw9pgchfv";
     fetchSubmodules = true;
   };
 
   httputils = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-http-utils";
-    rev = "f142cb2e8bd812dd002a6493b6082827bb248592";
-    sha256 = "03msj4zdxraz4qx9cidb17g7v0asazxv91nng6xxbzjxz0qaqxw6";
+    rev = "7d771ca337bd3bf563f6834569d2a06085ac21f1";
+    sha256 = "0s4pa0g50kmnzl6151pxzil0w0324l0nvfyfbjgvcn0lyflrxjaw";
     fetchSubmodules = true;
   };
 
   chronos = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-chronos";
-    rev = "45f43a9ad8bd8bcf5903b42f365c1c879bd54240";
-    sha256 = "1v1n59zfzznp97pvwgs9kf136bqmv4x2s2y9f24msspa7qv27w39";
+    rev = "90f543e447f6ade46f028bd7bdf882ae7fcb0ba9";
+    sha256 = "0grbkcr4whiadzcszx84ch4mpa71hhr77n3z0dlzyb4d4iykj6cr";
     fetchSubmodules = true;
   };
 
   metrics = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-metrics";
-    rev = "a1296caf3ebb5f30f51a5feae7749a30df2824c2";
-    sha256 = "02vxqy20g8012ks939ac25ksc25k727q84si0p2cmihy5bw1a3qm";
+    rev = "b56bfb8656bd135f0be17d4da95680e86f71e8b4";
+    sha256 = "0zl8hazcmb3mz0wr48dvs6ani9cy7si1i9x6f183n4cmvkrr9flb";
     fetchSubmodules = true;
   };
 
   faststreams = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-faststreams";
-    rev = "ce27581a3e881f782f482cb66dc5b07a02bd615e";
-    sha256 = "0y6bw2scnmr8cxj4fg18w7f34l2bh9qwg5nhlgd84m9fpr5bqarn";
+    rev = "059bc2f52546ac14b583639c33372c14b1d46fa3";
+    sha256 = "0xmma6a1b5lgzfqnk1vq3hvf8klbhcab0fnzz4xb68mpdrgvlvk4";
     fetchSubmodules = true;
   };
 
   snappy = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-snappy";
-    rev = "00bfcef94f8ef6981df5d5b994897f6695badfb2";
-    sha256 = "117mam97mkjjj1hs8svc07679k5ayww9yigi74yq8dyqm6fpbl6l";
+    rev = "da2f0c7b6ce9053106e9bb098204fe5319038387";
+    sha256 = "1jmjh1b70wkhzmyzvp46y50x3i1f0hkdrpy6msvqix60xwkxf1zy";
     fetchSubmodules = true;
   };
 
   serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-serialization";
-    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
-    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
+    rev = "b5473564e80a4908cf6c5a038e4c4a6ca7de2223";
+    sha256 = "09abpya7mvcaymxf0n2sc122rq4jkwg9kpis8xyc4z3fx3x3znxk";
+    fetchSubmodules = true;
+  };
+
+  protobuf_serialization = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-protobuf-serialization";
+    rev = "a671c6d497c7028ed7390b2d5a80c7b62138c586";
+    sha256 = "1i7nid50smfmxvc0zc5cp2xd227ll11r7y261bbj769gpd9bz0ax";
     fetchSubmodules = true;
   };
 
@@ -124,8 +159,8 @@
 
   confutils = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-confutils";
-    rev = "36f3115ca350f40841ac0eecc7dfa5fe7790c864";
-    sha256 = "1vppqplwlpl7a61r8iki5hlzvhd8lnq41ixpqslv35dnm482c55j";
+    rev = "cdbac612f0f3d2883e959807d790658854e73cf2";
+    sha256 = "0p0yws752k72hc0g1lz6a4nz5n5nnbpipy7sxvnmg80dd6hb4xj8";
     fetchSubmodules = true;
   };
 
@@ -138,22 +173,22 @@
 
   json_serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-json-serialization";
-    rev = "c343b0e243d9e17e2c40f3a8a24340f7c4a71d44";
-    sha256 = "0i8sq51nqj8lshf6bfixaz9a7sq0ahsbvq3chkxdvv4khsqvam91";
+    rev = "73c37b46591cf3d6a19d39ff0ed14b2e77433778";
+    sha256 = "0fk01rscd5kwdvgv2g3r3wdgbh1cliyjkgdmxc25k11lbkzyp0dl";
     fetchSubmodules = true;
   };
 
   chronicles = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-chronicles";
-    rev = "27ec507429a4eb81edc20f28292ee8ec420be05b";
-    sha256 = "1xx9fcfwgcaizq3s7i3s03mclz253r5j8va38l9ycl19fcbc96z9";
+    rev = "45c823b8af409f82fa35fd5e1f6a7c9a06fe3137";
+    sha256 = "1pl3cs6v4b4l3jk7kifni7sc7jn64alpbkwlh12vwd78knqkqmhf";
     fetchSubmodules = true;
   };
 
   presto = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-presto";
-    rev = "d66043dd7ede146442e6c39720c76a20bde5225f";
-    sha256 = "1hrppcak32aigrdv3mqk124w81yy9jv1prs57vqqhfj83gl930vi";
+    rev = "e07ae5ddfe6ae17e238a0cd7a366e1ee6886bec0";
+    sha256 = "1hr4w2qm0pp3r63h4rpgsc450ghrvqx817qs1x1c0bnncwgalhkz";
     fetchSubmodules = true;
   };
 
@@ -166,22 +201,43 @@
 
   stint = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stint";
-    rev = "470b7892561b5179ab20bd389a69217d6213fe58";
-    sha256 = "1isfwmbj98qfi5pm9acy0yyvq0vlz38nxp30xl43jx2mmaga2w22";
+    rev = "273fcdfa8dce4ceb975b383ffafe5e79e82766e2";
+    sha256 = "0a82y2c3s8bfzvaz8bpcfdn22xy79cqzhrkrncbb70lkdnnsyd4h";
+    fetchSubmodules = true;
+  };
+
+  taskpools = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-taskpools";
+    rev = "7d96007793fdb2d244d392eb7c5cfa4a695d4ecc";
+    sha256 = "0qi2kf1lj5ki101whjq68k5l00hh1vrz3izp2riv9q29zicwczyc";
+    fetchSubmodules = true;
+  };
+
+  ffi = pkgs.fetchgit {
+    url = "https://github.com/logos-messaging/nim-ffi";
+    rev = "07ee8e1d6500762bab290465457a8d23559de546";
+    sha256 = "04q5gmldyxd8jawrnjfws007zpyr4h08ijphp943iypbpblflfmz";
     fetchSubmodules = true;
   };
 
   minilru = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-minilru";
-    rev = "6dd93feb60f4cded3c05e7af7209cf63fb677893";
-    sha256 = "1xgx4j56ais3hk8b51zhnfs9q85g2afkp3y1j9ky5iziqvcs2sml";
+    rev = "6a6929edaf365bf032f00e5cd197d0eeb7a0467e";
+    sha256 = "0zbpqb4iixgk2fs5bw56m9zjzyb7q42gj4ps53bvgw3hzcy48zhb";
+    fetchSubmodules = true;
+  };
+
+  db_connector = pkgs.fetchgit {
+    url = "https://github.com/nim-lang/db_connector";
+    rev = "29450a2063970712422e1ab857695c12d80112a6";
+    sha256 = "11dna09ccdhj3pzpqa04j7a95ibx907z6n1ff33yf0n92qa4x59z";
     fetchSubmodules = true;
   };
 
   sqlite3_abi = pkgs.fetchgit {
     url = "https://github.com/arnetheduck/nim-sqlite3-abi";
-    rev = "8240e8e2819dfce1b67fa2733135d01b5cc80ae0";
-    sha256 = "0g8bc0kiwxxh3h5w06ksa23cw81hnx87rdn93v64m2f053nb6bcm";
+    rev = "9645cad7f8c6d27a322ef48a60722a3f88f44c27";
+    sha256 = "0vy8viiqbpf28pqy5s515qfsc0ygxxishmyz56xjqa29l3qslqjk";
     fetchSubmodules = true;
   };
 
@@ -192,38 +248,10 @@
     fetchSubmodules = true;
   };
 
-  unicodedb = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-unicodedb";
-    rev = "66f2458710dc641dd4640368f9483c8a0ec70561";
-    sha256 = "092z3glgdb7rmwajm7dmqzvralkm7ixighixk8ycf8sf17zm72ck";
-    fetchSubmodules = true;
-  };
-
-  regex = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-regex";
-    rev = "4593305ed1e49731fc75af1dc572dd2559aad19c";
-    sha256 = "1b666qws5sva3n5allin0ycvnqlzdjd7xzprpdvv632ccqddzcl9";
-    fetchSubmodules = true;
-  };
-
   nimcrypto = pkgs.fetchgit {
     url = "https://github.com/cheatfate/nimcrypto";
     rev = "721fb99ee099b632eb86dfad1f0d96ee87583774";
     sha256 = "178vzb3q8wzjq295ik2pd25rrqf32w381ck76hm5x2d8qnzfmkkc";
-    fetchSubmodules = true;
-  };
-
-  websock = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-websock";
-    rev = "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d";
-    sha256 = "1v0m3x96fbp9jdzsys6mbxxc2xw3k3dqiv7wksfla89gc6z8w377";
-    fetchSubmodules = true;
-  };
-
-  json_rpc = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-json-rpc.git";
-    rev = "6f1fff8ba685c9192fab153a9d66484ad9066e78";
-    sha256 = "1r4xlis5fxcmp1cdqskb25nzmxckfkl8lndshvl76kcqrb0hl88d";
     fetchSubmodules = true;
   };
 
@@ -234,10 +262,45 @@
     fetchSubmodules = true;
   };
 
+  websock = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-websock";
+    rev = "0432dc445c500b20963ef4b76e585c1a3943c254";
+    sha256 = "17kdlywwrlnqx8chf8l1b5gsbix5mmgkpgcwrxgj58af029h4yhr";
+    fetchSubmodules = true;
+  };
+
+  json_rpc = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-json-rpc.git";
+    rev = "6f1fff8ba685c9192fab153a9d66484ad9066e78";
+    sha256 = "1r4xlis5fxcmp1cdqskb25nzmxckfkl8lndshvl76kcqrb0hl88d";
+    fetchSubmodules = true;
+  };
+
   secp256k1 = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-secp256k1";
-    rev = "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15";
-    sha256 = "1qjrmwbngb73f6r1fznvig53nyal7wj41d1cmqfksrmivk2sgrn2";
+    rev = "f44cff901dff2a24fedcf4ef9e12a6f72355d58f";
+    sha256 = "09j0j5raf2nsb65s4zmarnpq4jn5v1hb4d73fj2s51kqpimhm46y";
+    fetchSubmodules = true;
+  };
+
+  libp2p = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-libp2p.git";
+    rev = "c43199378f46d0aaf61be1cad1ee1d63e8f665d6";
+    sha256 = "0q1hkwwz08zfdwwz7cfql1hqil0iyv3dn8jypdwqmg7497l1bmxk";
+    fetchSubmodules = true;
+  };
+
+  sds = pkgs.fetchgit {
+    url = "https://github.com/logos-messaging/nim-sds.git";
+    rev = "b12f5ee07c5b764303b51fb948b32a4ade1de3b5";
+    sha256 = "1z8f0v1ww7y6zssdacjxfs6s4862dwckw25df3yn1v0qnz40rpc8";
+    fetchSubmodules = true;
+  };
+
+  libp2p_mix = pkgs.fetchgit {
+    url = "https://github.com/logos-co/nim-libp2p-mix";
+    rev = "380513117d556bf8f70066f5e72a7fd74fe36ba6";
+    sha256 = "05zjf98nl2hxx62m9blk4yip2f31y44r5x4n98lmm5hghb7wbcpk";
     fetchSubmodules = true;
   };
 
@@ -257,64 +320,8 @@
 
   dnsdisc = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-dnsdisc";
-    rev = "38f2e0f52c0a8f032ef4530835e519d550706d9e";
-    sha256 = "0dk787ny49n41bmzhlrvm87giwajr01gwdw9nlmphch89rdqpxxn";
-    fetchSubmodules = true;
-  };
-
-  libp2p = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-libp2p.git";
-    rev = "c43199378f46d0aaf61be1cad1ee1d63e8f665d6";
-    sha256 = "0q1hkwwz08zfdwwz7cfql1hqil0iyv3dn8jypdwqmg7497l1bmxk";
-    fetchSubmodules = true;
-  };
-
-  taskpools = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-taskpools";
-    rev = "9e8ccc754631ac55ac2fd495e167e74e86293edb";
-    sha256 = "1y78l33vdjxmb9dkr455pbphxa73rgdsh8m9gpkf4d9b1wm1yivy";
-    fetchSubmodules = true;
-  };
-
-  sds = pkgs.fetchgit {
-    url = "https://github.com/logos-messaging/nim-sds.git";
-    rev = "b12f5ee07c5b764303b51fb948b32a4ade1de3b5";
-    sha256 = "1z8f0v1ww7y6zssdacjxfs6s4862dwckw25df3yn1v0qnz40rpc8";
-    fetchSubmodules = true;
-  };
-
-  ffi = pkgs.fetchgit {
-    url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "07ee8e1d6500762bab290465457a8d23559de546";
-    sha256 = "04q5gmldyxd8jawrnjfws007zpyr4h08ijphp943iypbpblflfmz";
-    fetchSubmodules = true;
-  };
-
-  boringssl = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "346429e4cda48e775f2d1eb3ccb8757edf4f3648";
-    sha256 = "0x46sdq75zp84qahwh472qr33xw38adrsp41fksh7xwwd6384fl3";
-    fetchSubmodules = true;
-  };
-
-  protobuf_serialization = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "38d24eb3bd93e605fb88199da71d36b1ec0ad60d";
-    sha256 = "0jr0a41b4r444si6xfa7bclw8mjsk6id10lrdvbxzp99750zspb9";
-    fetchSubmodules = true;
-  };
-
-  npeg = pkgs.fetchgit {
-    url = "https://github.com/zevv/npeg";
-    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
-    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
-    fetchSubmodules = true;
-  };
-
-  libp2p_mix = pkgs.fetchgit {
-    url = "https://github.com/logos-co/nim-libp2p-mix";
-    rev = "380513117d556bf8f70066f5e72a7fd74fe36ba6";
-    sha256 = "05zjf98nl2hxx62m9blk4yip2f31y44r5x4n98lmm5hghb7wbcpk";
+    rev = "6cb1b7e3922645275043c68e476cac1501a45e55";
+    sha256 = "02vxprjw4ixicdfczznns62izys9jgmsvy28rzlfd0wqg79gn9mc";
     fetchSubmodules = true;
   };
 

--- a/scripts/audit_deps.nims
+++ b/scripts/audit_deps.nims
@@ -1,0 +1,191 @@
+# Verify installed Nimble dependency metadata against nimble.lock.
+# File-and-line references below refer to Nimble 0.24.1:
+# https://github.com/nim-lang/nimble
+#
+# Run after setup or cache restoration:
+#
+#   nim e scripts/audit_deps.nims
+#
+# For each non-Nim lock entry, the audit locates an installed package by
+# normalized repository URL, falling back to the package name parsed from
+# its pkgs2 directory. Its nimblemeta.json vcsRevision must equal the
+# revision in nimble.lock. The reverse check rejects installed directories
+# that match no lock entry, and directories without nimblemeta.json are
+# also rejected.
+#
+# This validates Nimble's installed metadata. It does not hash or
+# otherwise compare every file in an installed package working tree.
+#
+# The audit does not help the build succeed: it can only fail it. It
+# reads files and writes nothing. A build that passes the audit is the
+# same build without it.
+#
+# Successful completion prints the matched count and exits with status 0.
+# Missing packages, extra packages, missing metadata, or revision
+# differences produce diagnostics and a nonzero exit. File and JSON
+# errors also propagate as failures.
+#
+# Rationale: Nimble 0.24.1 has been observed to exit with status 0 after
+# installing a revision different from a requested special revision. The
+# reproduction is recorded below.
+#
+# A failure can result from dependency resolution, an outdated or
+# incomplete cache, missing metadata, an upstream tag change, or a
+# repository or lock edit. Inspect the reported package and installed
+# metadata before updating the lock.
+#
+# Update procedure:
+# 1. To accept a newly reviewed resolution, update logos_delivery.nimble
+#    as needed, run `nimble lock`, regenerate nix/deps.nix, perform a
+#    clean setup, and require this audit to pass.
+# 2. To retain the existing revision, add or adjust a constraint
+#    compatible with the other requirements for that package, then perform
+#    a clean setup and require this audit to pass. A `url#commit`
+#    constraint is not assumed to win when a competing name requirement
+#    exists.
+# 3. After removing a package, delete nimbledeps/ before setup because
+#    `nimble setup` does not remove directories for packages no longer
+#    selected.
+#
+# The `nim` lock entry is skipped because these builds pass --useSystemNim
+# and do not install Nim under nimbledeps/.
+#
+# Relevant Nimble behavior:
+# - solveLockFileDeps, src/nimblepkg/nimblesat.nim:1226, matches lock
+#   entries by package name. URL requirements do not match those entries
+#   directly.
+# - normalizeSpecialVersions, src/nimblepkg/nimblesat.nim:663, retains one
+#   special version for a package and rewrites or removes competing
+#   special requirements, with a warning.
+# - Related historical resolution defects are documented in issues #1691
+#   and #1692; their fixes shipped in Nimble 0.24.0.
+# - Reproduction from the upstream state observed in 2026-08: the
+#   requirement
+#   "https://github.com/status-im/nim-secp256k1#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15"
+#   plus nim-eth's name requirement for secp256k1 caused Nimble 0.24.1 to
+#   record f44cff901dff2a24fedcf4ef9e12a6f72355d58f and exit with
+#   status 0.
+
+import std/[json, strutils, algorithm, sets, tables]
+
+let root = thisDir() & "/.."
+
+proc normUrl(url: string): string =
+  result = url.toLowerAscii()
+  result.removeSuffix("/")
+  result.removeSuffix(".git")
+
+# Read a metadata field from either nimblemeta.json layout observed in
+# this dependency set: top-level or nested under `metaData`.
+proc metaField(meta: JsonNode, field: string): string =
+  if meta.hasKey(field):
+    return meta[field].getStr()
+  return meta{"metaData", field}.getStr()
+
+# Fallback parser for a pkgs2 directory name. Remove the final checksum
+# and version fields from `name-version-checksum`. This assumes the
+# encoded version field contains no hyphen; URL matching is preferred
+# when metadata provides it.
+proc nameFromDir(dir: string): string =
+  result = dir
+  for _ in 1 .. 2:
+    let cut = result.rfind('-')
+    if cut < 0:
+      return dir
+    result = result[0 ..< cut]
+
+proc main() =
+  let lock = parseJson(readFile(root & "/nimble.lock"))["packages"]
+  let pkgs2 = root & "/nimbledeps/pkgs2"
+  if not dirExists(pkgs2):
+    echo "audit: no nimbledeps/pkgs2 directory; run setup first"
+    quit(1)
+
+  var installedByUrl = initTable[string, (string, string)]()
+  var installedByName = initTable[string, (string, string)]()
+  var dirs: seq[string]
+  var metaless: seq[string]
+  for path in listDirs(pkgs2):
+    let d = path.split('/')[^1]
+    let metaPath = path & "/nimblemeta.json"
+    if not fileExists(metaPath):
+      metaless.add(d)
+      continue
+    let meta = parseJson(readFile(metaPath))
+    let rev = metaField(meta, "vcsRevision")
+    let url = normUrl(metaField(meta, "url"))
+    dirs.add(d)
+    if url.len > 0:
+      installedByUrl[url] = (d, rev)
+    installedByName[nameFromDir(d)] = (d, rev)
+
+  var names: seq[string]
+  for name, _ in lock:
+    names.add(name)
+  names.sort()
+
+  var ok = 0
+  var total = 0
+  var bad: seq[string]
+  var matchedDirs: HashSet[string]
+  for name in names:
+    if name == "nim":
+      continue
+    total += 1
+    let entry = lock[name]
+    let want = entry["vcsRevision"].getStr()
+    var hit: (string, string)
+    if normUrl(entry["url"].getStr()) in installedByUrl:
+      hit = installedByUrl[normUrl(entry["url"].getStr())]
+    elif name in installedByName:
+      hit = installedByName[name]
+    else:
+      bad.add(name & ": in nimble.lock but not installed")
+      continue
+    matchedDirs.incl(hit[0])
+    if hit[1] != want:
+      bad.add(name & ": lock has " & want & ", installed " & hit[0] &
+              " has " & hit[1])
+    else:
+      ok += 1
+
+  # Reject installed package directories not matched to a lock entry.
+  # This also detects packages added by a later task solve, such as a
+  # Nim toolchain.
+  dirs.sort()
+  for d in dirs:
+    if d notin matchedDirs:
+      bad.add(d & ": installed but not in nimble.lock")
+  metaless.sort()
+  for d in metaless:
+    bad.add(d & ": installed without nimblemeta.json")
+
+  for b in bad:
+    echo "audit: " & b
+  echo "audit: " & $ok & "/" & $total & " installed packages match nimble.lock"
+  if bad.len > 0:
+    quit(1)
+
+#---------------------------------------------------------------------
+# Self-tests for the metadata and directory-name parsers. Executed before main().
+#---------------------------------------------------------------------
+proc selfTest() =
+  doAssert normUrl("https://github.com/NagyZoltanPeter/nim-brokers.git") ==
+    "https://github.com/nagyzoltanpeter/nim-brokers"
+  # A version contains no dash, so two rsplits recover the name, also
+  # when the name itself contains dashes or digits.
+  doAssert nameFromDir("nim-2.2.10-17ec440fdb89") == "nim"
+  doAssert nameFromDir("secp256k1-0.6.0.3.2-abfc2c1a") == "secp256k1"
+  doAssert nameFromDir("bearssl_pkey_decoder-0.1.0-8666edbc") == "bearssl_pkey_decoder"
+  doAssert nameFromDir("nodash") == "nodash"
+  # Both nimblemeta.json shapes: top-level and nested under metaData.
+  doAssert metaField(parseJson(
+    """{"vcsRevision": "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368"}"""),
+    "vcsRevision") == "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368"
+  doAssert metaField(parseJson(
+    """{"metaData": {"vcsRevision": "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368"}}"""),
+    "vcsRevision") == "d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368"
+  doAssert metaField(parseJson("""{}"""), "vcsRevision") == ""
+
+selfTest()
+main()

--- a/scripts/gen_requires.nims
+++ b/scripts/gen_requires.nims
@@ -1,0 +1,286 @@
+# Workaround for Nimble 0.24.1 lock handling when requirements use URLs.
+# File-and-line references below refer to that Nimble version:
+# https://github.com/nim-lang/nimble
+#
+# This script writes requires.generated, a supplemental requirements string
+# passed to:
+#
+#   nimble setup --requires "$(cat requires.generated)"
+#
+# Nimble matches lock entries by package name in solveLockFileDeps
+# (src/nimblepkg/nimblesat.nim:1226). A URL requirement therefore may not
+# receive the revision recorded under the package name in nimble.lock.
+# This script derives additional constraints from the lock. It does not
+# guarantee which revision Nimble selects; scripts/audit_deps.nims checks
+# the installed metadata after setup.
+#
+# Inputs:
+# - nimble.lock supplies the expected package name, version, repository
+#   URL, and VCS revision.
+# - logos_delivery.nimble supplies explicit URL requirements. The generator
+#   omits matching URLs rather than adding a second root constraint.
+# - The configured registry mirrors supply the current name-to-URL mapping.
+# - `git ls-remote --tags` supplies the current tag refs for each
+#   repository.
+#
+# Emission rule for each git lock entry not already required by URL:
+# - registry URL matches and the version tag points to the locked revision:
+#     "name == version"
+# - either condition does not match:
+#     "url#revision"
+#
+# Known limitation: Nimble 0.24.1 can normalize a `url#revision`
+# requirement together with a competing name requirement and retain the
+# other special version. The post-setup audit rejects the result when its
+# recorded vcsRevision differs from nimble.lock.
+#
+# The script also compares the normalized repository URL and revision
+# mappings in nimble.lock and nix/deps.nix in both directions for the git
+# dependencies it processes. A missing URL or differing revision causes a
+# nonzero exit. Registry-fetch and tag-query failures also cause a nonzero
+# exit.
+#
+# Outputs:
+# - requires.generated: written through a temporary path and rename only
+#   after validation succeeds.
+# - observed.generated: diagnostic output from the current invocation.
+#   Build and setup rules do not consume this file. It may be written even
+#   when a later validation error causes the invocation to fail.
+
+import std/[json, strutils, algorithm, sets, tables]
+
+let root = thisDir() & "/.."
+
+const registryMirrors = [
+  "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json",
+  "https://packages.nim-lang.org/packages.json",
+]
+
+const nixHint = "regenerate with: tools/gen-nix-deps.sh nimble.lock nix/deps.nix"
+
+proc normUrl(url: string): string =
+  result = url.toLowerAscii()
+  result.removeSuffix("/")
+  result.removeSuffix(".git")
+
+# Return normalized base URLs from quoted URL requirements on non-comment
+# lines. A fragment or version constraint terminates the base URL.
+proc urlPinsFrom(content: string): HashSet[string] =
+  for line in content.splitLines():
+    if line.strip(trailing = false).startsWith("#"):
+      continue
+    let parts = line.split('"')
+    var i = 1
+    while i < parts.len:
+      if parts[i].startsWith("http://") or parts[i].startsWith("https://"):
+        var base = parts[i]
+        let cut = min(
+          if base.find('#') >= 0: base.find('#') else: base.len,
+          if base.find(' ') >= 0: base.find(' ') else: base.len,
+        )
+        base = base[0 ..< cut]
+        result.incl(normUrl(base))
+      i += 2
+
+proc nimbleUrlPins(path: string): HashSet[string] =
+  urlPinsFrom(readFile(path))
+
+# Map normalized repository URLs to revisions from fetchgit blocks in
+# nix/deps.nix.
+proc nixEntriesFrom(content: string): Table[string, string] =
+  var url = ""
+  for line in content.splitLines():
+    let l = line.strip()
+    if l.startsWith("url = \""):
+      url = l.split('"')[1]
+    elif l.startsWith("rev = \"") and url.len > 0:
+      result[normUrl(url)] = l.split('"')[1]
+      url = ""
+
+proc nixEntries(path: string): Table[string, string] =
+  nixEntriesFrom(readFile(path))
+
+# Map lowercase package names to normalized repository URLs. Resolve one
+# level of registry alias.
+proc registryFrom(jsonContent: string): Table[string, string] =
+  var byName = initTable[string, JsonNode]()
+  for p in parseJson(jsonContent):
+    if p.hasKey("name"):
+      byName[p["name"].getStr().toLowerAscii()] = p
+  for lname, p in byName:
+    var entry = p
+    if entry.hasKey("alias"):
+      entry = byName.getOrDefault(entry["alias"].getStr().toLowerAscii(), newJObject())
+    if entry.hasKey("url"):
+      result[lname] = normUrl(entry["url"].getStr())
+
+proc registryUrls(): Table[string, string] =
+  var lastErr = ""
+  for mirror in registryMirrors:
+    let (output, code) = gorgeEx("curl -fsSL --max-time 60 " & mirror)
+    if code != 0:
+      lastErr = "curl exit " & $code & " for " & mirror
+      continue
+    return registryFrom(output)
+  echo "gen_requires: cannot fetch the Nimble registry: " & lastErr
+  quit(1)
+
+# Return true when a plain tag or the peeled target of an annotated tag
+# for `version` equals `rev`. The comparison uses complete ls-remote
+# output lines. The git invocation below requests an abort when transfer
+# speed remains below one byte per second for 60 seconds.
+proc tagLineMatches(lsRemoteOutput, version, rev: string): bool =
+  var expected: HashSet[string]
+  for prefix in ["refs/tags/", "refs/tags/v"]:
+    for suffix in ["", "^{}"]:
+      expected.incl(rev & "\t" & prefix & version & suffix)
+  for line in lsRemoteOutput.splitLines():
+    if line in expected:
+      return true
+  return false
+
+proc versionTagPointsAtRev(url, version, rev: string): bool =
+  let (output, code) = gorgeEx(
+    "git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=60 ls-remote --tags " & url)
+  if code != 0:
+    raise newException(CatchableError, "git ls-remote --tags failed for " & url)
+  tagLineMatches(output, version, rev)
+
+proc writeAtomic(path, content: string) =
+  writeFile(path & ".tmp", content)
+  mvFile(path & ".tmp", path)
+
+type LockEntry = tuple[name, version, rev, url: string]
+
+proc main() =
+  let lock = parseJson(readFile(root & "/nimble.lock"))["packages"]
+  let inFile = nimbleUrlPins(root & "/logos_delivery.nimble")
+  let nix = nixEntries(root & "/nix/deps.nix")
+  let registry = registryUrls()
+
+  var entries: seq[LockEntry]
+  for name, e in lock:
+    if name == "nim" or name == "nimble":
+      continue
+    if e{"downloadMethod"}.getStr() != "git":
+      continue
+    entries.add((name, e["version"].getStr(), e["vcsRevision"].getStr(),
+                 e["url"].getStr()))
+  entries.sort(proc(a, b: LockEntry): int = cmp(a.name, b.name))
+
+  var errors: seq[string]
+  var lockUrls: HashSet[string]
+  for e in entries:
+    lockUrls.incl(normUrl(e.url))
+  var missing = inFile - lockUrls
+  for u in missing:
+    errors.add("logos_delivery.nimble pins " & u &
+               ", but nimble.lock has no entry for it")
+
+  for url, _ in nix:
+    if url notin lockUrls:
+      errors.add("nix/deps.nix has " & url &
+                 ", but nimble.lock has no entry for it (" & nixHint & ")")
+
+  var candidates: seq[LockEntry]
+  for e in entries:
+    let url = normUrl(e.url)
+    if url notin nix:
+      errors.add(e.name & ": not in nix/deps.nix (" & nixHint & ")")
+      continue
+    if nix[url] != e.rev:
+      errors.add(e.name & ": nimble.lock has " & e.rev &
+                 ", nix/deps.nix has " & nix[url])
+    if url in inFile:
+      continue
+    candidates.add(e)
+
+  var outParts: seq[string]
+  var record = @[
+    "# Diagnostic output from the most recent gen_requires.nims invocation.",
+    "# Not consumed by dependency setup or build rules.",
+  ]
+  for e in candidates:
+    let inRegistry = registry.getOrDefault(e.name.toLowerAscii(), "") == normUrl(e.url)
+    var usable = false
+    if inRegistry:
+      try:
+        usable = versionTagPointsAtRev(e.url, e.version, e.rev)
+      except CatchableError as ex:
+        errors.add(e.name & ": observation failed: " & ex.msg)
+        record.add(e.name & " " & e.rev & " observation-failed")
+        continue
+    let taggedCol = if inRegistry: $ord(usable) else: "-"
+    record.add(e.name & " " & e.rev & " tagged=" & taggedCol &
+               " registry=" & $ord(inRegistry))
+    if usable:
+      outParts.add(e.name & " == " & e.version)
+    else:
+      var base = e.url
+      base.removeSuffix("/")
+      base.removeSuffix(".git")
+      outParts.add(base & "#" & e.rev)
+
+  writeAtomic(root & "/observed.generated", record.join("\n") & "\n")
+
+  if errors.len > 0:
+    for e in errors:
+      echo "gen_requires: " & e
+    quit(1)
+
+  let requires = outParts.join("; ")
+  writeAtomic(root & "/requires.generated", requires & "\n")
+  echo requires
+
+#---------------------------------------------------------------------
+# Self-tests for the parsing helpers. Executed before main().
+#---------------------------------------------------------------------
+proc selfTest() =
+  # Cover a mixed-case owner and the optional ".git" suffix.
+  doAssert normUrl("https://github.com/NagyZoltanPeter/nim-brokers.git") ==
+    "https://github.com/nagyzoltanpeter/nim-brokers"
+  doAssert normUrl("https://github.com/vacp2p/nim-boringssl") ==
+    "https://github.com/vacp2p/nim-boringssl"
+  # A package name that starts with "http" is not a URL requirement.
+  doAssert urlPinsFrom("""  "httputils >= 0.4.1",""").len == 0
+  # A comment line is not a requirement, also when it quotes a URL.
+  doAssert urlPinsFrom("""# v2.0.0: "https://github.com/vacp2p/nim-libp2p"""").len == 0
+  doAssert "https://github.com/vacp2p/nim-libp2p" in urlPinsFrom(
+    """requires "https://github.com/vacp2p/nim-libp2p.git#c43199378f46d0aaf61be1cad1ee1d63e8f665d6"""")
+  doAssert "https://github.com/vacp2p/nim-lsquic" in urlPinsFrom(
+    """requires "https://github.com/vacp2p/nim-lsquic.git == 0.5.1"""")
+  let nix = nixEntriesFrom("""
+  chronos = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-chronos";
+    rev = "45f43a9ad8bd8bcf5903b42f365c1c879bd54240";
+    sha256 = "sha256-000";
+    fetchSubmodules = true;
+  };
+""")
+  doAssert nix["https://github.com/status-im/nim-chronos"] ==
+    "45f43a9ad8bd8bcf5903b42f365c1c879bd54240"
+  # These tag lines were captured from the referenced repositories: a
+  # plain tag, then the peeled target of an annotated tag.
+  doAssert tagLineMatches(
+    "c43199378f46d0aaf61be1cad1ee1d63e8f665d6\trefs/tags/v2.0.0",
+    "2.0.0", "c43199378f46d0aaf61be1cad1ee1d63e8f665d6")
+  doAssert tagLineMatches(
+    "19565dd80621e33f6da396ef3fb07c379d55c324\trefs/tags/v3.3.0^{}",
+    "3.3.0", "19565dd80621e33f6da396ef3fb07c379d55c324")
+  # A tag that points at a different revision does not match.
+  doAssert not tagLineMatches(
+    "f44cff901dff2a24fedcf4ef9e12a6f72355d58f\trefs/tags/v0.6.0",
+    "0.6.0", "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15")
+  # Registry parsing: names compare case-insensitively, an alias is
+  # followed one level, and an alias to a missing entry yields nothing.
+  let reg = registryFrom("""[
+    {"name": "Chronos", "url": "https://github.com/status-im/nim-chronos"},
+    {"name": "old", "alias": "chronos"},
+    {"name": "dead", "alias": "gone"}
+  ]""")
+  doAssert reg["chronos"] == "https://github.com/status-im/nim-chronos"
+  doAssert reg["old"] == "https://github.com/status-im/nim-chronos"
+  doAssert "dead" notin reg
+
+selfTest()
+main()

--- a/scripts/install_nimble.sh
+++ b/scripts/install_nimble.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 # Installs a specific nimble version without using `nimble install nimble`.
 #
-# `nimble install nimble` is inherently fragile:
-#   - ETXTBSY: overwriting the running nimble binary in pkgs2/
-#   - JSON parse failures with older nimble versions reading packages_official.json
+# Install the selected executable under:
 #
-# Strategy:
-#   1. If the right version is already at ~/.nimble/bin/nimble → done.
-#   2. If a previously-compiled binary exists in pkgs2/ → re-link it.
-#   3. Otherwise: clone the nimble git repo, init submodules, build with nim,
-#      and atomically replace the target (mv avoids ETXTBSY on the old binary).
+#   ~/.local/nimble-<version>/bin
+#
+# The Makefile places this directory before ~/.nimble/bin on PATH. Nimble
+# may update package links under ~/.nimble/bin during setup, including the
+# `nimble` link when Nimble is installed as a package. Installing the
+# selected executable outside that directory avoids writing through that
+# link.
+#
+# Procedure:
+#   1. Reuse an executable already reporting the requested version.
+#   2. On a recognized platform, try the version-specific GitHub release
+#      asset.
+#   3. If download, extraction, or execution fails, build the requested
+#      tag from source with the Nim compiler on PATH.
 
 set -e
 
@@ -19,9 +26,10 @@ if [ -z "${NIMBLE_VERSION}" ]; then
   exit 1
 fi
 
-NIMBLE_BIN="${HOME}/.nimble/bin/nimble"
+NIMBLE_DIR="${HOME}/.local/nimble-${NIMBLE_VERSION}/bin"
+NIMBLE_BIN="${NIMBLE_DIR}/nimble"
 
-# 1. Already installed at the right version?
+# Step 1: reuse the executable if it reports the requested version.
 if [ -x "${NIMBLE_BIN}" ]; then
   nimble_ver=$("${NIMBLE_BIN}" --version 2>/dev/null \
     | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
@@ -31,21 +39,40 @@ if [ -x "${NIMBLE_BIN}" ]; then
   fi
 fi
 
-# 2. Already compiled into pkgs2/ from a previous (possibly partial) run?
-PKGS2_NIMBLE=$(ls -dt "${HOME}/.nimble/pkgs2/nimble-${NIMBLE_VERSION}-"*/nimble \
-  2>/dev/null | head -1 || true)
-if [ -n "${PKGS2_NIMBLE}" ] && [ -x "${PKGS2_NIMBLE}" ]; then
-  echo "Nimble ${NIMBLE_VERSION} found in pkgs2, re-linking to ${NIMBLE_BIN}."
-  mkdir -p "${HOME}/.nimble/bin"
-  ln -sf "${PKGS2_NIMBLE}" "${NIMBLE_BIN}"
-  exit 0
+mkdir -p "${NIMBLE_DIR}"
+
+# Step 2: try the version-specific prebuilt release asset.
+#
+# The URL identifies a release under github.com/nim-lang/nimble. After
+# extraction, the script checks that the binary can execute --version.
+# It does not independently verify an archive checksum. A failed
+# download, extraction, or execution falls through to the source build.
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)  ASSET="linux_x64" ;;
+  Linux-aarch64) ASSET="linux_aarch64" ;;
+  Darwin-arm64)  ASSET="macosx_aarch64" ;;
+  Darwin-x86_64) ASSET="macosx_x64" ;;
+  MINGW*-x86_64|MSYS*-x86_64) ASSET="windows_x64" ;;
+  *)             ASSET="" ;;
+esac
+if [ -n "${ASSET}" ]; then
+  URL="https://github.com/nim-lang/nimble/releases/download/v${NIMBLE_VERSION}/nimble-${ASSET}.tar.gz"
+  echo "Downloading prebuilt nimble ${NIMBLE_VERSION} (${ASSET})..."
+  if curl -fsSL "${URL}" | tar -xz -C "${NIMBLE_DIR}"; then
+    if "${NIMBLE_BIN}" --version >/dev/null 2>&1; then
+      "${NIMBLE_BIN}" --version | head -1
+      echo "Nimble ${NIMBLE_VERSION} installed to ${NIMBLE_BIN}"
+      exit 0
+    fi
+    echo "Prebuilt binary does not run, falling back to source build." >&2
+  else
+    echo "Prebuilt download failed, falling back to source build." >&2
+  fi
 fi
 
-# 3. Build from source.
-NIM_BIN="${HOME}/.nimble/bin/nim"
-if [ ! -x "${NIM_BIN}" ]; then
-  NIM_BIN="$(command -v nim)"
-fi
+# Step 3: clone the requested version tag and build it with the Nim
+# compiler resolved from PATH.
+NIM_BIN="$(command -v nim)"
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
@@ -58,12 +85,13 @@ git clone --depth=1 --branch "v${NIMBLE_VERSION}" \
 
 echo "Building nimble ${NIMBLE_VERSION} with $("${NIM_BIN}" --version | head -1)..."
 cd "${WORK_DIR}/nimble"
-# nim reads nim.cfg / config.nims in the current dir, which sets vendor paths.
+# Nim reads nim.cfg and config.nims from the current directory; these
+# files add the vendored module paths used by the build.
 "${NIM_BIN}" c -d:release --path:src \
   -o:"${WORK_DIR}/nimble_new" src/nimble.nim
 
-mkdir -p "${HOME}/.nimble/bin"
-# Atomic rename: avoids ETXTBSY when the old binary at NIMBLE_BIN is still running.
+# Stage the executable under a separate pathname, then rename it over
+# the target. This avoids writing the target executable in place.
 cp "${WORK_DIR}/nimble_new" "${NIMBLE_BIN}.new.$$"
 mv -f "${NIMBLE_BIN}.new.$$" "${NIMBLE_BIN}"
 


### PR DESCRIPTION
## Description

Fixes dependency setup.

This also bumps Nimble from 0.22.3 to 0.24.1, which can resolve the current dependency graph without adding transitive version caps to steer the older solver. Nim remains at 2.2.4.

Make and CI now share the same setup path, with the same checks whether or not dependencies are restored from cache.

## Changes

* update Nimble and dependency pins
* refresh the lock file and Nix dependencies
* install the selected Nimble version from a stable path
* generate setup constraints from the lock file
* use the same dependency setup in Make and CI
* apply the same constraints to Nimble tasks
* verify installed dependency revisions after setup and after build tasks
* check the lock file against Nix dependencies
* add a daily job that regenerates the Nix dependencies and compares them
* make cached and uncached setup follow the same verification path
* update the affected caches and workflows

## Issue

Maintenance Y2026H2 #4043
