### PR TITLE
feat(mix): integrate Mix-RLN with Delivery

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -92,6 +92,9 @@ requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312
 # Temporary pin to the mix commit that widens its libp2p requirement.
 requires "https://github.com/logos-co/nim-libp2p-mix#39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94"
 
+# Draft integration pin; update to the final revision when the plugin PR lands.
+requires "https://github.com/logos-co/mix-rln-spam-protection-plugin#7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333"
+
 proc getMyCPU(): string =
   ## Need to set cpu more explicit manner to avoid arch issues between dependencies
   when defined(macosx) and defined(arm64):

--- a/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
@@ -5,6 +5,7 @@ import
   libp2p/crypto/curve25519,
   libp2p_mix/curve25519
 import libp2p_mix/spam_protection
+import mix_rln_spam_protection/spam_protection as mix_rln
 import ../waku_conf, logos_delivery/waku/waku_mix
 
 logScope:
@@ -20,6 +21,7 @@ type MixConfBuilder* = object
   mixKey: Opt[string]
   mixNodes: seq[MixNodePubInfo]
   spamProtection: Opt[SpamProtection]
+  mixRlnConfig: Opt[mix_rln.MixRlnConfig]
 
 proc init*(T: type MixConfBuilder): MixConfBuilder =
   MixConfBuilder()
@@ -36,10 +38,16 @@ proc withMixNodes*(b: var MixConfBuilder, mixNodes: seq[MixNodePubInfo]) =
 proc withSpamProtection*(b: var MixConfBuilder, spamProtection: SpamProtection) =
   b.spamProtection = Opt.some(spamProtection)
 
+proc withMixRln*(b: var MixConfBuilder, config: mix_rln.MixRlnConfig) =
+  b.mixRlnConfig = Opt.some(config)
+
 proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
   if not b.enabled.get(DefaultMixEnabled):
     return ok(Opt.none(MixConf))
   else:
+    if b.spamProtection.isSome() and b.mixRlnConfig.isSome():
+      return err("Mix spam protection and Mix-RLN cannot both be configured")
+
     if b.mixKey.isSome():
       let mixPrivKey = intoCurve25519Key(ncrutils.fromHex(b.mixKey.get()))
       let mixPubKey = public(mixPrivKey)
@@ -50,6 +58,7 @@ proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
             mixPubKey: mixPubKey,
             mixNodes: b.mixNodes,
             spamProtection: b.spamProtection,
+            mixRlnConfig: b.mixRlnConfig,
           )
         )
       )
@@ -63,6 +72,7 @@ proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
             mixPubKey: mixPubKey,
             mixNodes: b.mixNodes,
             spamProtection: b.spamProtection,
+            mixRlnConfig: b.mixRlnConfig,
           )
         )
       )

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -10,7 +10,9 @@ import
   libp2p/crypto/crypto,
   libp2p/crypto/curve25519,
   libp2p/extended_peer_record,
-  libp2p_mix/mix_protocol
+  libp2p_mix/mix_protocol,
+  libp2p_mix/spam_protection,
+  mix_rln_spam_protection/spam_protection as mix_rln
 
 import
   ./internal_config,
