### PR TITLE
feat(mix): allow spam protection injection

### DIFF
--- a/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
@@ -4,6 +4,7 @@ import
   libp2p/crypto/crypto,
   libp2p/crypto/curve25519,
   libp2p_mix/curve25519
+import libp2p_mix/spam_protection
 import ../waku_conf, logos_delivery/waku/waku_mix
 
 logScope:
@@ -18,6 +19,7 @@ type MixConfBuilder* = object
   enabled: Opt[bool]
   mixKey: Opt[string]
   mixNodes: seq[MixNodePubInfo]
+  spamProtection: Opt[SpamProtection]
 
 proc init*(T: type MixConfBuilder): MixConfBuilder =
   MixConfBuilder()
@@ -31,6 +33,9 @@ proc withMixKey*(b: var MixConfBuilder, mixKey: string) =
 proc withMixNodes*(b: var MixConfBuilder, mixNodes: seq[MixNodePubInfo]) =
   b.mixNodes = mixNodes
 
+proc withSpamProtection*(b: var MixConfBuilder, spamProtection: SpamProtection) =
+  b.spamProtection = Opt.some(spamProtection)
+
 proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
   if not b.enabled.get(DefaultMixEnabled):
     return ok(Opt.none(MixConf))
@@ -40,7 +45,12 @@ proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
       let mixPubKey = public(mixPrivKey)
       return ok(
         Opt.some(
-          MixConf(mixKey: mixPrivKey, mixPubKey: mixPubKey, mixNodes: b.mixNodes)
+          MixConf(
+            mixKey: mixPrivKey,
+            mixPubKey: mixPubKey,
+            mixNodes: b.mixNodes,
+            spamProtection: b.spamProtection,
+          )
         )
       )
     else:
