### PR TITLE
fix(ffi): serialise byte fields as base64 on the FFI surface

### DIFF
--- a/library/events/json_message_event.nim
+++ b/library/events/json_message_event.nim
@@ -76,8 +76,8 @@ proc new*(T: type JsonMessage, msg: WakuMessage): T =
 proc `%`*(value: Base64String): JsonNode =
   %(value.string)
 
-proc toJsonNode*(msg: WakuMessage): JsonNode =
-  ## RFC 36 JSON for a WakuMessage, for callers assembling an event by hand.
+proc `%`*(msg: WakuMessage): JsonNode =
+  ## Serializes a WakuMessage in the RFC 36 shape, with byte fields base64-encoded.
   %JsonMessage.new(msg)
 
 type JsonMessageEvent* = ref object of JsonEvent

--- a/library/events/json_message_event.nim
+++ b/library/events/json_message_event.nim
@@ -61,8 +61,24 @@ proc toWakuMessage*(self: JsonMessage): Result[WakuMessage, string] =
     )
   )
 
+proc new*(T: type JsonMessage, msg: WakuMessage): T =
+  ## Renders a WakuMessage in the RFC 36 shape, with the byte fields base64-encoded.
+  JsonMessage(
+    payload: base64.encode(msg.payload),
+    contentTopic: msg.contentTopic,
+    version: msg.version,
+    timestamp: int64(msg.timestamp),
+    ephemeral: msg.ephemeral,
+    meta: base64.encode(msg.meta),
+    proof: base64.encode(msg.proof),
+  )
+
 proc `%`*(value: Base64String): JsonNode =
   %(value.string)
+
+proc toJsonNode*(msg: WakuMessage): JsonNode =
+  ## RFC 36 JSON for a WakuMessage, for callers assembling an event by hand.
+  %JsonMessage.new(msg)
 
 type JsonMessageEvent* = ref object of JsonEvent
   pubsubTopic*: string
@@ -73,33 +89,13 @@ proc new*(T: type JsonMessageEvent, pubSubTopic: string, msg: WakuMessage): T =
   # Returns a WakuMessage event as indicated in
   # https://github.com/vacp2p/rfc/blob/master/content/docs/rfcs/36/README.md#jsonmessageevent-type
 
-  var payload = newSeq[byte](len(msg.payload))
-  if len(msg.payload) != 0:
-    copyMem(addr payload[0], unsafeAddr msg.payload[0], len(msg.payload))
-
-  var meta = newSeq[byte](len(msg.meta))
-  if len(msg.meta) != 0:
-    copyMem(addr meta[0], unsafeAddr msg.meta[0], len(msg.meta))
-
-  var proof = newSeq[byte](len(msg.proof))
-  if len(msg.proof) != 0:
-    copyMem(addr proof[0], unsafeAddr msg.proof[0], len(msg.proof))
-
   let msgHash = computeMessageHash(pubSubTopic, msg)
 
   return JsonMessageEvent(
     eventType: "message",
     pubSubTopic: pubSubTopic,
     messageHash: msgHash.to0xHex(),
-    wakuMessage: JsonMessage(
-      payload: base64.encode(payload),
-      contentTopic: msg.contentTopic,
-      version: msg.version,
-      timestamp: int64(msg.timestamp),
-      ephemeral: msg.ephemeral,
-      meta: base64.encode(meta),
-      proof: base64.encode(proof),
-    ),
+    wakuMessage: JsonMessage.new(msg),
   )
 
 method `$`*(jsonMessage: JsonMessageEvent): string =

--- a/library/kernel_api/protocols/store_api.nim
+++ b/library/kernel_api/protocols/store_api.nim
@@ -5,6 +5,8 @@ import
   library/utils,
   logos_delivery/waku/waku_core/message/digest,
   logos_delivery/waku/waku_store/common,
+  logos_delivery/waku/rest_api/endpoint/serdes,
+  logos_delivery/waku/rest_api/endpoint/store/types,
   logos_delivery/waku/common/paging,
   library/declare_lib
 
@@ -80,5 +82,6 @@ proc waku_store_query(
   ).valueOr:
     return err("StoreRequest failed store query: " & error)
 
-  let res = $(%*(queryResponse.toHex()))
+  let res = encodeIntoJsonString(queryResponse.toHex()).valueOr:
+    return err("StoreRequest failed encoding store response: " & $error)
   return ok(res) ## returning the response in json format

--- a/library/logos_delivery_api/node_api.nim
+++ b/library/logos_delivery_api/node_api.nim
@@ -3,7 +3,7 @@ import chronos, chronicles, results, ffi
 import brokers/broker_context
 import libp2p/peerid # pull PeerId pretty string formatting
 import logos_delivery/waku/common/base64