@@ -171,19 +173,6 @@ proc setupProtocols(
     ## e.g. the connection with the database is lost and not recovered.
     error "Unrecoverable error occurred", error = msg
     quit(QuitFailure)
-
-  #mount mix
-  if conf.mixConf.isSome():
-    let mixConf = conf.mixConf.get()
-    (
-      await node.mountMix(
-        conf.clusterId,
-        mixConf.mixKey,
-        mixConf.mixnodes,
-        spamProtection = mixConf.spamProtection,
-      )
-    ).isOkOr:
-      return err("failed to mount waku mix protocol: " & $error)
 
   # Setup service discovery
   if conf.kademliaDiscoveryConf.isSome():
@@ -421,6 +410,40 @@ proc setupProtocols(
   if conf.peerExchangeDiscovery:
     await node.mountPeerExchangeClient()
 
+  if conf.mixConf.isSome():
+    let mixConf = conf.mixConf.get()
+    var spamProtection = mixConf.spamProtection
+
+    if mixConf.mixRlnConfig.isSome():
+      if not conf.relay:
+        return err("Mix-RLN coordination requires Waku Relay")
+      if node.wakuAutoSharding.isNone():
+        return err("Mix-RLN coordination requires autosharding")
+
+      let mixRln = mix_rln.MixRlnSpamProtection.new(mixConf.mixRlnConfig.get()).valueOr:
+        return err("failed to create Mix-RLN spam protection: " & error)
+      (await mixRln.init()).isOkOr:
+        return err("failed to initialize Mix-RLN spam protection: " & error)
+
+      node.wakuMixRln = mixRln
+      spamProtection = Opt.some(SpamProtection(mixRln))
+
+    (
+      await node.mountMix(
+        conf.clusterId,
+        mixConf.mixKey,
+        mixConf.mixnodes,
+        spamProtection = spamProtection,
+      )
+    ).isOkOr:
+      return err("failed to mount waku mix protocol: " & $error)
+
+    if not node.wakuMixRln.isNil():
+      node.mountMixRlnCoordination().isOkOr:
+        return err("failed to mount Mix-RLN coordination: " & error)
+      (await node.wakuMixRln.start()).isOkOr:
+        return err("failed to start Mix-RLN spam protection: " & error)
+
   return ok()
 
 ## Start node
@@ -467,6 +490,13 @@ proc startNode*(
   # periodic loop to find peers and px returned peers actually come from discv5
   if conf.peerExchangeDiscovery and not conf.discv5Conf.isSome():
     node.startPeerExchangeLoop()
+
+  try:
+    if not node.wakuMixRln.isNil():
+      (await node.wakuMixRln.registerSelf()).isOkOr:
+        return err("failed to register Mix-RLN membership: " & error)
+  except CatchableError:
+    return err("failed to register Mix-RLN membership: " & getCurrentExceptionMsg())
 
   # Maintain relay connections
   if conf.relay:

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -10,6 +10,7 @@ import
   libp2p/protocols/kademlia/types,
   libp2p/protocols/service_discovery/types as sd_types,
   libp2p_mix/spam_protection,
+  mix_rln_spam_protection/spam_protection as mix_rln,
   secp256k1,
   results
 
@@ -67,6 +68,7 @@ type MixConf* = ref object
   mixPubKey*: Curve25519Key
   mixnodes*: seq[MixNodePubInfo]
   spamProtection*: Opt[SpamProtection]
+  mixRlnConfig*: Opt[mix_rln.MixRlnConfig]
 
 type StoreServiceConf* = object
   dbMigration*: bool

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -25,6 +25,7 @@ import
   libp2p_mix,
   libp2p_mix/mix_protocol,
   libp2p_mix/spam_protection,
+  mix_rln_spam_protection/spam_protection as mix_rln,
   brokers/broker_context,
   brokers/request_broker
 
@@ -144,6 +145,8 @@ type
     legacyAppHandlers*: Table[PubsubTopic, WakuRelayHandler]
       ## Kernel API Relay appHandlers (if any)
     subscriptionManager*: SubscriptionManager
+    wakuMixRln*: mix_rln.MixRlnSpamProtection
+    wakuMixRlnListener*: Opt[MessageSeenEventListener]
     wakuMix*: WakuMix
     wakuKademlia*: WakuKademlia
     ports*: BoundPorts
@@ -678,6 +681,13 @@ proc stop*(node: WakuNode) {.async.} =
   # Cancel the background relay reconnection (may still be in its backoff wait).
   if not node.relayReconnectFut.isNil():
     await node.relayReconnectFut.cancelAndWait()
+
+  node.wakuMixRlnListener.withValue(listener):
+    await MessageSeenEvent.dropListener(node.brokerCtx, listener)
+  node.wakuMixRlnListener = Opt.none(MessageSeenEventListener)
+
+  if not node.wakuMixRln.isNil():
+    await node.wakuMixRln.stop()
 
   await node.subscriptionManager.stop()
 

--- a/logos_delivery/waku/node/waku_node/mix_rln.nim
+++ b/logos_delivery/waku/node/waku_node/mix_rln.nim
@@ -1,0 +1,75 @@
+{.push raises: [].}
+
+import chronos, chronicles, results
+import mix_rln_spam_protection/spam_protection as mix_rln
+
+import
+  logos_delivery/api/events/kernel_events,
+  logos_delivery/waku/[waku_core, node/waku_node, node/subscription_manager]
+
+import ./relay
+
+logScope:
+  topics = "waku mix rln"
+
+proc publishMixRlnMessage(
+    node: WakuNode, contentTopic: string, data: seq[byte]
+): Future[Result[void, string]] {.async, gcsafe.} =
+  let message = WakuMessage(
+    payload: data,
+    contentTopic: contentTopic,
+    timestamp: getNowInNanosecondTime(),
+    ephemeral: true,
+  )
+
+  (await node.publish(Opt.none(PubsubTopic), message)).isOkOr:
+    return err(error)
+
+  return ok()
+
+proc handleMixRlnMessage(
+    spamProtection: mix_rln.MixRlnSpamProtection, event: MessageSeenEvent
+) {.async: (raises: []).} =
+  try:
+    let contentTopic = event.message.contentTopic
+    if contentTopic == spamProtection.getMembershipContentTopic():
+      (await spamProtection.handleMembershipUpdate(event.message.payload)).isOkOr:
+        warn "Failed to handle Mix-RLN membership update", error
+    elif contentTopic == spamProtection.getProofMetadataContentTopic():
+      spamProtection.handleProofMetadata(event.message.payload).isOkOr:
+        warn "Failed to handle Mix-RLN proof metadata", error
+  except CatchableError as exc:
+    warn "Exception handling Mix-RLN coordination message", error = exc.msg
+
+proc mountMixRlnCoordination*(node: WakuNode): Result[void, string] =
+  if node.wakuMixRln.isNil():
+    return err("Mix-RLN is not configured")
+  if node.wakuRelay.isNil():
+    return err("Mix-RLN coordination requires Waku Relay")
+  if node.wakuAutoSharding.isNone():
+    return err("Mix-RLN coordination requires autosharding")
+  if node.wakuMixRlnListener.isSome():
+    return err("Mix-RLN coordination is already mounted")
+
+  let spamProtection = node.wakuMixRln
+  spamProtection.setPublishCallback(
+    proc(
+        contentTopic: string, data: seq[byte]
+    ): Future[Result[void, string]] {.async, gcsafe.} =
+      return await node.publishMixRlnMessage(contentTopic, data)
+  )
+
+  for contentTopic in spamProtection.getContentTopics():
+    node.subscriptionManager.subscribe(contentTopic).isOkOr:
+      return err("Failed to subscribe to Mix-RLN content topic: " & error)
+
+  let handler = proc(event: MessageSeenEvent): Future[void] {.async: (raises: []).} =
+    await spamProtection.handleMixRlnMessage(event)
+
+  let listener = MessageSeenEvent.listen(node.brokerCtx, handler).valueOr:
+    return err("Failed to register Mix-RLN message listener: " & error)
+  node.wakuMixRlnListener = Opt.some(listener)
+
+  return ok()
+
+{.pop.}

--- a/logos_delivery/waku/waku_node.nim
+++ b/logos_delivery/waku/waku_node.nim
@@ -5,9 +5,10 @@ import
   ./node/waku_node/lightpush as lightpush_api,
   ./node/waku_node/store as store_api,
   ./node/waku_node/relay as relay_api,
+  ./node/waku_node/mix_rln as mix_rln_api,
   ./node/waku_node/peer_exchange as peer_exchange_api,
   ./node/waku_node/ping as ping_api
 
 export
-  switch, node, filter_api, lightpush_api, store_api, relay_api, peer_exchange_api,
-  ping_api
+  switch, node, filter_api, lightpush_api, store_api, relay_api, mix_rln_api,
+  peer_exchange_api, ping_api

--- a/nimble.lock
+++ b/nimble.lock
@@ -666,6 +666,27 @@
         "sha1": "053909f0933b725018f7d87b27403a4b06d7f23a"
       }
     },
+    "mix_rln_spam_protection": {
+      "version": "#7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333",
+      "vcsRevision": "7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333",
+      "url": "https://github.com/logos-co/mix-rln-spam-protection-plugin",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "results",
+        "stew",
+        "chronicles",
+        "chronos",
+        "nimcrypto",
+        "secp256k1",
+        "json_serialization",
+        "libp2p",
+        "libp2p_mix"
+      ],
+      "checksums": {
+        "sha1": "1d21ff885470ce70906ae928e16475056e43c4be"
+      }
+    },
     "eth": {
       "version": "0.9.0",
       "vcsRevision": "d9135e6c3c5d6d819afdfb566aa8d958756b73a8",

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -311,6 +311,13 @@
     fetchSubmodules = true;
   };
 
