### PR TITLE
test: verify send on a nil or destroyed ctx returns an error

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -137,6 +137,12 @@ Prefer an explicit `logosdelivery_stop_node`: a failed stop here is only logged
 and nim-ffi cancels the stop at `ffiTeardownTimeoutMs` (10 s), leaving the node
 half stopped.
 
+### Invalid context handles
+
+A `NULL`, garbage or already destroyed `ctx` is rejected at the entry point: the
+call returns `RET_ERR` and its callback, if any, runs first with
+`ctx is not a valid FFI context`. No event is emitted.
+
 ### Context-free calls
 
 No `ctx` and no callback: `dlsym` the symbol and read the return value.

--- a/tests-e2e/tests/wrappers_tests/helpers/send_invalid_handle.py
+++ b/tests-e2e/tests/wrappers_tests/helpers/send_invalid_handle.py
@@ -12,7 +12,8 @@ taking the pytest runner down.
 Cases:
 - nil:       send() on a wrapper built with ctx=ffi.NULL.
 - destroyed: send() after destroy_keep_ctx() — self.ctx stays non-nil so the
-             call reaches the C side with the original (now-stale) pointer.
+             call reaches the C side with the original (now-stale) pointer;
+             a second destroy must be rejected too.
 """
 
 import json
@@ -113,6 +114,8 @@ def _run_destroyed_handle(marker: str) -> None:
 
     new_events = collector.events[events_before_send:]
 
+    destroy_again = sender.destroy_keep_ctx()
+
     _emit(
         marker,
         {
@@ -121,6 +124,8 @@ def _run_destroyed_handle(marker: str) -> None:
             "ok": send_result.ok_value if send_result.is_ok() else None,
             "err": send_result.err() if send_result.is_err() else None,
             "events_after_send": [str(e) for e in new_events],
+            "destroy_again_is_ok": destroy_again.is_ok(),
+            "destroy_again_err": destroy_again.err() if destroy_again.is_err() else None,
         },
     )
 

--- a/tests-e2e/tests/wrappers_tests/test_send_handle_and_subscription.py
+++ b/tests-e2e/tests/wrappers_tests/test_send_handle_and_subscription.py
@@ -19,10 +19,7 @@ from src.node.wrapper_helpers import (
 
 PROPAGATED_TIMEOUT_S = 30.0
 
-S01_EXPECTED_ERROR_FRAGMENT = "not initialized"
-# Destroyed-handle path fails synchronously in the C layer (no callback),
-# so the binding surfaces a different string than the nil-handle path.
-S01_DESTROYED_HANDLE_ERROR_FRAGMENT = "immediate call failed"
+S01_EXPECTED_ERROR_FRAGMENT = "not a valid FFI context"
 S01_SUBPROCESS_TIMEOUT_S = 30
 S01_RESULT_MARKER = "__S01_RESULT__"
 SEND_AFTER_DESTROY_RESULT_MARKER = "__SEND_AFTER_DESTROY_RESULT__"
@@ -47,7 +44,6 @@ S05_MALFORMED_CONTENT_TOPICS = [
 class TestS01NilOrUninitializedHandle(StepsCommon):
     """S01 — send() on a nil/destroyed handle must Err, no events, no crash."""
 
-    @pytest.mark.skip(reason="see https://github.com/logos-messaging/logos-delivery/issues/3873")
     def test_s01_send_on_uninitialized_handle(self):
         completed = subprocess.run(
             [sys.executable, "-m", S01_INVALID_HANDLE_HELPER, "nil", S01_RESULT_MARKER],
@@ -73,7 +69,6 @@ class TestS01NilOrUninitializedHandle(StepsCommon):
             result["err"] or ""
         ), f"expected error to mention {S01_EXPECTED_ERROR_FRAGMENT!r}, got: {result['err']!r}"
 
-    @pytest.mark.skip(reason="see https://github.com/logos-messaging/logos-delivery/issues/3863")
     def test_s01_send_on_destroyed_handle(self):
         completed = subprocess.run(
             [sys.executable, "-m", S01_INVALID_HANDLE_HELPER, "destroyed", SEND_AFTER_DESTROY_RESULT_MARKER],
@@ -96,11 +91,11 @@ class TestS01NilOrUninitializedHandle(StepsCommon):
 
         assert result["stage"] == "send_message", f"setup failed at stage {result['stage']!r}: {result['err']!r}"
         assert result["is_ok"] is False, f"expected Err, got Ok({result['ok']!r})"
-        err_msg = result["err"] or ""
-        assert S01_EXPECTED_ERROR_FRAGMENT in err_msg or S01_DESTROYED_HANDLE_ERROR_FRAGMENT in err_msg, (
-            f"expected error to mention {S01_EXPECTED_ERROR_FRAGMENT!r} " f"or {S01_DESTROYED_HANDLE_ERROR_FRAGMENT!r}, got: {result['err']!r}"
-        )
+        assert S01_EXPECTED_ERROR_FRAGMENT in (
+            result["err"] or ""
+        ), f"expected error to mention {S01_EXPECTED_ERROR_FRAGMENT!r}, got: {result['err']!r}"
         assert result["events_after_send"] == [], f"expected no events after send(), got: {result['events_after_send']}"
+        assert result["destroy_again_is_ok"] is False, "a second destroy on a destroyed handle must be rejected"
 
 
 class TestS03SendOnAlreadySubscribedTopic(StepsCommon):

--- a/tests-e2e/vendor/logos-delivery-python-bindings/waku/wrapper.py
+++ b/tests-e2e/vendor/logos-delivery-python-bindings/waku/wrapper.py
@@ -133,6 +133,12 @@ def _wait_cb_ok(state, op_name: str, timeout_s: float = 20.0) -> Result[int, str
     return Ok(cb_ret)
 
 
+def _immediate_failure(op_name: str, rc: int, state) -> str:
+    """Non-zero return: the callback already ran synchronously with the reason."""
+    reason = state["msg"].decode("utf-8", errors="replace") if state["done"].is_set() else ""
+    return f"{op_name}: immediate call failed (ret={rc})" + (f": {reason}" if reason else "")
+
+
 class NodeWrapper:
     def __init__(self, ctx, config_buffer, event_cb_handler, listener_ids=()):
         self.ctx = ctx
@@ -259,7 +265,7 @@ class NodeWrapper:
 
         rc = lib.logosdelivery_start_node(self.ctx, cb, ffi.NULL)
         if rc != 0:
-            return Err(f"start_node: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("start_node", rc, state))
 
         return _wait_cb_ok(state, "start_node", timeout_s)
 
@@ -269,7 +275,7 @@ class NodeWrapper:
 
         rc = lib.logosdelivery_stop_node(self.ctx, cb, ffi.NULL)
         if rc != 0:
-            return Err(f"stop_node: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("stop_node", rc, state))
 
         return _wait_cb_ok(state, "stop_node", timeout_s)
 
@@ -310,7 +316,7 @@ class NodeWrapper:
         req = ffi.new("SubscribeReq *", {"contentTopicStr": topic_buffer})
         rc = lib.logosdelivery_subscribe(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"subscribe_content_topic: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("subscribe_content_topic", rc, state))
 
         return _wait_cb_ok(state, f"subscribe({content_topic})", timeout_s)
 
@@ -322,7 +328,7 @@ class NodeWrapper:
         req = ffi.new("UnsubscribeReq *", {"contentTopicStr": topic_buffer})
         rc = lib.logosdelivery_unsubscribe(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"unsubscribe_content_topic: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("unsubscribe_content_topic", rc, state))
 
         return _wait_cb_ok(state, f"unsubscribe({content_topic})", timeout_s)
 
@@ -336,7 +342,7 @@ class NodeWrapper:
         req = ffi.new("SendReq *", {"messageJson": message_buffer})
         rc = lib.logosdelivery_send(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"send_message: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("send_message", rc, state))
 
         wait_result = _wait_cb_raw(state, "send_message", timeout_s)
         if wait_result.is_err():
@@ -355,7 +361,7 @@ class NodeWrapper:
 
         rc = lib.logosdelivery_get_available_node_info_ids(self.ctx, cb, ffi.NULL)
         if rc != 0:
-            return Err(f"get_available_node_info_ids: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("get_available_node_info_ids", rc, state))
 
         wait_result = _wait_cb_raw(state, "get_available_node_info_ids", timeout_s)
         if wait_result.is_err():
@@ -380,7 +386,7 @@ class NodeWrapper:
         req = ffi.new("GetNodeInfoReq *", {"nodeInfoId": info_id_buffer})
         rc = lib.logosdelivery_get_node_info(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"get_node_info: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("get_node_info", rc, state))
 
         wait_result = _wait_cb_raw(state, "get_node_info", timeout_s)
         if wait_result.is_err():
@@ -401,7 +407,7 @@ class NodeWrapper:
 
         rc = lib.logosdelivery_get_available_configs(self.ctx, cb, ffi.NULL)
         if rc != 0:
-            return Err(f"get_available_configs: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("get_available_configs", rc, state))
 
         wait_result = _wait_cb_raw(state, "get_available_configs", timeout_s)
         if wait_result.is_err():
@@ -458,7 +464,7 @@ class NodeWrapper:
         )
         rc = lib.logosdelivery_channel_create(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"channel_create: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("channel_create", rc, state))
 
         wait_result = _wait_cb_raw(state, f"channel_create({channel_id})", timeout_s)
         if wait_result.is_err():
@@ -481,7 +487,7 @@ class NodeWrapper:
         req = ffi.new("ChannelSendReq *", {"channelIdStr": channel_buffer, "messageJson": message_buffer})
         rc = lib.logosdelivery_channel_send(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"channel_send: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("channel_send", rc, state))
 
         wait_result = _wait_cb_raw(state, f"channel_send({channel_id})", timeout_s)
         if wait_result.is_err():
@@ -501,7 +507,7 @@ class NodeWrapper:
         req = ffi.new("ChannelCloseReq *", {"channelIdStr": channel_buffer})
         rc = lib.logosdelivery_channel_close(self.ctx, cb, ffi.NULL, req)
         if rc != 0:
-            return Err(f"channel_close: immediate call failed (ret={rc})")
+            return Err(_immediate_failure("channel_close", rc, state))
 
         wait_result = _wait_cb_raw(state, f"channel_close({channel_id})", timeout_s)
         if wait_result.is_err():


### PR DESCRIPTION
## Description
Calling `logosdelivery_send` on a nil ctx crashed the process (#3863), and calling it on a destroyed ctx was a use-after-free (#3873). Both came from the old nim-ffi, which treated the ctx as a raw pointer. The nim-ffi 0.3 bump already on master turned the ctx into a validated handle, so both calls now return `RET_ERR` with `ctx is not a valid FFI context` instead of crashing.

## Issue

closes #3863
closes #3873