-from ../events/json_message_event import toJsonNode
+from ../events/json_message_event import `%` # base64 rendering for WakuMessage
 import
   logos_delivery,
   logos_delivery/waku/node/waku_node,
@@ -54,13 +54,7 @@ proc registerFFIEventListeners(self: LogosDelivery): Result[void, string] =
     self.waku.brokerCtx,
     proc(event: MessageReceivedEvent) {.async: (raises: []).} =
       emitEvent("onMessageReceived"):
-        $(
-          %*{
-            "eventType": "message_received",
-            "messageHash": event.messageHash,
-            "message": event.message.toJsonNode(),
-          }
-        ),
+        $newJsonEvent("message_received", event),
   ).isOkOr:
     chronicles.error "MessageReceivedEvent.listen failed", err = $error
     return err("MessageReceivedEvent.listen failed: " & $error)

--- a/library/logos_delivery_api/node_api.nim
+++ b/library/logos_delivery_api/node_api.nim
@@ -3,6 +3,7 @@ import chronos, chronicles, results, ffi
 import brokers/broker_context
 import libp2p/peerid # pull PeerId pretty string formatting
 import logos_delivery/waku/common/base64
+from ../events/json_message_event import toJsonNode
 import
   logos_delivery,
   logos_delivery/waku/node/waku_node,
@@ -53,7 +54,13 @@ proc registerFFIEventListeners(self: LogosDelivery): Result[void, string] =
     self.waku.brokerCtx,
     proc(event: MessageReceivedEvent) {.async: (raises: []).} =
       emitEvent("onMessageReceived"):
-        $newJsonEvent("message_received", event),
+        $(
+          %*{
+            "eventType": "message_received",
+            "messageHash": event.messageHash,
+            "message": event.message.toJsonNode(),
+          }
+        ),
   ).isOkOr:
     chronicles.error "MessageReceivedEvent.listen failed", err = $error
     return err("MessageReceivedEvent.listen failed: " & $error)

--- a/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
+++ b/tests-e2e/tests/wrappers_tests/test_channel_delivery.py
@@ -111,8 +111,8 @@ def wait_for_message_received(collector, content_topic, timeout_s, poll_interval
 
 
 def wire_payload(event):
-    """The SDS envelope an event carried; the FFI sends it as an array of bytes."""
-    return bytes((event.get("message") or {}).get("payload") or ())
+    """The SDS envelope an event carried; the FFI sends it base64-encoded."""
+    return base64.b64decode((event.get("message") or {}).get("payload") or "")
 
 
 SDS_MESSAGE_ID_RE = re.compile(rb"[0-9a-f]{64}")


### PR DESCRIPTION
Closes #4169

# Description

1. `message_received` now carries the same base64 message object as the relay `message` event, instead of the raw `WakuMessage` that Nim's `std/json` rendered as `{"payload":[104,101,...]}`. A `%` overload for `WakuMessage` does it, so the event still derives its JSON from the event object via `newJsonEvent`.
2. `waku_store_query` now encodes its reply with the `json_serialization` writers the REST store endpoint already uses, so payloads are base64 and `Opt[T]` no longer leaks as `{"oResultPrivate":…,"vResultPrivate":…}`.
3. Extracted `JsonMessage.new(WakuMessage)` from `JsonMessageEvent.new`, dropping three `copyMem` blocks. They were the `seq[byte]` → `string` cast from the original cbindings commit and became dead when #2435 changed the field to `Base64String`; `base64.encode` takes an `openArray` and returns a fresh string, so nothing aliased the copy.

4. Updated `wire_payload` in the channel-delivery e2e tests, which built `bytes` straight from the JSON value and only worked while the payload was an array of integers.

Breaking change for FFI consumers of those two calls. `logos-delivery-go-bindings` already accepts both shapes (logos-messaging/logos-delivery-go-bindings#125); other bindings need checking before this ships.

<details>
<summary>AI-made decisions</summary>

- Reused the REST `encodeIntoJsonString` rather than adding `%` overloads for the store DTOs. Smaller, and it makes the FFI store reply byte-identical to the REST one, at the cost of importing `rest_api/endpoint` from `kernel_api`.
- First tried `Json.encode`, which is ambiguous here: `json_serialization` and the store types module both reach `serialization/formats`, so `Writer` resolves twice.
- The `from … import` in `node_api.nim` is load-bearing — without the `%` in scope the payload silently reverts to an integer array. Commented in the house style already used for the `libp2p/peerid` import above it.
- Empty `meta`/`proof` are omitted from the store reply but present as `""` in the events. Each side matches the encoder it now shares; unifying them would change the relay event's existing shape.
- Left the peer-ID and multiaddress `(data: @[...])` leaks alone. Same root cause, no byte fields, tracked in #4169.
- No unit test: `library/` has no registered suite and `tests/ffi/` is not wired into `all_tests_*`.

</details>