+  mix_rln_spam_protection = pkgs.fetchgit {
+    url = "https://github.com/logos-co/mix-rln-spam-protection-plugin";
+    rev = "7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333";
+    sha256 = "01dggifhxbl93mqgyjhnfc6d28l2iskh3zxlsllgjrrd6gfd9pla";
+    fetchSubmodules = true;
+  };
+
   eth = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-eth";
     rev = "d9135e6c3c5d6d819afdfb566aa8d958756b73a8";

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -7,6 +7,8 @@ import
   std/[net, random, sequtils],
   results,
   testutils/unittests
+import libp2p_mix/spam_protection
+import mix_rln_spam_protection/spam_protection as mix_rln
 import
   logos_delivery/waku/factory/waku_conf,
   logos_delivery/waku/factory/conf_builder/conf_builder,
@@ -404,3 +406,27 @@ suite "Waku Conf Builder - rate limits":
 
     ## Then
     assert res.isOk(), $res.error
+
+suite "Waku Conf Builder - Mix-RLN":
+  test "Mix-RLN configuration is retained":
+    var builder = MixConfBuilder.init()
+    let config = mix_rln.defaultConfig()
+    builder.withEnabled(true)
+    builder.withMixRln(config)
+
+    let conf = builder.build().expect("Mix configuration should build").get()
+
+    check conf.mixRlnConfig.isSome()
+    check conf.mixRlnConfig.get().membershipContentTopic == config.membershipContentTopic
+    check conf.mixRlnConfig.get().proofMetadataContentTopic ==
+      config.proofMetadataContentTopic
+
+  test "Mix-RLN and another spam protection provider are rejected":
+    var builder = MixConfBuilder.init()
+    builder.withEnabled(true)
+    builder.withMixRln(mix_rln.defaultConfig())
+    builder.withSpamProtection(SpamProtection(proofSize: 0))
+
+    let conf = builder.build()
+
+    check conf.isErr()


