### PR TITLE
DO NOT MERGE: net backend train (#4152-#4156) as one diff

### DIFF
--- a/docs/api/net-backend.md
+++ b/docs/api/net-backend.md
@@ -1,0 +1,73 @@
+# Running the Edge protocols over another module's libp2p node
+
+A node normally owns its libp2p stack. When another module in the same process
+already runs a libp2p node, that module can register a *net backend* with
+`liblogosdelivery`, and a node created with `"libp2pProvider": "<name>"` then
+runs its Edge protocols over that node. The process then holds one identity and
+one socket set.
+
+```json
+{
+  "mode": "Edge",
+  "preset": "logos.test",
+  "kernelConf": { "nodekey": "<hex private key>" },
+  "libp2pProvider": "libp2p_module"
+}
+```
+
+Both sides must hold the same private key, or the two peer IDs diverge.
+
+## C ABI
+
+`library/liblogosdelivery.h` declares both symbols. The ABI version is 1.
+
+```c
+int logosdelivery_register_net_backend(const char *name,
+                                       const LogosDeliveryNetBackendTable *table,
+                                       void *userData);
+int logosdelivery_net_backend_respond(uint64_t requestId, int ok,
+                                      const char *data, size_t len);
+```
+
+Register the backend before you create the node. The library then calls
+`table->submit(requestId, opJson, opLen, userData)` on its own thread with
+`{"op": "<name>", "args": {...}}`. `submit` must return at once, and every
+request must get exactly one `logosdelivery_net_backend_respond`, from any
+thread: `ok != 0` carries the result JSON, `ok == 0` the error text. An op with
+no answer within its timeout fails on the library side and its answer is then
+dropped.
+
+## Ops
+
+| op | args | result |
+| --- | --- | --- |
+| `connectPeer` | `{peerId, multiaddrs, timeoutMs}` | `{}` |
+| `dial` | `{peerId, proto}` | the stream id |
+| `protocolRequest` | `{peerId, proto, multiaddrs, requestB64, timeoutMs, maxSize, expectResponse}` | `{responseB64}` |
+| `mountProtocol` | `{proto}` | `{}` |
+| `protocolAcceptStream` | `{proto, timeoutMs}` | `{streamId, proto, peerId}` |
+| `streamReadLp` | `{streamId, maxSize, timeoutMs}` | `{dataB64}` |
+| `streamWriteLp` | `{streamId, dataB64}` | `{}` |
+| `streamClose` / `streamRelease` | `{streamId}` | `{}` |
+
+A request/response exchange costs one `protocolRequest`. An inbound stream costs
+one `protocolAcceptStream` plus one op per frame, so a long poll holds one worker
+on the backend side for its whole timeout.
+
+## Limits
+
+- Edge protocols only. `createNode` rejects a config that enables relay, because
+  gossipsub needs a real `PubSub` object mounted on a switch.
+- discv5 stays off. It owns a UDP socket and signs with the node key, so
+  `createNode` turns it off and says so in the log. Use entry nodes and peer
+  exchange.
+- The local switch is built but never started, and it serves the peer store
+  alone. That store and the backend's own peer store drift apart: a bridged node
+  answers `getPeersByProtocol` from peers it was told about, not from peers the
+  backend knows. Give a service peer explicitly until the peer store ops exist.
+- The node still advertises the addresses it was configured with, in its ENR and
+  in peer exchange, and nothing listens on them. The backend's own addresses are
+  the reachable ones.
+- A backend restart invalidates every stream id. Create the node again.
+- A bridged stream carries whole length-prefixed frames. A raw `write` or
+  `readOnce` on it fails.

--- a/library/liblogosdelivery.h
+++ b/library/liblogosdelivery.h
@@ -61,6 +61,40 @@ extern "C"
   int logosdelivery_remove_event_listener(void *ctx,
                                           uint64_t listenerId);
 
+// Net backend ABI. A module that owns a libp2p node registers a backend under a
+// name, and a node created with "libp2pProvider": "<name>" runs its Edge
+// protocols over that node instead of its own libp2p stack.
+#define LOGOSDELIVERY_NET_BACKEND_ABI_VERSION 1
+
+  // Called on the library thread with {"op": "<name>", "args": {...}} and must
+  // return at once. Every request gets exactly one
+  // logosdelivery_net_backend_respond, from any thread.
+  typedef void (*LogosDeliveryNetSubmitFn)(uint64_t requestId,
+                                           const char *opJson,
+                                           size_t opLen,
+                                           void *userData);
+
+  typedef struct
+  {
+    uint32_t version;
+    LogosDeliveryNetSubmitFn submit;
+  } LogosDeliveryNetBackendTable;
+
+  // Registers (or replaces) the backend named `name`. Returns 0 on success, and
+  // non-zero for a null argument, an unsupported version, a name longer than 63
+  // characters, or a full backend registry.
+  int logosdelivery_register_net_backend(const char *name,
+                                         const LogosDeliveryNetBackendTable *table,
+                                         void *userData);
+
+  // Answers one submitted op. `ok != 0` carries the result JSON in `data`, and
+  // `ok == 0` carries the error text. The library copies `data` before
+  // returning. Returns 0 when the answer reaches the library thread.
+  int logosdelivery_net_backend_respond(uint64_t requestId,
+                                        int ok,
+                                        const char *data,
+                                        size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/liblogosdelivery.nim
+++ b/library/liblogosdelivery.nim
@@ -15,6 +15,7 @@ import
 ## Include different APIs, i.e. all procs with {.ffi.} pragma
 
 include
+  ./network_bridge_api,
   ./logos_delivery_api/node_api,
   ./logos_delivery_api/messaging_api,
   ./logos_delivery_api/debug_api,

--- a/library/network_bridge_api.nim
+++ b/library/network_bridge_api.nim
@@ -1,0 +1,15 @@
+import logos_delivery/waku/net/net_bridge
+
+proc logosdelivery_register_net_backend(
+    name: cstring, table: ptr NetBackendTable, userData: pointer
+): cint {.dynlib, exportc, cdecl.} =
+  registerNetBackend(name, table, userData)
+
+proc logosdelivery_net_backend_respond(
+    requestId: uint64, ok: cint, data: cstring, len: csize_t
+): cint {.dynlib, exportc, cdecl.} =
+  ## The caller's thread owns `data` and may free it once this returns.
+  if len > csize_t(int.high):
+    return 1
+
+  netBackendRespond(requestId, ok != 0, cast[pointer](data), int(len))

--- a/logos_delivery/api/conf/logos_delivery_conf_json.nim
+++ b/logos_delivery/api/conf/logos_delivery_conf_json.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import std/[json, strutils, tables]
+import std/[json, sequtils, strutils, tables]
 import results
 
 import tools/confutils/conf_from_json
@@ -14,6 +14,7 @@ const
   KeyKernelConf = "kernelconf"
   KeyMessagingOverrides = "messagingoverrides"
   KeyChannelsOverrides = "channelsoverrides"
+  KeyLibp2pProvider = "libp2pprovider"
   # [Legacy flat JSON config] Keys that left the kernel and so must be lifted out of
   # a flat blob before the WakuNodeConf walker sees them (it would reject them).
   KeyReliabilityEnabled = "reliabilityenabled"
@@ -99,15 +100,38 @@ proc parseFlatConf(
     )
   )
 
-proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
-  var node: JsonNode
-  try:
-    node = parseJson(jsonStr)
-  except CatchableError as e:
-    return err("invalid JSON: " & e.msg)
-  if node.kind != JObject:
-    return err("configuration JSON must be an object")
+proc takeLibp2pProvider(node: JsonNode): Result[string, string] =
+  ## The key names a net backend the library owns, so it never reaches the
+  ## kernel field walker under its JSON name. Every spelling of it goes, or the
+  ## one left behind would be rejected as an unknown kernel field.
+  var provider = Opt.none(string)
 
+  for key in toSeq(node.keys):
+    if key.toLowerAscii() != KeyLibp2pProvider:
+      continue
+
+    let value = node.getOrDefault(key)
+    if value.isNil() or value.kind != JString:
+      return err("libp2pProvider must be a string")
+
+    try:
+      node.delete(key)
+    except KeyError:
+      return err("failed to read libp2pProvider")
+
+    provider = Opt.some(value.getStr().strip())
+
+  let name = provider.valueOr:
+    return ok("")
+
+  ## Asking for a backend by no name is a mistake, not a request for the
+  ## node's own libp2p stack. Leave the key out for that.
+  if name.len == 0:
+    return err("libp2pProvider must name a registered net backend")
+
+  return ok(name)
+
+proc parseConfNode(node: JsonNode): ConfResult[LogosDeliveryConf] =
   var top = ?collectJsonFields(node)
 
   var mode = LogosDeliveryMode.Core
@@ -186,5 +210,24 @@ proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
     messagingOverrides = messagingOverrides,
     channelsOverrides = channelsOverrides,
   )
+
+proc parseLogosDeliveryConf*(jsonStr: string): ConfResult[LogosDeliveryConf] =
+  var node: JsonNode
+  try:
+    node = parseJson(jsonStr)
+  except CatchableError as e:
+    return err("invalid JSON: " & e.msg)
+  if node.kind != JObject:
+    return err("configuration JSON must be an object")
+
+  let libp2pProvider = ?takeLibp2pProvider(node)
+
+  var conf = ?parseConfNode(node)
+  if libp2pProvider.len > 0:
+    var kernel = WakuNodeConf(conf.kernelConf)
+    kernel.libp2pProvider = libp2pProvider
+    conf.kernelConf = KernelConf(kernel)
+
+  return ok(conf)
 
 {.pop.}

--- a/logos_delivery/waku/factory/builder.nim
+++ b/logos_delivery/waku/factory/builder.nim
@@ -33,6 +33,7 @@ type
     peerStorageCapacity: Opt[int]
 
     # Peer manager config
+    netBackend: NetBackend
     maxRelayPeers: int
     maxServicePeers: int
     colocationLimit: int