@@ -48,6 +58,11 @@ proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
         return err("Generate key pair error: " & $error)
       return ok(
         Opt.some(
-          MixConf(mixKey: mixPrivKey, mixPubKey: mixPubKey, mixNodes: b.mixNodes)
+          MixConf(
+            mixKey: mixPrivKey,
+            mixPubKey: mixPubKey,
+            mixNodes: b.mixNodes,
+            spamProtection: b.spamProtection,
+          )
         )
       )

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -175,7 +175,14 @@ proc setupProtocols(
   #mount mix
   if conf.mixConf.isSome():
     let mixConf = conf.mixConf.get()
-    (await node.mountMix(conf.clusterId, mixConf.mixKey, mixConf.mixnodes)).isOkOr:
+    (
+      await node.mountMix(
+        conf.clusterId,
+        mixConf.mixKey,
+        mixConf.mixnodes,
+        spamProtection = mixConf.spamProtection,
+      )
+    ).isOkOr:
       return err("failed to mount waku mix protocol: " & $error)
 
   # Setup service discovery

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -9,6 +9,7 @@ import
   libp2p/extended_peer_record,
   libp2p/protocols/kademlia/types,
   libp2p/protocols/service_discovery/types as sd_types,
+  libp2p_mix/spam_protection,
   secp256k1,
   results
 
@@ -65,6 +66,7 @@ type MixConf* = ref object
   mixKey*: Curve25519Key
   mixPubKey*: Curve25519Key
   mixnodes*: seq[MixNodePubInfo]
+  spamProtection*: Opt[SpamProtection]
 
 type StoreServiceConf* = object
   dbMigration*: bool

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -24,6 +24,7 @@ import
   libp2p/utils/offsettedseq,
   libp2p_mix,
   libp2p_mix/mix_protocol,
+  libp2p_mix/spam_protection,
   brokers/broker_context,
   brokers/request_broker
 
@@ -354,6 +355,7 @@ proc mountMix*(
     clusterId: uint16,
     mixPrivKey: Curve25519Key,
     mixnodes: seq[MixNodePubInfo],
+    spamProtection: Opt[SpamProtection] = Opt.none(SpamProtection),
 ): Future[Result[void, string]] {.async.} =
   info "Mounting mix protocol", nodeId = node.info #TODO log the config used
 
@@ -365,7 +367,12 @@ proc mountMix*(
   info "local addr", localaddr = localaddrStr
 
   node.wakuMix = WakuMix.new(
-    localaddrStr, node.peerManager, clusterId, mixPrivKey, mixnodes
+    localaddrStr,
+    node.peerManager,
+    clusterId,
+    mixPrivKey,
+    mixnodes,
+    spamProtection = spamProtection,
   ).valueOr:
     error "Waku Mix protocol initialization failed", err = error
     return

--- a/logos_delivery/waku/waku_mix/protocol.nim
+++ b/logos_delivery/waku/waku_mix/protocol.nim
@@ -10,6 +10,7 @@ import
   libp2p_mix/mix_protocol,
   libp2p_mix/mix_metrics,
   libp2p_mix/delay_strategy,
+  libp2p_mix/spam_protection,
   libp2p/[multiaddress, peerid],
   eth/common/keys
 
@@ -77,6 +78,7 @@ proc new*(
     clusterId: uint16,
     mixPrivKey: Curve25519Key,
     bootnodes: seq[MixNodePubInfo],
+    spamProtection: Opt[SpamProtection] = Opt.none(SpamProtection),
 ): WakuMixResult[T] =
   let mixPubKey = public(mixPrivKey)
   info "mixPubKey", mixPubKey = mixPubKey
@@ -91,11 +93,20 @@ proc new*(
   procCall MixProtocol(m).init(
     localMixNodeInfo,
     peermgr.switch,
-    delayStrategy = Opt.some(
-      DelayStrategy(
-        ExponentialDelayStrategy.new(meanDelay = 50'u16, rng = crypto.newRng())
-      )
-    ),
+    spamProtection = spamProtection,
+    delayStrategy =
+      if spamProtection.isSome():
+        Opt.some(
+          DelayStrategy(
+            SpamProtectionDelayStrategy.new(meanDelay = 50'u16, rng = crypto.newRng())
+          )
+        )
+      else:
+        Opt.some(
+          DelayStrategy(
+            ExponentialDelayStrategy.new(meanDelay = 50'u16, rng = crypto.newRng())
+          )
+        ),
   )
 
   processBootNodes(bootnodes, peermgr, m)

--- a/nimble.lock
+++ b/nimble.lock
@@ -197,8 +197,8 @@
       }
     },
     "chronos": {
-      "version": "4.2.4",
-      "vcsRevision": "90f543e447f6ade46f028bd7bdf882ae7fcb0ba9",
+      "version": "4.2.5",
+      "vcsRevision": "0ab802baef6bf16a8e3cc7d8a5c3128ddafadec5",
       "url": "https://github.com/status-im/nim-chronos",
       "downloadMethod": "git",
       "dependencies": [
@@ -210,7 +210,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "2161fffc20d6337784b5cee15a486b50f185e6ce"
+        "sha1": "5acb420a1aa1193eaf0e130e094ed4a80c095abb"
       }
     },
     "libplum": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -110,8 +110,8 @@
 
   chronos = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-chronos";
-    rev = "90f543e447f6ade46f028bd7bdf882ae7fcb0ba9";
-    sha256 = "0grbkcr4whiadzcszx84ch4mpa71hhr77n3z0dlzyb4d4iykj6cr";
+    rev = "0ab802baef6bf16a8e3cc7d8a5c3128ddafadec5";
+    sha256 = "0hlj4jml2vl7hcvg7g33qa8vbhlgv0qhb07b2nsqc2dbp05lyka5";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description

Allow callers to inject a Mix `SpamProtection` implementation through Delivery's Mix configuration and builder. The instance is passed into the existing `WakuMix` mounted on `node.switch`; no additional libp2p switch or node is created.

When spam protection is present, Mix uses `SpamProtectionDelayStrategy` so proof-generation time does not collapse short delays into a timing signal.

## Changes

- add optional spam protection to `MixConf` and `MixConfBuilder`
- pass it through node setup and `mountMix`
- initialize `MixProtocol` with the injected implementation
- preserve the current unprotected behavior when none is configured

## Impact on Library Users

Existing callers are unaffected because the new arguments are optional. Embedders can provide any implementation of the nim-libp2p-mix `SpamProtection` interface.

## Risk Assessment

The unprotected Mix path retains its existing delay strategy. The protected path changes only when a caller explicitly injects spam protection.

## References

- Mix-RLN dependency alignment: https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/22