### PR DESCRIPTION
## Summary

- Instantiates the draft Mix-RLN spam-protection provider and injects it into Delivery's existing WakuMix instance, reusing `node.switch` rather than creating another libp2p node.
- Publishes membership updates and proof metadata as ephemeral, autosharded Waku messages over Delivery Relay.
- Routes coordination messages from `MessageSeenEvent` listeners into the plugin without replacing application handlers.
- Adds Mix-RLN configuration, lifecycle management, self-registration after peer connections, and configuration tests.

## Affected Areas

- [x] Protocol Logic — Mix-RLN coordination over Delivery Relay
- [x] Build / Tooling — draft plugin dependency and reproducible lock/Nix entries
- [x] Other — WakuMix spam-protection integration and node lifecycle

## Risk Assessment

- This is opt-in through programmatic configuration; existing Mix behavior is unchanged when Mix-RLN is not configured.
- Relay and autosharding are required for coordination-message transport.
- Membership gossip is currently best effort. History synchronization and distributed allocation of membership indices remain follow-up work, so late joiners are not fully supported yet.

## References

- Delivery injection seam: #4181
- Mix-RLN plugin: https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/22

## Additional Notes

- This PR is stacked on #4181 and should be reviewed as the follow-up commit.
- Compile-only checks for the adapter, factory, and configuration tests pass. The executable configuration test cannot link in this environment because the native `librln` symbols are unavailable.
- `nimble check`, formatting, JSON/Nix parsing, and lock-to-Nix consistency checks pass.
- Nimble 0.24.1 cannot solve the full Delivery graph during a fresh `nimble lock`; the plugin lock entry was generated from an isolated satisfiable graph and checked against Delivery's dependency generator.