@@ -105,6 +106,9 @@ proc withNetworkConfigurationDetails*(
   ok()
 
 ## Peer storage and peer manager
+
+proc withNetBackend*(builder: var WakuNodeBuilder, netBackend: NetBackend) =
+  builder.netBackend = netBackend
 
 proc withPeerStorage*(
     builder: var WakuNodeBuilder, peerStorage: PeerStorage, capacity = Opt.none(int)
@@ -213,6 +217,7 @@ proc build*(builder: WakuNodeBuilder): Result[WakuNode, string] =
 
   let peerManager = PeerManager.new(
     switch = switch,
+    netBackend = builder.netBackend,
     storage = builder.peerStorage.get(nil),
     maxRelayPeers = Opt.some(builder.maxRelayPeers),
     maxServicePeers = Opt.some(builder.maxServicePeers),

--- a/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
@@ -165,6 +165,7 @@ type WakuConfBuilder* = object
   colocationLimit: Opt[int]
 
   agentString: Opt[string]
+  libp2pProvider: Opt[string]
 
   maxRelayPeers: Opt[int]
   relayShardedPeerManagement: Opt[bool]
@@ -297,6 +298,10 @@ proc withNatDiscoveryTimeoutMs*(b: var WakuConfBuilder, timeoutMs: uint32) =
 
 proc withAgentString*(b: var WakuConfBuilder, agentString: string) =
   b.agentString = Opt.some(agentString)
+
+proc withLibp2pProvider*(b: var WakuConfBuilder, libp2pProvider: string) =
+  if libp2pProvider.len > 0:
+    b.libp2pProvider = Opt.some(libp2pProvider)
 
 proc withColocationLimit*(b: var WakuConfBuilder, colocationLimit: int) =
   b.colocationLimit = Opt.some(colocationLimit)
@@ -851,6 +856,7 @@ proc build*(
     peerStoreCapacity: builder.peerStoreCapacity,
     maxConnections: maxConnections,
     agentString: agentString,
+    libp2pProvider: builder.libp2pProvider,
     colocationLimit: colocationLimit,
     maxRelayPeers: builder.maxRelayPeers,
     relayServiceRatio: builder.relayServiceRatio.get(DefaultRelayServiceRatio),

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -22,6 +22,9 @@ import
   ../waku_node,
   ../net/net_config,
   ../net/nat_config,
+  ../net/net_backend,
+  ../net/bridged_backend,
+  ../net/net_bridge,
   ../waku_core,
   ../waku_core/codecs,
   ../rln,
@@ -56,6 +59,18 @@ proc setupPeerStorage(): Result[Opt[WakuPeerStorage], string] =
   return ok(Opt.some(res))
 
 ## Init waku node instance
+
+proc netBackendFor(conf: WakuConf): Result[NetBackend, string] =
+  ## Nil unless the config names a backend that owns the libp2p node.
+  let provider = conf.libp2pProvider.valueOr:
+    return ok(nil)
+
+  if conf.relay:
+    return err("libp2pProvider serves the Edge protocols only, so relay must be off")
+
+  let transport = ?getNetTransport(provider)
+
+  return ok(BridgedNetBackend.new(transport))
 
 proc initNode(
     conf: WakuConf,
@@ -133,6 +148,14 @@ proc initNode(
     )
   builder.withRateLimit(conf.rateLimit)
   builder.withCircuitRelay(relay)
+
+  let netBackend = ?netBackendFor(conf)
+  if not netBackend.isNil():
+    builder.withNetBackend(netBackend)
+    if conf.discv5Conf.isSome():
+      info "the net backend owns the node key and the sockets, so discv5 stays off",
+        provider = conf.libp2pProvider.get()
+      conf.discv5Conf = Opt.none(Discv5Conf)
 
   let node = ?builder.build().mapErr(
     proc(err: string): string =

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -129,6 +129,7 @@ type WakuConf* {.requiresInit.} = ref object
 
   dnsAddrsNameServers*: seq[IpAddress]
   endpointConf*: EndpointConf
+  libp2pProvider*: Opt[string]
   wakuFlags*: CapabilitiesBitfield
 
   # TODO: could probably make it a `PeerRemoteInfo`

--- a/logos_delivery/waku/net/bridged_backend.nim
+++ b/logos_delivery/waku/net/bridged_backend.nim
@@ -1,0 +1,343 @@
+## Runs the Edge protocols over a libp2p node another module owns. Every op
+## crosses the process boundary as JSON, so a request/response exchange goes in
+## one crossing and a stream costs one crossing per frame.
+
+{.push raises: [].}
+
+import std/[json, sequtils, strutils]
+import results, chronicles, chronos
+import libp2p/[multiaddress, peerid]
+import libp2p/protocols/protocol
+import libp2p/stream/connection
+import ../common/base64, ./net_backend, ./net_transport
+
+logScope:
+  topics = "waku bridged backend"
+
+const
+  AcceptPollTimeout = chronos.seconds(10)
+  PollRetryDelay = chronos.milliseconds(250)
+  OpSlack = chronos.seconds(5)
+  FramesOnly = "a bridged stream carries whole frames only"
+
+type
+  InboundProtocol = object
+    proto: string
+    handler: LPProtoHandler
+
+  BridgedNetBackend* = ref object of NetBackend
+    transport: NetTransport
+    inbound: seq[InboundProtocol]
+    acceptFuts: seq[Future[void]]
+    running: bool
+
+  BridgedConnection* = ref object of Connection
+    transport: NetTransport
+    streamId*: uint64
+
+func new*(T: type BridgedNetBackend, transport: NetTransport): T =
+  BridgedNetBackend(transport: transport)
+
+proc streamIdOf(node: JsonNode): Opt[uint64] =
+  if node.isNil():
+    return Opt.none(uint64)
+
+  case node.kind
+  of JInt:
+    Opt.some(uint64(node.getBiggestInt()))
+  of JString:
+    try:
+      Opt.some(uint64(parseBiggestUInt(node.getStr())))
+    except ValueError:
+      Opt.none(uint64)
+  else:
+    Opt.none(uint64)
+
+proc fieldStr(node: JsonNode, key: string): string =
+  if node.isNil() or node.kind != JObject:
+    return ""
+
+  let field = node.getOrDefault(key)
+  if field.isNil() or field.kind != JString:
+    return ""
+
+  return field.getStr()
+
+proc bytesOf(node: JsonNode, key: string): Result[seq[byte], string] =
+  let encoded = node.fieldStr(key)
+  if encoded.len == 0:
+    return ok(newSeq[byte]())
+
+  return base64.decode(Base64String(encoded))
+
+proc call(
+    backend: BridgedNetBackend, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  return await backend.transport.submit(op, args, timeout + OpSlack)
+
+proc newBridgedConnection(
+    transport: NetTransport,
+    streamId: uint64,
+    peerId: PeerId,
+    proto: string,
+    dir: Direction,
+): BridgedConnection =
+  let conn = BridgedConnection(transport: transport, streamId: streamId, peerId: peerId)
+  conn.protocol = proto
+  conn.dir = dir
+  conn.transportDir = dir
+  conn.objName = "BridgedConnection"
+  conn.initStream()
+
+  return conn
+
+proc isPollTimeout(error: string): bool =
+  error.contains("timeout") or error.contains("timed out")
+
+proc streamOp(
+    conn: BridgedConnection, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  return await conn.transport.submit(op, args, timeout + OpSlack)
+
+method readLp*(
+    conn: BridgedConnection, maxSize: int
+): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
+  let args = %*{
+    "streamId": conn.streamId,
+    "maxSize": maxSize,
+    "timeoutMs": DefaultConnectionTimeout.milliseconds,
+  }
+
+  while true:
+    let answer = (await conn.streamOp("streamReadLp", args, DefaultConnectionTimeout)).valueOr:
+      if not conn.isClosed and error.isPollTimeout():
+        continue
+      conn.isEof = true
+      raise newException(LPStreamError, error)
+
+    let data = answer.bytesOf("dataB64").valueOr:
+      conn.isEof = true
+      raise newException(LPStreamError, error)
+
+    if data.len > maxSize:
+      conn.isEof = true
+      raise (ref MaxSizeError)(msg: "Message exceeds maximum length")
+
+    conn.activity = true
+
+    return data
+
+proc writeFrame(
+    conn: BridgedConnection, msg: seq[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
+  let args = %*{"streamId": conn.streamId, "dataB64": $base64.encode(msg)}
+
+  discard (await conn.streamOp("streamWriteLp", args, DefaultConnectionTimeout)).valueOr:
+    raise newException(LPStreamError, error)
+
+  conn.activity = true
+
+method writeLp*(
+    conn: BridgedConnection, msg: openArray[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  conn.writeFrame(@msg)
+
+method writeLp*(
+    conn: BridgedConnection, msg: string
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  conn.writeFrame(toSeq(msg.toOpenArrayByte(0, msg.high)))
+
+method write*(
+    conn: BridgedConnection, msg: sink seq[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  let fut = Future[void].Raising([CancelledError, LPStreamError]).init(
+      "bridgedconnection.write"
+    )
+  fut.fail(newException(LPStreamError, FramesOnly))
+
+  return fut
+
+method readOnce*(
+    conn: BridgedConnection, pbytes: pointer, nbytes: int
+): Future[int] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  let fut = Future[int].Raising([CancelledError, LPStreamError]).init(
+      "bridgedconnection.readOnce"
+    )
+  fut.fail(newException(LPStreamError, FramesOnly))
+
+  return fut
+
+method closeImpl*(conn: BridgedConnection): Future[void] {.async: (raises: []).} =
+  let args = %*{"streamId": conn.streamId}
+  discard await conn.streamOp("streamClose", args, DefaultConnectionTimeout)
+  discard await conn.streamOp("streamRelease", args, DefaultConnectionTimeout)
+
+  conn.isEof = true
+
+  await procCall Connection(conn).closeImpl()
+
+method dial*(
+    backend: BridgedNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  if addrs.len > 0:
+    let connectArgs = %*{
+      "peerId": $peerId,
+      "multiaddrs": addrs.mapIt($it),
+      "timeoutMs": timeout.milliseconds,
+    }
+    let connected = await backend.call("connectPeer", connectArgs, timeout)
+    if connected.isErr():
+      trace "Bridged connect failed",
+        peerId = peerId, proto = proto, reason = connected.error
+      return Opt.none(Connection)
+
+  let answer = (
+    await backend.call("dial", %*{"peerId": $peerId, "proto": proto}, timeout)
+  ).valueOr:
+    trace "Bridged dial failed", peerId = peerId, proto = proto, reason = error
+    return Opt.none(Connection)
+
+  let streamId = streamIdOf(answer).valueOr:
+    trace "Bridged dial returned no stream", peerId = peerId, proto = proto
+    return Opt.none(Connection)
+
+  return Opt.some(
+    Connection(
+      newBridgedConnection(backend.transport, streamId, peerId, proto, Direction.Out)
+    )
+  )
+
+proc requestErrorKind(cause: string): NetErrorKind =
+  ## One crossing covers connect, dial, write and read, so only the error prefix tells the stages apart.
+  if cause.contains("dial failed") or cause.contains("connect failed"):
+    NetErrorKind.Dial
+  elif cause.contains("write failed"):
+    NetErrorKind.Write
+  else:
+    NetErrorKind.Read
+
+method request*(
+    backend: BridgedNetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  let args = %*{
+    "peerId": $req.peerId,
+    "proto": req.proto,
+    "multiaddrs": req.addrs.mapIt($it),
+    "requestB64": $base64.encode(req.payload),
+    "timeoutMs": req.timeout.milliseconds,
+    "maxSize": req.maxSize,
+    "expectResponse": req.expectResponse,
+  }
+
+  let answer = (await backend.call("protocolRequest", args, req.timeout)).valueOr:
+    return err(NetError(kind: requestErrorKind(error), cause: error))
+
+  if not req.expectResponse:
+    return ok(newSeq[byte]())
+
+  let data = answer.bytesOf("responseB64").valueOr:
+    return err(NetError(kind: NetErrorKind.Read, cause: error))
+
+  if data.len > req.maxSize:
+    return
+      err(NetError(kind: NetErrorKind.Read, cause: "response exceeds maximum length"))
+
+  return ok(data)
+
+proc serveInbound(
+    handler: LPProtoHandler, conn: Connection, proto: string
+) {.async: (raises: []).} =
+  try:
+    await handler(conn, proto)
+  except CancelledError:
+    discard
+
+  await conn.close()
+
+proc acceptLoop(
+    backend: BridgedNetBackend, entry: InboundProtocol
+) {.async: (raises: []).} =
+  let args = %*{"proto": entry.proto, "timeoutMs": AcceptPollTimeout.milliseconds}
+
+  while backend.running:
+    let answer = (await backend.call("protocolAcceptStream", args, AcceptPollTimeout)).valueOr:
+      ## A poll that saw no stream is the ordinary outcome, so it goes straight
+      ## back in. Anything else backs off and says so.
+      if error.isPollTimeout():
+        continue
+
+      debug "Inbound accept poll failed", proto = entry.proto, reason = error
+
+      try:
+        await sleepAsync(PollRetryDelay)
+      except CancelledError:
+        return
+
+      continue
+
+    let streamId = streamIdOf(answer.getOrDefault("streamId")).valueOr:
+      continue
+
+    let peerId = PeerId.init(answer.fieldStr("peerId")).valueOr:
+      trace "Inbound stream has no usable peer id", proto = entry.proto
+      continue
+
+    let conn = newBridgedConnection(
+      backend.transport, streamId, peerId, entry.proto, Direction.In
+    )
+
+    asyncSpawn serveInbound(entry.handler, Connection(conn), entry.proto)
+
+proc mountOne(
+    backend: BridgedNetBackend, entry: InboundProtocol
+) {.async: (raises: []).} =
+  let mounted = await backend.call("mountProtocol", %*{"proto": entry.proto}, OpSlack)
+  if mounted.isErr():
+    error "failed to mount an inbound protocol on the net backend",
+      proto = entry.proto, error = mounted.error
+    return
+
+  ## A stop can land while the mount op is still crossing, and a loop added
+  ## after that one would never be cancelled by anybody.
+  if not backend.running:
+    return
+
+  backend.acceptFuts.add(backend.acceptLoop(entry))
+
+proc mountInboundProtocols(backend: BridgedNetBackend) {.async: (raises: []).} =
+  for entry in backend.inbound:
+    await backend.mountOne(entry)
+
+method mountInbound*(
+    backend: BridgedNetBackend, proto: string, handler: LPProtoHandler
+) {.gcsafe.} =
+  let entry = InboundProtocol(proto: proto, handler: handler)
+  backend.inbound.add(entry)
+
+  ## Mounted after the node started, so it needs its own loop now: nothing is
+  ## going to walk `inbound` a second time.
+  if backend.running:
+    asyncSpawn backend.mountOne(entry)
+
+method start*(backend: BridgedNetBackend) {.async: (raises: []).} =
+  if backend.running:
+    return
+
+  backend.running = true
+
+  ## Spawned rather than awaited: a backend that never answers `mountProtocol`
+  ## would otherwise hold up the whole node start.
+  asyncSpawn backend.mountInboundProtocols()
+
+method stop*(backend: BridgedNetBackend) {.async: (raises: []).} =
+  backend.running = false
+  let futs = backend.acceptFuts
+  backend.acceptFuts = @[]
+
+  await allFutures(futs.mapIt(cancelAndWait(it)))
+
+{.pop.}

--- a/logos_delivery/waku/net/bridged_backend.nim
+++ b/logos_delivery/waku/net/bridged_backend.nim
@@ -176,6 +176,9 @@ method closeImpl*(conn: BridgedConnection): Future[void] {.async: (raises: []).}
 
   await procCall Connection(conn).closeImpl()
 
+method usesLocalSwitch*(backend: BridgedNetBackend): bool {.gcsafe.} =
+  false
+
 method dial*(
     backend: BridgedNetBackend,
     peerId: PeerId,

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -1,4 +1,5 @@
-## The peer manager dial path: its own switch, or a libp2p node another process owns.
+## Abstracts the libp2p operations the Edge protocol clients need, so a node can
+## run them over its own switch or over a libp2p node another process owns.
 
 {.push raises: [].}
 
@@ -7,11 +8,56 @@ import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
 logScope:
   topics = "waku net backend"
 
+const
+  DefaultNetDialTimeout* = chronos.seconds(10)
+  DefaultNetMaxResponseSize* = 1024 * 1024
+
 type
+  NetErrorKind* {.pure.} = enum
+    Dial
+    Write
+    Read
+
+  NetError* = object
+    kind*: NetErrorKind
+    cause*: string
+
+  NetRequest* = object
+    peerId*: PeerId
+    addrs*: seq[MultiAddress]
+    proto*: string
+    payload*: seq[byte]
+    maxSize*: int
+    timeout*: Duration
+
   NetBackend* = ref object of RootObj
 
   SwitchNetBackend* = ref object of NetBackend
     switch: Switch
+
+func init*(
+    T: type NetRequest,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultNetDialTimeout,
+): NetRequest =
+  NetRequest(
+    peerId: peerId,
+    addrs: addrs,
+    proto: proto,
+    payload: payload,
+    maxSize: maxSize,
+    timeout: timeout,
+  )
+
+func dialError*(cause: string): NetError =
+  NetError(kind: NetErrorKind.Dial, cause: cause)
+
+func `$`*(err: NetError): string =
+  $err.kind & " failed: " & err.cause
 
 method dial*(
     backend: NetBackend,
@@ -20,10 +66,60 @@ method dial*(
     proto: string,
     timeout: Duration,
 ): Future[Opt[Connection]] {.base, async: (raises: []).} =
-  raiseAssert "[NetBackend.dial] abstract method not implemented"
+  error "backend serves no streams", proto = proto
+  return Opt.none(Connection)
+
+method connect*(
+    backend: NetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
+): Future[Result[void, string]] {.base, async: (raises: []).} =
+  return err("backend opens no connections")
+
+method request*(
+    backend: NetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.base, async: (raises: []).} =
+  ## One length-prefixed frame out, one back, over a stream of its own.
+  let connection = (await backend.dial(req.peerId, req.addrs, req.proto, req.timeout)).valueOr:
+    return err(dialError($req.peerId & " on " & req.proto))
+
+  defer:
+    await connection.closeWithEof()
+
+  let writeRes = catch:
+    await connection.writeLP(req.payload)
+  if writeRes.isErr():
+    return err(NetError(kind: NetErrorKind.Write, cause: writeRes.error.msg))
+
+  let readRes = catch:
+    await connection.readLp(req.maxSize)
+
+  let buffer = readRes.valueOr:
+    return err(NetError(kind: NetErrorKind.Read, cause: error.msg))
+
+  return ok(buffer)
 
 func new*(T: type SwitchNetBackend, switch: Switch): T =
   SwitchNetBackend(switch: switch)
+
+method connect*(
+    backend: SwitchNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    timeout: Duration,
+): Future[Result[void, string]] {.async: (raises: []).} =
+  let connectFut = backend.switch.connect(peerId, addrs)
+
+  let res = catch:
+    if await connectFut.withTimeout(timeout):
+      connectFut.read()
+      return ok()
+
+  if not connectFut.finished():
+    await noCancel cancelAndWait(connectFut)
+
+  if res.isErr():
+    return err(res.error.msg)
+
+  return err("timed out")
 
 method dial*(
     backend: SwitchNetBackend,

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -4,6 +4,7 @@
 {.push raises: [].}
 
 import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
+import libp2p/protocols/protocol
 
 logScope:
   topics = "waku net backend"
@@ -73,6 +74,18 @@ method connect*(
     backend: NetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
 ): Future[Result[void, string]] {.base, async: (raises: []).} =
   return err("backend opens no connections")
+
+method mountInbound*(
+    backend: NetBackend, proto: string, handler: LPProtoHandler
+) {.base, gcsafe.} =
+  ## A switch dispatches an inbound stream to the mounted protocol on its own.
+  discard
+
+method start*(backend: NetBackend) {.base, async: (raises: []).} =
+  discard
+
+method stop*(backend: NetBackend) {.base, async: (raises: []).} =
+  discard
 
 method request*(
     backend: NetBackend, req: NetRequest

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -1,0 +1,50 @@
+## The peer manager dial path: its own switch, or a libp2p node another process owns.
+
+{.push raises: [].}
+
+import results, chronicles, chronos, libp2p/[multiaddress, peerid, switch]
+
+logScope:
+  topics = "waku net backend"
+
+type
+  NetBackend* = ref object of RootObj
+
+  SwitchNetBackend* = ref object of NetBackend
+    switch: Switch
+
+method dial*(
+    backend: NetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.base, async: (raises: []).} =
+  raiseAssert "[NetBackend.dial] abstract method not implemented"
+
+func new*(T: type SwitchNetBackend, switch: Switch): T =
+  SwitchNetBackend(switch: switch)
+
+method dial*(
+    backend: SwitchNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  let dialFut = backend.switch.dial(peerId, addrs, proto)
+
+  let res = catch:
+    if await dialFut.withTimeout(timeout):
+      return Opt.some(dialFut.read())
+
+  if not dialFut.finished():
+    await noCancel cancelAndWait(dialFut)
+
+  let reasonFailed = if res.isOk(): "timed out" else: res.error.msg
+
+  trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
+
+  return Opt.none(Connection)
+
+{.pop.}

--- a/logos_delivery/waku/net/net_backend.nim
+++ b/logos_delivery/waku/net/net_backend.nim
@@ -81,6 +81,11 @@ method mountInbound*(
   ## A switch dispatches an inbound stream to the mounted protocol on its own.
   discard
 
+method usesLocalSwitch*(backend: NetBackend): bool {.base, gcsafe.} =
+  ## False when another process owns the libp2p node, so the local switch
+  ## keeps the peer store alone and never listens.
+  true
+
 method start*(backend: NetBackend) {.base, async: (raises: []).} =
   discard
 

--- a/logos_delivery/waku/net/net_bridge.nim
+++ b/logos_delivery/waku/net/net_bridge.nim
@@ -1,0 +1,324 @@
+## Carries net ops to a backend registered over the C ABI, and carries the
+## answers back. A backend answers from a foreign thread, so a response crosses
+## on shared memory and wakes the library thread through a signal.
+
+{.push raises: [].}
+
+import std/[json, locks, tables]
+import results, chronicles, chronos, chronos/threadsync, metrics
+import ./net_transport
+
+declarePublicCounter logos_delivery_net_bridge_ops,
+  "number of net backend ops by outcome", ["op", "outcome"]
+
+logScope:
+  topics = "waku net bridge"
+
+const
+  NetBackendAbiVersion* = 1'u32
+  MaxNetBackends = 8
+  MaxBackendNameLen = 63
+
+type
+  NetSubmitFn* = proc(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+  ) {.cdecl, gcsafe, raises: [].}
+
+  NetBackendTable* = object
+    version*: uint32
+    submit*: NetSubmitFn
+
+  BackendSlot = object
+    name: array[MaxBackendNameLen + 1, char]
+    submit: NetSubmitFn
+    userData: pointer
+    used: bool
+
+  Response = object
+    next: ptr Response
+    requestId: uint64
+    ok: bool
+    len: int
+    data: ptr UncheckedArray[byte]
+
+  OpAnswer = object
+    ok: bool
+    data: string
+
+  NetBridgeTransport* = ref object of NetTransport
+    name*: string
+    submitFn: NetSubmitFn
+    userData: pointer
+
+var
+  bridgeLock: Lock
+  backends: array[MaxNetBackends, BackendSlot]
+  responseHead: ptr Response
+  responseTail: ptr Response
+  responseSignal: ThreadSignalPtr
+  signalReady: bool
+  drainClaimed: bool
+
+var nextRequestId: uint64
+
+var
+  pending {.threadvar.}: Table[uint64, Future[OpAnswer]]
+  drainFut {.threadvar.}: Future[void]
+
+initLock(bridgeLock)
+
+proc slotFor(name: cstring): int =
+  ## Caller holds the lock. A free slot when the name is new, else the match.
+  var free = -1
+  for i in 0 ..< MaxNetBackends:
+    if not backends[i].used:
+      if free < 0:
+        free = i
+      continue
+    if cast[cstring](addr backends[i].name[0]) == name:
+      return i
+  return free
+
+proc registerNetBackend*(
+    name: cstring, table: ptr NetBackendTable, userData: pointer
+): cint {.gcsafe.} =
+  if name.isNil() or table.isNil() or table.submit.isNil():
+    return 1
+  if table.version != NetBackendAbiVersion:
+    return 2
+  ## Read once: the caller owns that buffer, so a second `len` could size the
+  ## copy past the array the first one cleared.
+  let nameLen = len(name)
+  if nameLen > MaxBackendNameLen:
+    return 3
+
+  acquire(bridgeLock)
+  defer:
+    release(bridgeLock)
+
+  let slot = slotFor(name)
+  if slot < 0:
+    return 4
+
+  zeroMem(addr backends[slot].name[0], MaxBackendNameLen + 1)
+  copyMem(addr backends[slot].name[0], cast[pointer](name), nameLen)
+  backends[slot].submit = table.submit
+  backends[slot].userData = userData
+  backends[slot].used = true
+
+  return 0
+
+proc freeResponse(node: ptr Response) =
+  if not node.data.isNil():
+    deallocShared(node.data)
+  deallocShared(node)
+
+proc netBackendRespond*(
+    requestId: uint64, ok: bool, data: pointer, len: int
+): cint {.gcsafe.} =
+  ## Runs on the backend's thread: it may touch no Nim heap and must not block.
+  if len < 0:
+    return 1
+
+  let node = cast[ptr Response](allocShared0(sizeof(Response)))
+  node.requestId = requestId
+  node.ok = ok
+
+  if len > 0 and not data.isNil():
+    node.data = cast[ptr UncheckedArray[byte]](allocShared(len))
+    copyMem(node.data, data, len)
+    node.len = len
+
+  acquire(bridgeLock)
+
+  ## No drain means nothing waits on this and nothing would ever free it.
+  if not signalReady:
+    release(bridgeLock)
+    freeResponse(node)
+    return 1
+
+  if responseTail.isNil():
+    responseHead = node
+  else:
+    responseTail.next = node
+  responseTail = node
+
+  ## Fired under the lock, because a drain on its way out closes the signal
+  ## under the same lock. Outside it, this could write to a closed handle.
+  discard responseSignal.fireSync()
+
+  release(bridgeLock)
+
+  return 0
+
+proc takeResponses(): ptr Response =
+  acquire(bridgeLock)
+  let head = responseHead
+  responseHead = nil
+  responseTail = nil
+  release(bridgeLock)
+
+  return head
+
+proc answerOf(node: ptr Response): OpAnswer =
+  var answer = OpAnswer(ok: node.ok)
+  if node.len > 0:
+    answer.data = newString(node.len)
+    copyMem(addr answer.data[0], node.data, node.len)
+
+  return answer
+
+proc dispatchResponses() =
+  var node = takeResponses()
+  while not node.isNil():
+    let next = node.next
+
+    pending.withValue(node.requestId, fut):
+      if not fut[].finished():
+        fut[].complete(answerOf(node))
+    pending.del(node.requestId)
+
+    freeResponse(node)
+
+    node = next
+
+proc releaseDrain() =
+  acquire(bridgeLock)
+  let signal = responseSignal
+  let hadSignal = signalReady
+  var queued = responseHead
+
+  responseHead = nil
+  responseTail = nil
+  signalReady = false
+  drainClaimed = false
+  release(bridgeLock)
+
+  while not queued.isNil():
+    let next = queued.next
+    freeResponse(queued)
+    queued = next
+
+  if hadSignal:
+    discard signal.close()
+
+proc drainLoop() {.async: (raises: []).} =
+  while true:
+    try:
+      await responseSignal.wait()
+    except CancelledError:
+      break
+    except AsyncError as e:
+      error "the net bridge signal failed, so no answer can reach this thread",
+        err = e.msg
+      break
+
+    dispatchResponses()
+
+  drainFut = nil
+  releaseDrain()
+
+proc startDrain(): Result[void, string] =
+  if not drainFut.isNil():
+    return ok()
+
+  ## `pending` and the loop are per thread, the signal and the queue are not.
+  ## A second thread taking them over would strand every future the first one
+  ## is still holding, so it is refused instead.
+  acquire(bridgeLock)
+  let taken = drainClaimed
+  if not taken:
+    drainClaimed = true
+  release(bridgeLock)
+
+  if taken:
+    return err("the net bridge already belongs to another thread")
+
+  let signal = ThreadSignalPtr.new().valueOr:
+    acquire(bridgeLock)
+    drainClaimed = false
+    release(bridgeLock)
+
+    return err("failed to create the net bridge signal: " & error)
+
+  acquire(bridgeLock)
+  responseSignal = signal
+  signalReady = true
+  release(bridgeLock)
+
+  drainFut = drainLoop()
+
+  return ok()
+
+proc getNetTransport*(name: string): Result[NetTransport, string] =
+  ## Runs on the library thread, where the returned transport is used.
+  acquire(bridgeLock)
+  var found = -1
+  for i in 0 ..< MaxNetBackends:
+    if backends[i].used and $cast[cstring](addr backends[i].name[0]) == name:
+      found = i
+      break
+  let slot =
+    if found < 0:
+      BackendSlot()
+    else:
+      backends[found]
+  release(bridgeLock)
+
+  if found < 0:
+    return err("no net backend named '" & name & "' is registered")
+
+  ?startDrain()
+
+  return ok(
+    NetTransport(
+      NetBridgeTransport(name: name, submitFn: slot.submit, userData: slot.userData)
+    )
+  )
+
+method submit*(
+    transport: NetBridgeTransport, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let payload =
+    try:
+      $(%*{"op": op, "args": args})
+    except CatchableError as e:
+      return err("failed to encode op " & op & ": " & e.msg)
+
+  inc(nextRequestId)
+  let requestId = nextRequestId
+  let fut = Future[OpAnswer].Raising([CancelledError]).init("netbridge.op")
+  pending[requestId] = fut
+
+  transport.submitFn(
+    requestId, cstring(payload), csize_t(payload.len), transport.userData
+  )
+
+  var answer: OpAnswer
+  try:
+    if not await fut.withTimeout(timeout):
+      pending.del(requestId)
+      logos_delivery_net_bridge_ops.inc(labelValues = [op, "timeout"])
+      return err("op " & op & " timed out")
+    answer = fut.read()
+  except CatchableError as e:
+    pending.del(requestId)
+    logos_delivery_net_bridge_ops.inc(labelValues = [op, "failed"])
+    return err("op " & op & " failed: " & e.msg)
+
+  if not answer.ok:
+    logos_delivery_net_bridge_ops.inc(labelValues = [op, "error"])
+    return err(answer.data)
+
+  let node =
+    try:
+      parseJson(answer.data)
+    except CatchableError as e:
+      logos_delivery_net_bridge_ops.inc(labelValues = [op, "failed"])
+      return err("op " & op & " returned invalid JSON: " & e.msg)
+
+  logos_delivery_net_bridge_ops.inc(labelValues = [op, "ok"])
+
+  return ok(node)
+
+{.pop.}

--- a/logos_delivery/waku/net/net_transport.nim
+++ b/logos_delivery/waku/net/net_transport.nim
@@ -1,0 +1,15 @@
+## One crossing to the process that owns the libp2p node: an op name, a JSON
+## argument object, and a JSON answer.
+
+{.push raises: [].}
+
+import std/json, results, chronos
+
+type NetTransport* = ref object of RootObj
+
+method submit*(
+    transport: NetTransport, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.base, async: (raises: []).} =
+  raiseAssert "[NetTransport.submit] abstract method not implemented"
+
+{.pop.}

--- a/logos_delivery/waku/node/peer_manager/peer_manager.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_manager.nim
@@ -25,11 +25,12 @@ import
     common/utils/parse_size_units,
     node/health_monitor/online_monitor,
     node/waku_switch,
+    net/net_backend,
   ],
   ./peer_store/peer_storage,
   ./waku_peer_store
 
-export waku_peer_store, peer_storage, peers
+export waku_peer_store, peer_storage, peers, net_backend
 
 declareCounter logos_delivery_peers_dials, "Number of peer dials", ["outcome"]
 # TODO: Populate from PeerStore.Source when ready
@@ -92,6 +93,7 @@ type ConnectionChangeHandler* = proc(
 type PeerManager* = ref object of RootObj
   brokerCtx: BrokerContext
   switch*: Switch
+  netBackend*: NetBackend
   wakuMetadata*: WakuMetadata
   initialBackoffInSec*: int
   backoffFactor*: int
@@ -450,20 +452,7 @@ proc dialPeer(
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
 
-  # Dial Peer
-  let dialFut = pm.switch.dial(peerId, addrs, proto)
-
-  let res = catch:
-    if await dialFut.withTimeout(dialTimeout):
-      return Opt.some(dialFut.read())
-    else:
-      await cancelAndWait(dialFut)
-
-  let reasonFailed = if res.isOk: "timed out" else: res.error.msg
-
-  trace "Dialing peer failed", peerId = peerId, reason = reasonFailed, proto = proto
-
-  return Opt.none(Connection)
+  return await pm.netBackend.dial(peerId, addrs, proto, dialTimeout)
 
 proc dialPeer*(
     pm: PeerManager,
@@ -1180,6 +1169,7 @@ proc new*(
     colocationLimit = DefaultColocationLimit,
     shardedPeerManagement = false,
     maxConnections: int = MaxConnections,
+    netBackend: NetBackend = nil,
 ): PeerManager {.gcsafe.} =
   let capacity = switch.peerStore.capacity
   if maxConnections > capacity:
@@ -1220,6 +1210,11 @@ proc new*(
 
   let pm = PeerManager(
     switch: switch,
+    netBackend:
+      if netBackend.isNil():
+        SwitchNetBackend.new(switch)
+      else:
+        netBackend,
     brokerCtx: brokerCtx,
     wakuMetadata: wakuMetadata,
     storage: storage,

--- a/logos_delivery/waku/node/peer_manager/peer_manager.nim
+++ b/logos_delivery/waku/node/peer_manager/peer_manager.nim
@@ -60,7 +60,7 @@ randomize()
 
 const
   # TODO: Make configurable
-  DefaultDialTimeout* = chronos.seconds(10)
+  DefaultDialTimeout* = DefaultNetDialTimeout
 
   # Max attempts before removing the peer
   MaxFailedAttempts = 5
@@ -348,29 +348,17 @@ proc connectPeer*(
   trace "Connecting to peer",
     wireAddr = peer.addrs, peerId = peerId, failedAttempts = failedAttempts
 
-  var deadline = sleepAsync(dialTimeout)
-  let workfut = pm.switch.connect(peerId, peer.addrs)
+  let connected = await pm.netBackend.connect(peerId, peer.addrs, dialTimeout)
 
-  # Can't use catch: with .withTimeout() in this case
-  let res = catch:
-    await workfut or deadline
+  if connected.isOk():
+    logos_delivery_peers_dials.inc(labelValues = ["successful"])
+    logos_delivery_node_conns_initiated.inc(labelValues = [source])
 
-  let reasonFailed =
-    if not workfut.finished():
-      await workfut.cancelAndWait()
-      "timed out"
-    elif res.isErr():
-      res.error.msg
-    else:
-      if not deadline.finished():
-        await deadline.cancelAndWait()
+    peerStore[NumberFailedConnBook][peerId] = 0
 
-      logos_delivery_peers_dials.inc(labelValues = ["successful"])
-      logos_delivery_node_conns_initiated.inc(labelValues = [source])
+    return true
 
-      peerStore[NumberFailedConnBook][peerId] = 0
-
-      return true
+  let reasonFailed = connected.error
 
   # Dial failed
   peerStore[NumberFailedConnBook][peerId] = peerStore[NumberFailedConnBook][peerId] + 1
@@ -381,7 +369,7 @@ proc connectPeer*(
     peerId = peerId,
     reason = reasonFailed,
     failedAttempts = peerStore[NumberFailedConnBook][peerId]
-  logos_delivery_peers_dials.inc(labelValues = [reasonFailed])
+  logos_delivery_peers_dials.inc(labelValues = ["failed"])
 
   return false
 
@@ -431,9 +419,26 @@ proc disconnectNode*(pm: PeerManager, peer: RemotePeerInfo) {.async.} =
   let peerId = peer.peerId
   await pm.disconnectNode(peerId)
 
-# Dialing should be used for just protocols that require a stream to write and read
-# This shall not be used to dial Relay protocols, since that would create
-# unneccesary unused streams.
+func checkStreamTarget(
+    pm: PeerManager, peerId: PeerId, proto: string
+): Result[void, string] =
+  if peerId == pm.switch.peerInfo.peerId:
+    return err("could not open a stream to self")
+
+  # A relay stream would sit there unused, so relay codecs never get one.
+  if proto == WakuRelayCodec:
+    return err("streams shall not be used to connect to relays")
+
+  ok()
+
+proc rememberPeer(pm: PeerManager, remotePeerInfo: RemotePeerInfo, proto: string) =
+  if pm.switch.peerStore.hasPeer(remotePeerInfo.peerId, proto):
+    return
+
+  trace "Adding newly dialed peer to manager",
+    peerId = $remotePeerInfo.peerId, addrs = remotePeerInfo.addrs, proto = proto
+  pm.addPeer(remotePeerInfo)
+
 proc dialPeer(
     pm: PeerManager,
     peerId: PeerID,
@@ -442,12 +447,8 @@ proc dialPeer(
     dialTimeout = DefaultDialTimeout,
     source = "api",
 ): Future[Opt[Connection]] {.async.} =
-  if peerId == pm.switch.peerInfo.peerId:
-    error "could not dial self"
-    return Opt.none(Connection)
-
-  if proto == WakuRelayCodec:
-    error "dial shall not be used to connect to relays"
+  pm.checkStreamTarget(peerId, proto).isOkOr:
+    error "dial refused", peerId = peerId, proto = proto, reason = error
     return Opt.none(Connection)
 
   trace "Dialing peer", wireAddr = addrs, peerId = peerId, proto = proto
@@ -464,12 +465,7 @@ proc dialPeer*(
   # Dial a given peer and add it to the list of known peers
   # TODO: check peer validity and score before continuing. Limit number of peers to be managed.
 
-  # First add dialed peer info to peer store, if it does not exist yet..
-  # TODO: nim libp2p peerstore already adds them
-  if not pm.switch.peerStore.hasPeer(remotePeerInfo.peerId, proto):
-    trace "Adding newly dialed peer to manager",
-      peerId = $remotePeerInfo.peerId, address = $remotePeerInfo.addrs[0], proto = proto
-    pm.addPeer(remotePeerInfo)
+  pm.rememberPeer(remotePeerInfo, proto)
 
   return await pm.dialPeer(
     remotePeerInfo.peerId, remotePeerInfo.addrs, proto, dialTimeout, source
@@ -487,6 +483,43 @@ proc dialPeer*(
 
   let addrs = pm.switch.peerStore[AddressBook][peerId]
   return await pm.dialPeer(peerId, addrs, proto, dialTimeout, source)
+
+proc request*(
+    pm: PeerManager,
+    remotePeerInfo: RemotePeerInfo,
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultDialTimeout,
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  ## Sends one length-prefixed frame to `proto` on `peer` and reads the answer.
+  pm.checkStreamTarget(remotePeerInfo.peerId, proto).isOkOr:
+    return err(dialError(error))
+
+  pm.rememberPeer(remotePeerInfo, proto)
+
+  return await pm.netBackend.request(
+    NetRequest.init(
+      peerId = remotePeerInfo.peerId,
+      addrs = remotePeerInfo.addrs,
+      proto = proto,
+      payload = payload,
+      maxSize = maxSize,
+      timeout = timeout,
+    )
+  )
+
+proc request*(
+    pm: PeerManager,
+    peerId: PeerId,
+    proto: string,
+    payload: seq[byte],
+    maxSize = DefaultNetMaxResponseSize,
+    timeout = DefaultDialTimeout,
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  let peer = RemotePeerInfo.init(peerId, pm.switch.peerStore[AddressBook][peerId])
+
+  return await pm.request(peer, proto, payload, maxSize, timeout)
 
 proc canBeConnected*(pm: PeerManager, peerId: PeerId): bool =
   # Returns if we can try to connect to this peer, based on past failed attempts

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -635,7 +635,10 @@ proc start*(node: WakuNode) {.async.} =
     await node.wakuRendezvousClient.start()
 
   ## NOTE: This will dispatch gossipsub start to the WakuRelay.start method override
-  await node.switch.start()
+  if node.peerManager.netBackend.usesLocalSwitch():
+    await node.switch.start()
+  else:
+    info "net backend owns the libp2p node, the local switch stays idle"
 
   ## The sockets are bound now. Resolve the announced addresses, commit
   ## them, and copy once. The observer fires only on a changed commit.
@@ -682,7 +685,8 @@ proc stop*(node: WakuNode) {.async.} =
     await node.wakuKademlia.stop()
 
   ## NOTE: This will dispatch gossipsub stop to the WakuRelay.stop method override
-  await node.switch.stop()
+  if node.peerManager.netBackend.usesLocalSwitch():
+    await node.switch.stop()
 
   await node.peerManager.netBackend.stop()
   node.peerManager.stop()

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -643,6 +643,8 @@ proc start*(node: WakuNode) {.async.} =
   await node.switch.peerInfo.update()
   node.copyCommittedAddresses()
 
+  await node.peerManager.netBackend.start()
+
   # Reconnect to known relay peers in the background; it waits a prune backoff
   # and must not block startup.
   node.relayReconnectFut = node.reconnectRelayPeers()
@@ -682,6 +684,7 @@ proc stop*(node: WakuNode) {.async.} =
   ## NOTE: This will dispatch gossipsub stop to the WakuRelay.stop method override
   await node.switch.stop()
 
+  await node.peerManager.netBackend.stop()
   node.peerManager.stop()
 
   if not node.rln.isNil():

--- a/logos_delivery/waku/node/waku_node/filter.nim
+++ b/logos_delivery/waku/node/waku_node/filter.nim
@@ -96,6 +96,10 @@ proc mountFilterClient*(node: WakuNode) {.async: (raises: []).} =
   except LPError:
     error "failed to mount wakuFilterClient", error = getCurrentExceptionMsg()
 
+  node.peerManager.netBackend.mountInbound(
+    WakuFilterPushCodec, node.wakuFilterClient.handler
+  )
+
 proc filterSubscribe*(
     node: WakuNode,
     pubsubTopic: Opt[PubsubTopic],

--- a/logos_delivery/waku/waku_filter_v2/client.nim
+++ b/logos_delivery/waku/waku_filter_v2/client.nim
@@ -40,42 +40,22 @@ proc sendSubscribeRequest(
   trace "Sending filter subscribe request",
     peerId = servicePeer.peerId, filterSubscribeRequest
 
-  var connOpt: Opt[Connection]
-  try:
-    connOpt = await wfc.peerManager.dialPeer(servicePeer, WakuFilterSubscribeCodec)
-    if connOpt.isNone():
+  let respBuf = (
+    await wfc.peerManager.request(
+      servicePeer,
+      WakuFilterSubscribeCodec,
+      filterSubscribeRequest.encode().buffer,
+      DefaultMaxSubscribeResponseSize,
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
       trace "Failed to dial filter service peer", servicePeer
       logos_delivery_filter_errors.inc(labelValues = [dialFailure])
       return err(FilterSubscribeError.peerDialFailure($servicePeer))
-  except CatchableError:
-    let errMsg = "failed to dialPeer: " & getCurrentExceptionMsg()
-    trace "failed to dialPeer", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
 
-  let connection = connOpt.get()
-
-  defer:
-    await connection.closeWithEOF()
-
-  try:
-    await connection.writeLP(filterSubscribeRequest.encode().buffer)
-  except CatchableError:
-    let errMsg =
-      "exception in waku_filter_v2 client writeLP: " & getCurrentExceptionMsg()
-    trace "exception in waku_filter_v2 client writeLP", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
-
-  var respBuf: seq[byte]
-  try:
-    respBuf = await connection.readLp(DefaultMaxSubscribeResponseSize)
-  except CatchableError:
-    let errMsg =
-      "exception in waku_filter_v2 client readLp: " & getCurrentExceptionMsg()
-    trace "exception in waku_filter_v2 client readLp", error = getCurrentExceptionMsg()
-    logos_delivery_filter_errors.inc(labelValues = [errMsg])
-    return err(FilterSubscribeError.badResponse(errMsg))
+    trace "filter subscribe request failed", error = $error
+    logos_delivery_filter_errors.inc(labelValues = [requestFailure])
+    return err(FilterSubscribeError.badResponse(error.cause))
 
   let response = FilterSubscribeResponse.decode(respBuf).valueOr:
     trace "Failed to decode filter subscribe response", servicePeer

--- a/logos_delivery/waku/waku_filter_v2/protocol_metrics.nim
+++ b/logos_delivery/waku/waku_filter_v2/protocol_metrics.nim
@@ -26,3 +26,4 @@ const
   requestIdMismatch* = "request_id_mismatch"
   errorResponse* = "error_response"
   pushTimeoutFailure* = "push_timeout_failure"
+  requestFailure* = "request_failure"

--- a/logos_delivery/waku/waku_lightpush/client.nim
+++ b/logos_delivery/waku/waku_lightpush/client.nim
@@ -30,34 +30,7 @@ func shortPeerId(peer: PeerId): string =
 func shortPeerId(peer: RemotePeerInfo): string =
   shortLog(peer.peerId)
 
-proc sendPushRequest(
-    wl: WakuLightPushClient,
-    req: LightPushRequest,
-    peer: PeerId | RemotePeerInfo,
-    conn: Opt[Connection] = Opt.none(Connection),
-): Future[WakuLightPushResult] {.async.} =
-  let connection = conn.valueOr:
-    (await wl.peerManager.dialPeer(peer, WakuLightPushCodec)).valueOr:
-      logos_delivery_lightpush_v3_errors.inc(labelValues = [dialFailure])
-      return lighpushErrorResult(
-        LightPushErrorCode.NO_PEERS_TO_RELAY,
-        dialFailure & ": " & $peer & " is not accessible",
-      )
-
-  defer:
-    await connection.closeWithEOF()
-
-  await connection.writeLP(req.encode().buffer)
-
-  var buffer: seq[byte]
-  try:
-    buffer = await connection.readLp(DefaultMaxRpcSize.int)
-  except LPStreamRemoteClosedError:
-    debug "Failed to read response from peer", error = getCurrentExceptionMsg()
-    return lightpushResultInternalError(
-      "Failed to read response from peer: " & getCurrentExceptionMsg()
-    )
-
+proc parsePushResponse(req: LightPushRequest, buffer: seq[byte]): WakuLightPushResult =
   let response = LightpushResponse.decode(buffer).valueOr:
     debug "Failed to decode response"
     logos_delivery_lightpush_v3_errors.inc(labelValues = [decodeRpcFailure])
@@ -70,6 +43,44 @@ proc sendPushRequest(
     return lightpushResultInternalError("response failure, requestId mismatch")
 
   return toPushResult(response)
+
+proc sendPushRequestOverConn(
+    wl: WakuLightPushClient, req: LightPushRequest, connection: Connection
+): Future[WakuLightPushResult] {.async.} =
+  defer:
+    await connection.closeWithEOF()
+
+  await connection.writeLP(req.encode().buffer)
+
+  var buffer: seq[byte]
+  try:
+    buffer = await connection.readLp(MaxLightpushResponseSize)
+  except LPStreamRemoteClosedError:
+    debug "Failed to read response from peer", error = getCurrentExceptionMsg()
+    return lightpushResultInternalError(
+      "Failed to read response from peer: " & getCurrentExceptionMsg()
+    )
+
+  return parsePushResponse(req, buffer)
+
+proc sendPushRequest(
+    wl: WakuLightPushClient, req: LightPushRequest, peer: PeerId | RemotePeerInfo
+): Future[WakuLightPushResult] {.async.} =
+  let buffer = (
+    await wl.peerManager.request(
+      peer, WakuLightPushCodec, req.encode().buffer, MaxLightpushResponseSize
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
+      logos_delivery_lightpush_v3_errors.inc(labelValues = [dialFailure])
+      return lighpushErrorResult(
+        LightPushErrorCode.NO_PEERS_TO_RELAY,
+        dialFailure & ": " & $peer & " is not accessible",
+      )
+    debug "Lightpush request failed", error = $error
+    return lightpushResultInternalError($error)
+
+  return parsePushResponse(req, buffer)
 
 proc publish*(
     wl: WakuLightPushClient,
@@ -99,7 +110,7 @@ proc publish*(
 
   let relayPeerCount =
     when dest is Connection:
-      ?await wl.sendPushRequest(request, dest.peerId, Opt.some(dest))
+      ?await wl.sendPushRequestOverConn(request, dest)
     else:
       ?await wl.sendPushRequest(request, dest)
 

--- a/logos_delivery/waku/waku_lightpush/common.nim
+++ b/logos_delivery/waku/waku_lightpush/common.nim
@@ -7,6 +7,8 @@ from ../waku_core/codecs import WakuLightPushCodec
 export WakuLightPushCodec
 export LightPushStatusCode
 
+const MaxLightpushResponseSize* = 64 * 1024
+
 const LightPushSuccessCode* = (SUCCESS: LightPushStatusCode(200))
 
 const LightPushErrorCode* = (

--- a/logos_delivery/waku/waku_peer_exchange/client.nim
+++ b/logos_delivery/waku/waku_peer_exchange/client.nim
@@ -25,34 +25,7 @@ type WakuPeerExchangeClient* = ref object
 proc new*(T: type WakuPeerExchangeClient, peerManager: PeerManager): T =
   WakuPeerExchangeClient(peerManager: peerManager)
 
-proc request*(
-    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, conn: Connection
-): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
-  let rpc = PeerExchangeRpc.makeRequest(numPeers)
-
-  var buffer: seq[byte]
-  var callResult =
-    (status_code: PeerExchangeResponseStatusCode.SUCCESS, status_desc: Opt.none(string))
-  try:
-    await conn.writeLP(rpc.encode().buffer)
-    buffer = await conn.readLp(DefaultMaxRpcSize.int)
-  except CatchableError as exc:
-    debug "Exception when handling peer exchange request", error = exc.msg
-    logos_delivery_px_client_errors.inc(
-      labelValues = ["error_sending_or_receiving_px_req"]
-    )
-    callResult = (
-      status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
-      status_desc: Opt.some($exc.msg),
-    )
-  finally:
-    # close, no more data is expected
-    await conn.closeWithEof()
-
-  if callResult.status_code != PeerExchangeResponseStatusCode.SUCCESS:
-    debug "Peer exchange request failed", status_code = callResult.status_code
-    return err(callResult)
-
+proc decodeResponse(buffer: seq[byte]): WakuPeerExchangeResult[PeerExchangeResponse] =
   let decoded = PeerExchangeRpc.decode(buffer).valueOr:
     debug "Peer exchange request error decoding buffer", error = $error
     return err(
@@ -73,11 +46,44 @@ proc request*(
   return ok(decoded.response)
 
 proc request*(
+    wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, conn: Connection
+): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
+  let rpc = PeerExchangeRpc.makeRequest(numPeers)
+
+  var buffer: seq[byte]
+  var callResult =
+    (status_code: PeerExchangeResponseStatusCode.SUCCESS, status_desc: Opt.none(string))
+  try:
+    await conn.writeLP(rpc.encode().buffer)
+    buffer = await conn.readLp(DefaultMaxRpcSize.int)
+  except CatchableError as exc:
+    debug "Exception when handling peer exchange request", error = exc.msg
+    logos_delivery_px_client_errors.inc(labelValues = [sendOrReceiveFailure])
+    callResult = (
+      status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+      status_desc: Opt.some($exc.msg),
+    )
+  finally:
+    # close, no more data is expected
+    await conn.closeWithEof()
+
+  if callResult.status_code != PeerExchangeResponseStatusCode.SUCCESS:
+    debug "Peer exchange request failed", status_code = callResult.status_code
+    return err(callResult)
+
+  return decodeResponse(buffer)
+
+proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq, peer: RemotePeerInfo
 ): Future[WakuPeerExchangeResult[PeerExchangeResponse]] {.async: (raises: []).} =
-  try:
-    let connOpt = await wpx.peerManager.dialPeer(peer, WakuPeerExchangeCodec)
-    if connOpt.isNone():
+  let rpc = PeerExchangeRpc.makeRequest(numPeers)
+
+  let buffer = (
+    await wpx.peerManager.request(
+      peer, WakuPeerExchangeCodec, rpc.encode().buffer, DefaultMaxRpcSize.int
+    )
+  ).valueOr:
+    if error.kind == NetErrorKind.Dial:
       debug "Peer exchange request dial failed, no connection"
       return err(
         (
@@ -85,15 +91,17 @@ proc request*(
           status_desc: Opt.some(dialFailure),
         )
       )
-    return await wpx.request(numPeers, connOpt.get())
-  except CatchableError:
-    debug "Peer exchange request exception", error = getCurrentExceptionMsg()
+
+    debug "Peer exchange request failed", error = $error
+    logos_delivery_px_client_errors.inc(labelValues = [sendOrReceiveFailure])
     return err(
       (
-        status_code: PeerExchangeResponseStatusCode.BAD_RESPONSE,
-        status_desc: Opt.some("exception dialing peer: " & getCurrentExceptionMsg()),
+        status_code: PeerExchangeResponseStatusCode.SERVICE_UNAVAILABLE,
+        status_desc: Opt.some(error.cause),
       )
     )
+
+  return decodeResponse(buffer)
 
 proc request*(
     wpx: WakuPeerExchangeClient, numPeers = DefaultPXNumPeersReq

--- a/logos_delivery/waku/waku_peer_exchange/common.nim
+++ b/logos_delivery/waku/waku_peer_exchange/common.nim
@@ -18,5 +18,6 @@ const
   retrievePeersDiscv5Error* = "retrieve_peers_discv5_failure"
   pxFailure* = "px_failure"
   streamClosedFailure* = "stream_closed_failure"
+  sendOrReceiveFailure* = "error_sending_or_receiving_px_req"
 
 type WakuPeerExchangeResult*[T] = Result[T, PeerExchangeResponseStatus]

--- a/logos_delivery/waku/waku_store/client.nim
+++ b/logos_delivery/waku/waku_store/client.nim
@@ -30,28 +30,32 @@ proc new*(
   WakuStoreClient(peerManager: peerManager, rng: rng)
 
 proc sendStoreRequest(
-    self: WakuStoreClient, request: StoreQueryRequest, connection: Connection
+    self: WakuStoreClient, request: StoreQueryRequest, peer: RemotePeerInfo | PeerId
 ): Future[StoreQueryResult] {.async, gcsafe.} =
   var req = request
 
-  self.peerManager.addActiveStoreRequest(connection.peerId)
+  let peerId = when peer is PeerId: peer else: peer.peerId
+
+  self.peerManager.addActiveStoreRequest(peerId)
   defer:
-    self.peerManager.removeActiveStoreRequest(connection.peerId)
-    await connection.closeWithEof()
+    self.peerManager.removeActiveStoreRequest(peerId)
 
   if req.requestId == "":
     req.requestId = generateRequestId(self.rng)
 
-  let writeRes = catch:
-    await connection.writeLP(req.encode().buffer)
-  if writeRes.isErr():
-    return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: writeRes.error.msg))
-
-  let readRes = catch:
-    await connection.readLp(DefaultMaxRpcSize.int)
-
-  let buf = readRes.valueOr:
-    return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.msg))
+  let buf = (
+    await self.peerManager.request(
+      peer, WakuStoreCodec, req.encode().buffer, MaxStoreResponseSize.int
+    )
+  ).valueOr:
+    case error.kind
+    of NetErrorKind.Dial:
+      logos_delivery_store_errors.inc(labelValues = [DialFailure])
+      return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
+    of NetErrorKind.Write:
+      return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: error.cause))
+    of NetErrorKind.Read:
+      return err(StoreError(kind: ErrorCode.BAD_RESPONSE, cause: error.cause))
 
   let res = StoreQueryResponse.decode(buf).valueOr:
     logos_delivery_store_errors.inc(labelValues = [DecodeRpcFailure])
@@ -80,12 +84,7 @@ proc query*(
   if request.paginationCursor.isSome() and request.paginationCursor.get() == EmptyCursor:
     return err(StoreError(kind: ErrorCode.BAD_REQUEST, cause: "invalid cursor"))
 
-  let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-    logos_delivery_store_errors.inc(labelValues = [DialFailure])
-
-    return err(StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer))
-
-  return await self.sendStoreRequest(request, connection)
+  return await self.sendStoreRequest(request, peer)
 
 proc queryToAny*(
     self: WakuStoreClient, request: StoreQueryRequest, peerId = Opt.none(PeerId)
@@ -107,13 +106,7 @@ proc queryToAny*(
 
   var lastError: StoreError
   for peer in peersToTry:
-    let connection = (await self.peerManager.dialPeer(peer, WakuStoreCodec)).valueOr:
-      logos_delivery_store_errors.inc(labelValues = [DialFailure])
-      debug "Failed to dial store peer, trying next"
-      lastError = StoreError(kind: ErrorCode.PEER_DIAL_FAILURE, address: $peer)
-      continue
-
-    let response = (await self.sendStoreRequest(request, connection)).valueOr:
+    let response = (await self.sendStoreRequest(request, peer)).valueOr:
       debug "Store query failed, trying next peer", peerId = peer.peerId, error = $error
       lastError = error
       continue

--- a/logos_delivery/waku/waku_store/common.nim
+++ b/logos_delivery/waku/waku_store/common.nim
@@ -11,6 +11,9 @@ const
 
   MaxPageSize*: uint64 = 100
 
+  MaxStoreResponseSize* =
+    MaxPageSize * DefaultMaxWakuMessageSize + DefaultSafetyBufferProtocolOverhead
+
   EmptyCursor*: WakuMessageHash = EmptyWakuMessageHash
 
 type WakuStoreResult*[T] = Result[T, string]

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -29,7 +29,10 @@ import ./wakunode_rest/test_rest_store
 # Waku store test suite
 import ./waku_store/test_all
 
-import ./waku_net/test_net_backend, ./waku_net/test_net_bridge
+import
+  ./waku_net/test_net_backend,
+  ./waku_net/test_net_bridge,
+  ./waku_net/test_bridged_backend
 
 # Waku store sync suite
 import ./waku_store_sync/test_all

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -29,7 +29,7 @@ import ./wakunode_rest/test_rest_store
 # Waku store test suite
 import ./waku_store/test_all
 
-import ./waku_net/test_net_backend
+import ./waku_net/test_net_backend, ./waku_net/test_net_bridge
 
 # Waku store sync suite
 import ./waku_store_sync/test_all

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -29,6 +29,9 @@ import ./wakunode_rest/test_rest_store
 # Waku store test suite
 import ./waku_store/test_all
 
+# Net backend test suite
+import ./waku_net/test_net_backend
+
 # Waku store sync suite
 import ./waku_store_sync/test_all
 

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -29,7 +29,6 @@ import ./wakunode_rest/test_rest_store
 # Waku store test suite
 import ./waku_store/test_all
 
-# Net backend test suite
 import ./waku_net/test_net_backend
 
 # Waku store sync suite

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -446,3 +446,32 @@ suite "parseLogosDeliveryConf - flat WakuNodeConf shape (interop compatibility)"
     # not flip to flat; the leftover bare field (relay) then has no structured home and
     # is rejected. Guards against the discriminator silently splitting a mixed object.
     check parseLogosDeliveryConf("""{"messagingOverrides": {}, "relay": true}""").isErr()
+
+suite "parseLogosDeliveryConf - libp2pProvider":
+  test "the provider reaches the kernel conf and leaves the field walker alone":
+    let conf = parseLogosDeliveryConf(
+      """{"mode": "Edge", "libp2pProvider": "libp2p_module"}"""
+    ).valueOr:
+      raiseAssert error
+
+    check WakuNodeConf(conf.kernelConf).libp2pProvider == "libp2p_module"
+
+  test "no provider leaves the node on its own libp2p stack":
+    let conf = parseLogosDeliveryConf("""{"mode": "Edge"}""").valueOr:
+      raiseAssert error
+
+    check WakuNodeConf(conf.kernelConf).libp2pProvider == ""
+
+  test "the key is taken under any spelling":
+    let conf = parseLogosDeliveryConf(
+      """{"mode": "Edge", "LIBP2PPROVIDER": "libp2p_module"}"""
+    ).valueOr:
+      raiseAssert error
+
+    check WakuNodeConf(conf.kernelConf).libp2pProvider == "libp2p_module"
+
+  test "a provider that is not a string is refused":
+    check parseLogosDeliveryConf("""{"libp2pProvider": 7}""").isErr()
+
+  test "a provider with no name is refused":
+    check parseLogosDeliveryConf("""{"libp2pProvider": "   "}""").isErr()

--- a/tests/waku_net/switch_transport.nim
+++ b/tests/waku_net/switch_transport.nim
@@ -1,0 +1,183 @@
+{.used.}
+
+## A net transport that answers the op vocabulary from its own switch.
+
+import std/[json, tables]
+import results, chronos, libp2p/[multiaddress, peerid, switch]
+import libp2p/protocols/protocol
+import logos_delivery/waku/common/base64, logos_delivery/waku/net/net_transport
+
+type SwitchTransport* = ref object of NetTransport
+  switch: Switch
+  streams: Table[uint64, Connection]
+  inbound: Table[string, seq[uint64]]
+  nextStreamId: uint64
+
+func new*(T: type SwitchTransport, switch: Switch): T =
+  SwitchTransport(switch: switch)
+
+proc track(transport: SwitchTransport, conn: Connection): uint64 =
+  inc(transport.nextStreamId)
+  transport.streams[transport.nextStreamId] = conn
+
+  return transport.nextStreamId
+
+proc streamOf(transport: SwitchTransport, args: JsonNode): Result[Connection, string] =
+  let streamId = uint64(args{"streamId"}.getBiggestInt())
+  transport.streams.withValue(streamId, conn):
+    return ok(conn[])
+
+  return err("unknown stream")
+
+proc addrsOf(args: JsonNode): seq[MultiAddress] =
+  var addrs: seq[MultiAddress]
+  for entry in args{"multiaddrs"}.getElems():
+    let address = MultiAddress.init(entry.getStr())
+    if address.isOk():
+      addrs.add(address.get())
+
+  return addrs
+
+proc dialStream(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[uint64, string]] {.async: (raises: []).} =
+  let peerId = PeerId.init(args{"peerId"}.getStr()).valueOr:
+    return err("bad peer id")
+
+  let addrs = addrsOf(args)
+
+  let conn =
+    try:
+      if addrs.len > 0:
+        await transport.switch.dial(peerId, addrs, args{"proto"}.getStr())
+      else:
+        await transport.switch.dial(peerId, args{"proto"}.getStr())
+    except CatchableError as e:
+      return err("dial failed: " & e.msg)
+
+  return ok(transport.track(conn))
+
+proc connectPeer(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let peerId = PeerId.init(args{"peerId"}.getStr()).valueOr:
+    return err("bad peer id")
+
+  try:
+    await transport.switch.connect(peerId, addrsOf(args))
+  except CatchableError as e:
+    return err("connect failed: " & e.msg)
+
+  return ok(newJObject())
+
+proc protocolRequest(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let streamId = ?await transport.dialStream(args)
+  let conn = transport.streams.getOrDefault(streamId)
+
+  defer:
+    transport.streams.del(streamId)
+    await conn.closeWithEof()
+
+  let payload = base64.decode(Base64String(args{"requestB64"}.getStr())).valueOr:
+    return err("bad requestB64")
+
+  try:
+    await conn.writeLP(payload)
+  except CatchableError as e:
+    return err("write failed: " & e.msg)
+
+  if not args{"expectResponse"}.getBool(true):
+    return ok(newJObject())
+
+  let response =
+    try:
+      await conn.readLp(int(args{"maxSize"}.getBiggestInt()))
+    except CatchableError as e:
+      return err("read failed: " & e.msg)
+
+  return ok(%*{"responseB64": $base64.encode(response)})
+
+proc mountProtocol(
+    transport: SwitchTransport, proto: string
+): Result[JsonNode, string] =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    let streamId = transport.track(conn)
+    transport.inbound.mgetOrPut(proto, @[]).add(streamId)
+    await conn.join()
+
+  let lp = LPProtocol.new(@[proto], handle)
+
+  try:
+    transport.switch.mount(lp)
+  except LPError as e:
+    return err("mount failed: " & e.msg)
+
+  return ok(newJObject())
+
+proc acceptStream(
+    transport: SwitchTransport, args: JsonNode
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  let proto = args{"proto"}.getStr()
+  let deadline = Moment.now() + chronos.milliseconds(args{"timeoutMs"}.getBiggestInt())
+
+  while Moment.now() < deadline:
+    var queue = transport.inbound.getOrDefault(proto)
+    if queue.len > 0:
+      let streamId = queue[0]
+      queue.delete(0)
+      transport.inbound[proto] = queue
+      let conn = transport.streams.getOrDefault(streamId)
+
+      return ok(%*{"streamId": streamId, "proto": proto, "peerId": $conn.peerId})
+
+    try:
+      await sleepAsync(chronos.milliseconds(10))
+    except CancelledError:
+      return err("cancelled")
+
+  return err("timeout waiting for inbound stream")
+
+method submit*(
+    transport: SwitchTransport, op: string, args: JsonNode, timeout: Duration
+): Future[Result[JsonNode, string]] {.async: (raises: []).} =
+  case op
+  of "getNodeInfo":
+    return ok(%($transport.switch.peerInfo.peerId))
+  of "connectPeer":
+    return await transport.connectPeer(args)
+  of "dial":
+    return ok(%(?await transport.dialStream(args)))
+  of "protocolRequest":
+    return await transport.protocolRequest(args)
+  of "mountProtocol":
+    return transport.mountProtocol(args{"proto"}.getStr())
+  of "protocolAcceptStream":
+    return await transport.acceptStream(args)
+  of "streamReadLp":
+    let conn = ?transport.streamOf(args)
+    let data =
+      try:
+        await conn.readLp(int(args{"maxSize"}.getBiggestInt()))
+      except CatchableError as e:
+        return err("read failed: " & e.msg)
+    return ok(%*{"dataB64": $base64.encode(data)})
+  of "streamWriteLp":
+    let conn = ?transport.streamOf(args)
+    let payload = base64.decode(Base64String(args{"dataB64"}.getStr())).valueOr:
+      return err("bad dataB64")
+    try:
+      await conn.writeLP(payload)
+    except CatchableError as e:
+      return err("write failed: " & e.msg)
+    return ok(newJObject())
+  of "streamClose":
+    let conn = ?transport.streamOf(args)
+    await conn.close()
+    return ok(newJObject())
+  of "streamRelease":
+    transport.streams.del(uint64(args{"streamId"}.getBiggestInt()))
+    return ok(newJObject())
+  else:
+    return err("unknown libp2p op: " & op)

--- a/tests/waku_net/test_bridged_backend.nim
+++ b/tests/waku_net/test_bridged_backend.nim
@@ -1,0 +1,198 @@
+{.used.}
+
+import results, testutils/unittests, chronos, libp2p/crypto/crypto
+
+import
+  logos_delivery/waku/[
+    node/peer_manager,
+    net/bridged_backend,
+    waku_core,
+    waku_filter_v2,
+    waku_filter_v2/client,
+    waku_filter_v2/rpc,
+    waku_filter_v2/rpc_codec,
+    waku_store,
+    waku_store/client,
+    waku_store/rpc_codec,
+    common/paging,
+  ],
+  ../testlib/[common, wakucore, testasync],
+  ../waku_store/store_utils,
+  ./switch_transport
+
+suite "Bridged net backend":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var client {.threadvar.}: WakuStoreClient
+  var handlerFuture {.threadvar.}: Future[StoreQueryRequest]
+  var serverPeerInfo {.threadvar.}: RemotePeerInfo
+  var messageSeq {.threadvar.}: seq[WakuMessageKeyValue]
+
+  asyncSetup:
+    let message = fakeWakuMessage(contentTopic = DefaultContentTopic)
+    messageSeq = @[
+      WakuMessageKeyValue(
+        messageHash: computeMessageHash(DefaultPubsubTopic, message),
+        message: Opt.some(message),
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    ]
+
+    handlerFuture = newFuture[StoreQueryRequest]()
+    let handler = proc(
+        req: StoreQueryRequest
+    ): Future[StoreQueryResult] {.async, gcsafe.} =
+      var request = req
+      request.requestId = ""
+      handlerFuture.complete(request)
+      return ok(StoreQueryResponse(messages: messageSeq))
+
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+
+    discard await newTestWakuStore(serverSwitch, handler = handler)
+
+    let peerManager = PeerManager.new(
+      clientSwitch,
+      netBackend = BridgedNetBackend.new(SwitchTransport.new(clientSwitch)),
+    )
+    client = WakuStoreClient.new(peerManager, common.rng())
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+    serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "a store query crosses the bridge":
+    let storeQuery = StoreQueryRequest(
+      pubsubTopic: Opt.some(DefaultPubsubTopic),
+      contentTopics: @[DefaultContentTopic],
+      paginationForward: PagingDirection.FORWARD,
+    )
+
+    let queryResponse = await client.query(storeQuery, peer = serverPeerInfo)
+
+    assert await handlerFuture.withTimeout(chronos.seconds(5))
+    check:
+      handlerFuture.read().contentTopics == @[DefaultContentTopic]
+      queryResponse.get().messages == messageSeq
+
+  asyncTest "a query to an unreachable peer fails to dial":
+    let unreachable = RemotePeerInfo.init(
+      PeerId.init(generateEcdsaKey().getPublicKey().get()).get(),
+      @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").get()],
+    )
+
+    let queryResponse = await client.query(
+      StoreQueryRequest(contentTopics: @[DefaultContentTopic]), peer = unreachable
+    )
+
+    check:
+      queryResponse.isErr()
+      queryResponse.error.kind == ErrorCode.PEER_DIAL_FAILURE
+
+suite "Bridged connection":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var backend {.threadvar.}: BridgedNetBackend
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+    backend = BridgedNetBackend.new(SwitchTransport.new(clientSwitch))
+
+    let handler = proc(
+        req: StoreQueryRequest
+    ): Future[StoreQueryResult] {.async, gcsafe.} =
+      return ok(StoreQueryResponse(statusCode: uint32(StatusCode.SUCCESS)))
+
+    discard await newTestWakuStore(serverSwitch, handler = handler)
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "frames cross a dialled stream":
+    let peer = serverSwitch.peerInfo.toRemotePeerInfo()
+
+    let conn = (
+      await backend.dial(peer.peerId, peer.addrs, WakuStoreCodec, chronos.seconds(5))
+    ).valueOr:
+      raiseAssert "dial over the bridge failed"
+
+    await conn.writeLP(StoreQueryRequest(requestId: "1").encode().buffer)
+    let response = StoreQueryResponse.decode(await conn.readLp(DefaultMaxRpcSize.int))
+
+    await conn.close()
+
+    check:
+      response.isOk()
+      response.get().statusCode == uint32(StatusCode.SUCCESS)
+
+  asyncTest "a raw write is refused":
+    let peer = serverSwitch.peerInfo.toRemotePeerInfo()
+
+    let conn = (
+      await backend.dial(peer.peerId, peer.addrs, WakuStoreCodec, chronos.seconds(5))
+    ).valueOr:
+      raiseAssert "dial over the bridge failed"
+
+    var refused = false
+    try:
+      await conn.write(@[1'u8, 2, 3])
+    except LPStreamError:
+      refused = true
+
+    await conn.close()
+
+    check refused
+
+suite "Bridged inbound streams":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var backend {.threadvar.}: BridgedNetBackend
+  var pushed {.threadvar.}: Future[WakuMessage]
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+    backend = BridgedNetBackend.new(SwitchTransport.new(clientSwitch))
+
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+    let filterClient = WakuFilterClient.new(peerManager, common.rng())
+
+    pushed = newFuture[WakuMessage]()
+    filterClient.registerPushHandler(
+      proc(pubsubTopic: PubsubTopic, message: WakuMessage) {.async, gcsafe.} =
+        if not pushed.finished():
+          pushed.complete(message)
+    )
+
+    backend.mountInbound(WakuFilterPushCodec, filterClient.handler)
+    await backend.start()
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis)
+
+  asyncTeardown:
+    await backend.stop()
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "a push reaches the filter client":
+    let message = fakeWakuMessage(contentTopic = DefaultContentTopic)
+    let push = MessagePush(pubsubTopic: DefaultPubsubTopic, wakuMessage: message)
+
+    let conn = await serverSwitch.dial(
+      clientSwitch.peerInfo.peerId, clientSwitch.peerInfo.addrs, WakuFilterPushCodec
+    )
+    await conn.writeLP(push.encode().buffer)
+
+    check await pushed.withTimeout(chronos.seconds(5))
+    check pushed.read() == message
+
+    await conn.close()

--- a/tests/waku_net/test_net_backend.nim
+++ b/tests/waku_net/test_net_backend.nim
@@ -1,0 +1,76 @@
+{.used.}
+
+import results, testutils/unittests, chronos, chronicles
+import libp2p/[multiaddress, peerid]
+import libp2p/protocols/protocol
+
+import
+  logos_delivery/waku/[net/net_backend, node/peer_manager, waku_core],
+  ../testlib/[wakucore, testasync]
+
+const TestCodec = "/waku/test/1.0.0"
+
+type StubNetBackend = ref object of NetBackend
+  dials: int
+  lastPeerId: PeerId
+  lastAddrs: seq[MultiAddress]
+  lastProto: string
+
+method dial(
+    backend: StubNetBackend,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    proto: string,
+    timeout: Duration,
+): Future[Opt[Connection]] {.async: (raises: []).} =
+  backend.dials.inc()
+  backend.lastPeerId = peerId
+  backend.lastAddrs = addrs
+  backend.lastProto = proto
+
+  return Opt.none(Connection)
+
+suite "Net backend":
+  var serverSwitch {.threadvar.}: Switch
+  var clientSwitch {.threadvar.}: Switch
+  var serverPeerInfo {.threadvar.}: RemotePeerInfo
+
+  asyncSetup:
+    serverSwitch = newTestSwitch()
+    clientSwitch = newTestSwitch()
+
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+      await conn.close()
+
+    serverSwitch.mount(LPProtocol.new(@[TestCodec], handle))
+
+    await allFutures(serverSwitch.start(), clientSwitch.start())
+    await sleepAsync(500.millis) # the listener is not ready on macos CI without it
+
+    serverPeerInfo = serverSwitch.peerInfo.toRemotePeerInfo()
+
+  asyncTeardown:
+    await allFutures(serverSwitch.stop(), clientSwitch.stop())
+
+  asyncTest "the default backend dials over the switch":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    check peerManager.netBackend of SwitchNetBackend
+
+    let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
+
+    check conn.isSome()
+    await conn.get().close()
+
+  asyncTest "a backend of its own takes every dial":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let conn = await peerManager.dialPeer(serverPeerInfo, TestCodec)
+
+    check:
+      conn.isNone()
+      backend.dials == 1
+      backend.lastPeerId == serverPeerInfo.peerId
+      backend.lastAddrs == serverPeerInfo.addrs
+      backend.lastProto == TestCodec

--- a/tests/waku_net/test_net_backend.nim
+++ b/tests/waku_net/test_net_backend.nim
@@ -5,16 +5,23 @@ import libp2p/[multiaddress, peerid]
 import libp2p/protocols/protocol
 
 import
-  logos_delivery/waku/[net/net_backend, node/peer_manager, waku_core],
+  logos_delivery/waku/[net/net_backend, node/peer_manager, waku_core, waku_core/codecs],
   ../testlib/[wakucore, testasync]
 
-const TestCodec = "/waku/test/1.0.0"
+const
+  TestCodec = "/waku/test/1.0.0"
+  EchoCodec = "/waku/test-echo/1.0.0"
+
+const StubAnswer = @[byte 9, 9, 9]
 
 type StubNetBackend = ref object of NetBackend
   dials: int
+  connects: int
+  requests: int
   lastPeerId: PeerId
   lastAddrs: seq[MultiAddress]
   lastProto: string
+  lastPayload: seq[byte]
 
 method dial(
     backend: StubNetBackend,
@@ -30,6 +37,26 @@ method dial(
 
   return Opt.none(Connection)
 
+method connect(
+    backend: StubNetBackend, peerId: PeerId, addrs: seq[MultiAddress], timeout: Duration
+): Future[Result[void, string]] {.async: (raises: []).} =
+  backend.connects.inc()
+  backend.lastPeerId = peerId
+  backend.lastAddrs = addrs
+
+  return err("the stub connects to nobody")
+
+method request(
+    backend: StubNetBackend, req: NetRequest
+): Future[Result[seq[byte], NetError]] {.async: (raises: []).} =
+  backend.requests.inc()
+  backend.lastPeerId = req.peerId
+  backend.lastAddrs = req.addrs
+  backend.lastProto = req.proto
+  backend.lastPayload = req.payload
+
+  return ok(StubAnswer)
+
 suite "Net backend":
   var serverSwitch {.threadvar.}: Switch
   var clientSwitch {.threadvar.}: Switch
@@ -42,7 +69,19 @@ suite "Net backend":
     proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       await conn.close()
 
+    proc echoBack(
+        conn: Connection, proto: string
+    ) {.async: (raises: [CancelledError]).} =
+      try:
+        let request = await conn.readLp(DefaultNetMaxResponseSize)
+        await conn.writeLP(request & request)
+      except CatchableError as e:
+        error "echo handler failed", err = e.msg
+
+      await conn.close()
+
     serverSwitch.mount(LPProtocol.new(@[TestCodec], handle))
+    serverSwitch.mount(LPProtocol.new(@[EchoCodec], echoBack))
 
     await allFutures(serverSwitch.start(), clientSwitch.start())
     await sleepAsync(500.millis) # the listener is not ready on macos CI without it
@@ -74,3 +113,94 @@ suite "Net backend":
       backend.lastPeerId == serverPeerInfo.peerId
       backend.lastAddrs == serverPeerInfo.addrs
       backend.lastProto == TestCodec
+
+  asyncTest "a request writes one frame and reads the answer":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response = await peerManager.request(serverPeerInfo, EchoCodec, @[byte 1, 2, 3])
+
+    check:
+      response.isOk()
+      response.get() == @[byte 1, 2, 3, 1, 2, 3]
+
+  asyncTest "a request to an undialable peer fails with a dial error":
+    let peerManager = PeerManager.new(clientSwitch)
+    let unreachable = RemotePeerInfo.init(
+      serverPeerInfo.peerId, @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+    )
+
+    let response = await peerManager.request(unreachable, TestCodec, @[byte 1])
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+
+  asyncTest "an answer over maxSize fails with a read error":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    let response =
+      await peerManager.request(serverPeerInfo, EchoCodec, @[byte 1, 2, 3], maxSize = 2)
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Read
+
+  asyncTest "a request to self is refused without a dial":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(
+      clientSwitch.peerInfo.toRemotePeerInfo(), TestCodec, @[byte 1]
+    )
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+      backend.requests == 0
+
+  asyncTest "the default backend connects over the switch":
+    let peerManager = PeerManager.new(clientSwitch)
+
+    check (await peerManager.connectPeer(serverPeerInfo))
+
+  asyncTest "a connect to an unreachable peer fails":
+    let peerManager = PeerManager.new(clientSwitch)
+    let unreachable = RemotePeerInfo.init(
+      serverPeerInfo.peerId, @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()]
+    )
+
+    check not (await peerManager.connectPeer(unreachable, dialTimeout = 2.seconds))
+
+  asyncTest "a backend of its own takes every connect":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    check not (await peerManager.connectPeer(serverPeerInfo))
+    check backend.connects == 1
+
+  asyncTest "a request never reaches the relay codec":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(serverPeerInfo, WakuRelayCodec, @[byte 1])
+
+    check:
+      response.isErr()
+      response.error.kind == NetErrorKind.Dial
+      backend.requests == 0
+
+  asyncTest "a backend of its own answers a request without dialing":
+    let backend = StubNetBackend()
+    let peerManager = PeerManager.new(clientSwitch, netBackend = backend)
+
+    let response = await peerManager.request(serverPeerInfo, TestCodec, @[byte 1, 2, 3])
+
+    check:
+      response.isOk()
+      response.get() == StubAnswer
+      backend.requests == 1
+      backend.dials == 0
+      backend.lastPeerId == serverPeerInfo.peerId
+      backend.lastAddrs == serverPeerInfo.addrs
+      backend.lastProto == TestCodec
+      backend.lastPayload == @[byte 1, 2, 3]

--- a/tests/waku_net/test_net_bridge.nim
+++ b/tests/waku_net/test_net_bridge.nim
@@ -1,0 +1,118 @@
+{.used.}
+
+import std/[json, os, strutils]
+import results, testutils/unittests, chronos
+
+import logos_delivery/waku/net/[net_bridge, net_transport]
+
+var worker {.threadvar.}: Thread[uint64]
+
+proc submitNever(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  discard
+
+proc submitInline(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let op = $cast[cstring](opJson)
+  let answer = "{\"echo\":" & escapeJson(op) & "}"
+  discard netBackendRespond(requestId, true, cast[pointer](cstring(answer)), answer.len)
+
+proc respondFromThread(requestId: uint64) {.thread.} =
+  sleep(20)
+  let answer = "{\"late\":true}"
+  discard netBackendRespond(requestId, true, cast[pointer](cstring(answer)), answer.len)
+
+proc submitThreaded(
+    requestId: uint64, opJson: cstring, opLen: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  try:
+    createThread(worker, respondFromThread, requestId)
+  except ResourceExhaustedError:
+    discard
+
+const
+  LongestName = "b".repeat(63)
+  TooLongName = "b".repeat(64)
+
+suite "Net backend ABI":
+  test "a table of another ABI version is refused":
+    var table = NetBackendTable(version: NetBackendAbiVersion + 1, submit: submitNever)
+
+    check:
+      registerNetBackend("wrong-version", addr table, nil) != 0
+      registerNetBackend("no-table", nil, nil) != 0
+
+  test "an unknown backend has no transport":
+    check getNetTransport("nobody").isErr()
+
+  asyncTest "a backend answers on the calling thread":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitInline)
+    check registerNetBackend("inline", addr table, nil) == 0
+
+    let transport = getNetTransport("inline").valueOr:
+      raiseAssert "no transport: " & error
+
+    let answer =
+      await transport.submit("getNodeInfo", %*{"field": "PeerId"}, chronos.seconds(5))
+
+    check:
+      answer.isOk()
+      answer.get(){"echo"}.getStr().contains("\"op\":\"getNodeInfo\"")
+
+  asyncTest "a backend answers from a foreign thread":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitThreaded)
+    check registerNetBackend("threaded", addr table, nil) == 0
+
+    let transport = getNetTransport("threaded").valueOr:
+      raiseAssert "no transport: " & error
+
+    let answer =
+      await transport.submit("pingPeer", %*{"peerId": "x"}, chronos.seconds(5))
+
+    joinThread(worker)
+
+    check:
+      answer.isOk()
+      answer.get(){"late"}.getBool()
+
+  asyncTest "an op with no answer times out":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitNever)
+    check registerNetBackend("silent", addr table, nil) == 0
+
+    let transport = getNetTransport("silent").valueOr:
+      raiseAssert "no transport: " & error
+
+    let answer =
+      await transport.submit("dial", %*{"peerId": "x"}, chronos.milliseconds(200))
+
+    check:
+      answer.isErr()
+      answer.error.contains("timed out")
+
+  test "a name is kept whole up to the length limit":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitInline)
+
+    check:
+      registerNetBackend(cstring(LongestName), addr table, nil) == 0
+      registerNetBackend(cstring(TooLongName), addr table, nil) != 0
+      getNetTransport(LongestName).isOk()
+      getNetTransport(TooLongName).isErr()
+
+  asyncTest "an answer nobody waits for does not wedge the drain":
+    var table = NetBackendTable(version: NetBackendAbiVersion, submit: submitInline)
+    check registerNetBackend("inline", addr table, nil) == 0
+
+    let transport = getNetTransport("inline").valueOr:
+      raiseAssert "no transport: " & error
+
+    let stray = "{}"
+    check netBackendRespond(
+      high(uint64), true, cast[pointer](cstring(stray)), stray.len
+    ) == 0
+
+    let answer =
+      await transport.submit("getNodeInfo", %*{"field": "PeerId"}, chronos.seconds(5))
+
+    check answer.isOk()

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -203,6 +203,13 @@ type WakuNodeConf* = object
     nodekey* {.desc: "P2P node private key as 64 char hex string.", name: "nodekey".}:
       Opt[PrivateKey]
 
+    libp2pProvider* {.
+      desc:
+        "Name of a registered net backend that owns the libp2p node. Empty runs the node's own libp2p stack.",
+      defaultValue: "",
+      name: "libp2p-provider"
+    .}: string
+
     listenAddress* {.
       defaultValue: defaultListenAddress(),
       desc: "Listening address for LibP2P (and Discovery v5, if enabled) traffic.",
@@ -1056,6 +1063,7 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
     b.withClusterId(n.clusterId.get())
 
   b.withAgentString(n.agentString)
+  b.withLibp2pProvider(n.libp2pProvider)
 
   if n.nodeKey.isSome():
     b.withNodeKey(n.nodeKey.get())


### PR DESCRIPTION
## Do not merge

This branch exists only to read the net backend train as one diff. Merge the five PRs in their own order. Close this one.

## What it holds

The train from #4152 to #4156, rebased onto current master:

| Commit | PR |
| --- | --- |
| `feat: net backend ABI` | #4152 |
| `feat(net): send Edge requests through the net backend` | #4153 |
| `feat(library): a C ABI for registering a net backend` | #4154 |
| `feat(net): run the Edge protocols over a registered backend` | #4155 |
| `feat(net): create a node that runs on a registered backend` | #4156 |

## The other half

The consumer of this ABI is the draft PR logos-co/logos-delivery-module#89, "feat: run the delivery node over another module's libp2p node". It registers a net backend over the C ABI that #4154 adds, so read the two together.

## One thing to know

#4154, #4155 and #4156 sit on stale versions of #4152 and #4153. The review fixes on the two lower PRs never reached the upper three. This branch takes the newest version of each PR and replays the upper three on top, so it shows the train as it will land, not as the branches stand now.

The rebase produced four conflicts:

- `net_backend.nim` doc header: kept the #4153 wording, which covers the wider surface.
- `test_net_backend.nim`: kept the #4153 imports and stub fields; the #4152 additions merged on top.
- `all_tests_waku.nim`: merged all three `waku_net` test imports.
- `waku_node.nim` `start()`: kept the master address-resolve block, then `netBackend.start()`.
- `node_factory.nim`: kept `nat_config` from master plus the three new net imports.

`nph --check` passes on every file the resolution touched. No compile check ran here.
