### PR TITLE
fix(conf): drop duplicated dnsDiscovery name servers

### DIFF
--- a/logos_delivery/waku/factory/conf_builder/dns_discovery_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/dns_discovery_conf_builder.nim
@@ -1,4 +1,4 @@
-import chronicles, std/[net, strutils], results
+import chronicles, std/strutils, results
 import ../waku_conf
 
 logScope:
@@ -9,7 +9,6 @@ logScope:
 ##################################
 type DnsDiscoveryConfBuilder* = object
   enrTreeUrl*: Opt[string]
-  nameServers*: seq[IpAddress]
 
 proc init*(T: type DnsDiscoveryConfBuilder): DnsDiscoveryConfBuilder =
   DnsDiscoveryConfBuilder()
@@ -17,20 +16,11 @@ proc init*(T: type DnsDiscoveryConfBuilder): DnsDiscoveryConfBuilder =
 proc withEnrTreeUrl*(b: var DnsDiscoveryConfBuilder, enrTreeUrl: string) =
   b.enrTreeUrl = Opt.some(enrTreeUrl)
 
-proc withNameServers*(b: var DnsDiscoveryConfBuilder, nameServers: seq[IpAddress]) =
-  b.nameServers = nameServers
-
 proc build*(b: DnsDiscoveryConfBuilder): Result[Opt[DnsDiscoveryConf], string] =
   if b.enrTreeUrl.isNone():
     return ok(Opt.none(DnsDiscoveryConf))
 
   if isEmptyOrWhiteSpace(b.enrTreeUrl.get()):
     return err("dnsDiscovery.enrTreeUrl cannot be an empty string")
-  if b.nameServers.len == 0:
-    return err("dnsDiscovery.nameServers is not specified")
 
-  return ok(
-    Opt.some(
-      DnsDiscoveryConf(nameServers: b.nameServers, enrTreeUrl: b.enrTreeUrl.get())
-    )
-  )
+  return ok(Opt.some(DnsDiscoveryConf(enrTreeUrl: b.enrTreeUrl.get())))

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -53,8 +53,6 @@ type ProtectedShard* {.requiresInit.} = object
 
 type DnsDiscoveryConf* {.requiresInit.} = object
   enrTreeUrl*: string
-  # TODO: should probably only have one set of name servers (see dnsaddrs)
-  nameServers*: seq[IpAddress]
 
 type StoreSyncConf* {.requiresInit.} = object
   rangeSec*: uint32

--- a/logos_delivery/waku/waku.nim
+++ b/logos_delivery/waku/waku.nim
@@ -334,7 +334,7 @@ proc startDnsDiscoveryRetryLoop(waku: Waku): Future[void] {.async.} =
       let dnsDiscoveryConf = waku.conf.dnsDiscoveryConf.get()
       waku.dynamicBootstrapNodes = (
         await waku_dnsdisc.retrieveDynamicBootstrapNodes(
-          dnsDiscoveryConf.enrTreeUrl, dnsDiscoveryConf.nameServers
+          dnsDiscoveryConf.enrTreeUrl, waku.conf.dnsAddrsNameServers
         )
       ).valueOr:
         debug "Retrieving dynamic bootstrap nodes failed", error = error
@@ -396,7 +396,7 @@ proc start*(waku: Waku): Future[Result[void, string]] {.async: (raises: []).} =
     let dynamicBootstrapNodesRes =
       try:
         await waku_dnsdisc.retrieveDynamicBootstrapNodes(
-          dnsDiscoveryConf.enrTreeUrl, dnsDiscoveryConf.nameServers
+          dnsDiscoveryConf.enrTreeUrl, waku.conf.dnsAddrsNameServers
         )
       except CatchableError as exc:
         Result[seq[RemotePeerInfo], string].err(

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -1173,7 +1173,6 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
 
   if n.dnsDiscoveryUrl != "":
     b.dnsDiscoveryConf.withEnrTreeUrl(n.dnsDiscoveryUrl)
-  b.dnsDiscoveryConf.withNameServers(n.dnsAddrsNameServers)
 
   if n.discv5Discovery.isSome():
     b.discv5Conf.withEnabled(n.discv5Discovery.get())


### PR DESCRIPTION
## Problem

`DnsDiscoveryConf` carried its own `nameServers` copy and its builder rejected an empty one:

```nim
if b.nameServers.len == 0:
  return err("dnsDiscovery.nameServers is not specified")
```

Nothing could ever set it to a distinct value. The only feeder was `cli_args` passing `n.dnsAddrsNameServers` — the very field it duplicated — and the dedicated `--dns-discovery-name-server` flag was removed back in v0.37.0. So any path that builds a `WakuConf` without going through `toWakuConf` (network presets, tests, embedders using `WakuConfBuilder` directly) failed as soon as the config carried an `enrtree://` URL.

This is what blocks #4146, which moves TWN to enrtree entry nodes: https://github.com/logos-messaging/logos-delivery/actions/runs/33078374228/job/98538595832?pr=4146

## Fix

Read `WakuConf.dnsAddrsNameServers` at the point of lookup instead. One settable source of resolvers rather than two, only one of which could be set — this resolves the `TODO: should probably only have one set of name servers (see dnsaddrs)` left on the field.

## Why this is not a regression

- **No behaviour change on any existing path.** The value fed to the deleted field was always `dnsAddrsNameServers` itself, so DNS discovery resolves through exactly the same servers as before, in the same order.
- **`--dns-addrs-name-server` is untouched.** Operators keep the override, on the CLI and as a `kernelConf` key in the liblogosdelivery JSON. Unset, it defaults to Cloudflare `1.1.1.1` / `1.0.0.1` — the confutils `defaultValue`, plus a second default in `WakuConfBuilder` for direct-builder embedders.
- **Nothing else referenced the removed field.** One construction site, one setter, two reads, all updated; no test, FFI symbol, or config key mapped to it. The fleets don't set any name-server option (checked `infra-waku`, `infra-logos`, `infra-role-nim-waku`, `infra-role-logos-node`) — waku.sandbox/test already run DNS discovery on the default resolvers.
- **The only capability lost** is pointing DNS discovery at different resolvers than dnsaddr resolution, which had no way of being expressed since v0.37.0. If it's ever wanted, the clean shape is a new flag feeding a genuinely separate field.
