### PR TITLE
fix(build): misc build system fixes

### DIFF
--- a/.github/actions/check-build-health/action.yml
+++ b/.github/actions/check-build-health/action.yml
@@ -1,0 +1,11 @@
+name: 'Check build health'
+description: 'Assert that build configuration reaches the compiler'
+
+runs:
+  using: 'composite'
+  steps:
+    # Reads variables with "make -pn". One case runs a Nimble task, which
+    # stops at an invalid flag before it compiles.
+    - name: Check build health
+      shell: bash
+      run: ./scripts/check_build_health.sh

--- a/.github/workflows/build-health.yml
+++ b/.github/workflows/build-health.yml
@@ -1,0 +1,30 @@
+name: build-health
+
+on:
+  workflow_call:
+
+env:
+  NIM_VERSION: '2.2.6'
+  NIMBLE_VERSION: '0.24.1'
+
+jobs:
+  build-health:
+    name: "Build health"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nimble deps
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
+
+      - uses: ./.github/actions/check-build-health

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -9,11 +9,31 @@ env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
-  NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.6'
   NIMBLE_VERSION: '0.24.1'
 
 jobs:
+  build-health:
+    name: "Build health"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nimble deps
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
+
+      - uses: ./.github/actions/check-build-health
+
   deps-freshness:
     name: "nix/deps.nix freshness"
     runs-on: ubuntu-22.04
@@ -31,7 +51,8 @@ jobs:
           # expressions and the committed file. Unfetchable revisions,
           # generator failures, and tool or environment incompatibilities
           # also fail this step.
-          nix-shell -p nix-prefetch-git --run './tools/gen-nix-deps.sh nimble.lock /tmp/deps.nix.fresh'
+          # nix-prefetch-git from the nixpkgs revision that flake.lock pins.
+          nix shell --inputs-from . nixpkgs#nix-prefetch-git --command ./tools/gen-nix-deps.sh nimble.lock /tmp/deps.nix.fresh
           diff /tmp/deps.nix.fresh nix/deps.nix
 
   build:
@@ -74,7 +95,8 @@ jobs:
           nim-version: ${{ env.NIM_VERSION }}
 
       - name: Build binaries
-        run: make V=1 examples tools
+        # -j1: concurrent nimble tasks corrupt shared package metadata.
+        run: make V=1 -j1 examples tools
 
       - name: Audit installed deps
         run: make audit-deps
@@ -84,6 +106,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          [ -z "$DISCORD_WEBHOOK_URL" ] && { echo "::warning::DISCORD_WEBHOOK_URL is not set; skipping the Discord notification"; exit 0; }
           STATUS="${{ job.status }}"
           OS="${{ matrix.os }}"
           REPO="${{ github.repository }}"

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -14,25 +14,7 @@ env:
 
 jobs:
   build-health:
-    name: "Build health"
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Nim ${{ env.NIM_VERSION }}
-        uses: jiro4989/setup-nim-action@v2
-        with:
-          nim-version: ${{ env.NIM_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install nimble deps
-        uses: ./.github/actions/nimble-deps
-        with:
-          nimble-version: ${{ env.NIMBLE_VERSION }}
-          nim-version: ${{ env.NIM_VERSION }}
-
-      - uses: ./.github/actions/check-build-health
+    uses: ./.github/workflows/build-health.yml
 
   deps-freshness:
     name: "nix/deps.nix freshness"

--- a/.github/workflows/ci-rln-simulator.yml
+++ b/.github/workflows/ci-rln-simulator.yml
@@ -246,7 +246,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          [ -z "$DISCORD_WEBHOOK_URL" ] && { echo "::warning::DISCORD_WEBHOOK_URL is not set; skipping the Discord notification"; exit 0; }
           STATUS="${{ job.status }}"
           BRANCH="${{ steps.cfg.outputs.branch }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,25 +61,7 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
 
   build-health:
-    name: "Build health"
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Nim ${{ env.NIM_VERSION }}
-        uses: jiro4989/setup-nim-action@v2
-        with:
-          nim-version: ${{ env.NIM_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install nimble deps
-        uses: ./.github/actions/nimble-deps
-        with:
-          nimble-version: ${{ env.NIMBLE_VERSION }}
-          nim-version: ${{ env.NIM_VERSION }}
-
-      - uses: ./.github/actions/check-build-health
+    uses: ./.github/workflows/build-health.yml
 
   build:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
   NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
-  NIM_PARAMS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.6'
   NIMBLE_VERSION: '0.24.1'
 
@@ -60,6 +59,27 @@ jobs:
       common: ${{ steps.filter.outputs.common }}
       v2: ${{ steps.filter.outputs.v2 }}
       docker: ${{ steps.filter.outputs.docker }}
+
+  build-health:
+    name: "Build health"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nimble deps
+        uses: ./.github/actions/nimble-deps
+        with:
+          nimble-version: ${{ env.NIMBLE_VERSION }}
+          nim-version: ${{ env.NIM_VERSION }}
+
+      - uses: ./.github/actions/check-build-health
 
   build:
     needs: changes

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -14,11 +14,7 @@ on:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC}"
-  # logos_delivery.nimble reads compile flags from NIM_PARAMS, not NIMFLAGS. Without
-  # -d:disableMarchNative here, config.nims applies -march=native and
-  # secp256k1 fails to compile.
-  NIM_PARAMS: "-d:disableMarchNative"
+  NIMFLAGS: "--parallelBuild:${NPROC} -d:disableMarchNative -d:chronicles_colors:none"
   NIM_VERSION: '2.2.6'
   NIMBLE_VERSION: '0.24.1'
 
@@ -76,8 +72,8 @@ jobs:
         # Serializing the targets removes the race; Nim's own --parallelBuild
         # still parallelizes compilation. Mirrors the -j1 fix in ci.yml.
         run: |
-          make -j${NPROC} V=1 POSTGRES=1 NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" wakunode2
-          make -j${NPROC} V=1 POSTGRES=1 NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" logosdeliverynode
+          make -j${NPROC} V=1 DEBUG=0 POSTGRES=1 wakunode2
+          make -j${NPROC} V=1 DEBUG=0 POSTGRES=1 logosdeliverynode
 
       - name: Audit installed deps
         if: ${{ steps.secrets.outcome == 'success' }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ env:
 
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIM_PARAMS: "-d:disableMarchNative"
+  NIMFLAGS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.6'
   NIMBLE_VERSION: '0.24.1'
 
@@ -90,7 +90,7 @@ jobs:
         run: |
           # -j1: each target starts one nimble process. Two parallel nimble
           # processes corrupt the shared package metadata (nimblemeta.json).
-          make V=1 -j1 CI=false POSTGRES=1 $NODE_BINARIES tools
+          make V=1 -j1 DEBUG=0 CI=false POSTGRES=1 $NODE_BINARIES tools
           tar -cvzf ${{steps.vars.outputs.nwaku}} $(printf './build/%s ' $NODE_BINARIES)
           tar -cvzf ${{steps.vars.outputs.nwakutools}} $(printf './build/%s ' $TOOLS_BINARIES)
 

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   NPROC: 2
-  NIM_PARAMS: "-d:disableMarchNative"
+  NIMFLAGS: "-d:disableMarchNative"
   NIM_VERSION: '2.2.6'
   NIMBLE_VERSION: '0.24.1'
 
@@ -127,13 +127,13 @@ jobs:
         run: |
           # One make target for each line. Two parallel nimble processes
           # corrupt the shared package metadata.
-          make -j${NPROC} POSTGRES=1 CI=false wakunode2
-          make -j${NPROC} CI=false chat2
-          make -j${NPROC} POSTGRES=1 CI=false logosdeliverynode
+          make -j${NPROC} DEBUG=0 POSTGRES=1 CI=false wakunode2
+          make -j${NPROC} DEBUG=0 CI=false chat2
+          make -j${NPROC} DEBUG=0 POSTGRES=1 CI=false logosdeliverynode
           tar -cvzf ${{steps.vars.outputs.waku}} ./build/
 
-          make -j${NPROC} POSTGRES=1 CI=false liblogosdelivery
-          make -j${NPROC} POSTGRES=1 CI=false STATIC=1 liblogosdelivery
+          make -j${NPROC} DEBUG=0 POSTGRES=1 CI=false liblogosdelivery
+          make -j${NPROC} DEBUG=0 POSTGRES=1 CI=false STATIC=1 liblogosdelivery
 
       - name: Audit installed deps
         run: make audit-deps

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,9 +2,9 @@
 	path = vendor/zerokit
 	url = https://github.com/vacp2p/zerokit.git
 	ignore = dirty
-	branch = v0.5.1
+	branch = release-v2.0.1
 [submodule "vendor/waku-rlnv2-contract"]
 	path = vendor/waku-rlnv2-contract
 	url = https://github.com/logos-messaging/waku-rlnv2-contract.git
 	ignore = untracked
-	branch = master
+	branch = main

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,16 @@ ARG MAKE_TARGET=wakunode2
 ARG NIM_COMMIT
 ARG HEAPTRACK_BUILD=0
 ARG POSTGRES=0
+# Jenkins and `make docker-image` pass both of these as build arguments.
+#
+# DEBUG selects the build mode. Make reads 0 as release and an unset value as
+# debug, so no default here leaves a direct `docker build` unchanged.
+# `make docker-image` passes DEBUG=0.
+ARG DEBUG
+# LOG_LEVEL is the chronicles compile-time floor: statements below it are not
+# compiled into the binary. Unset leaves whatever default the build target
+# already applies.
+ARG LOG_LEVEL
 
 # Get build tools and required header files
 RUN apk add --no-cache bash git build-base openssl-dev linux-headers curl jq libbsd-dev
@@ -19,15 +29,23 @@ RUN apk update && apk upgrade
 # Ran separately from 'make' to avoid re-doing
 RUN git submodule update --init --recursive
 
-RUN if [ "$HEAPTRACK_BUILD" = "1" ]; then \
-      git apply --directory=vendor/nimbus-build-system/vendor/Nim docs/tutorial/nim.2.2.4_heaptracker_addon.patch; \
-    fi
-
 # Slowest build step for the sake of caching layers
 RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
 
+# The heaptracker hooks live in Nim's allocator, so patch the Nim that deps
+# installed. Resolve it from the symlink rather than assuming a path.
+RUN if [ "$HEAPTRACK_BUILD" = "1" ]; then \
+      export PATH="$HOME/.nimble/bin:$PATH"; \
+      NIM_ROOT=$(dirname "$(dirname "$(readlink -f "$(command -v nim)")")"); \
+      git -C "$NIM_ROOT" apply /app/docs/tutorial/nim.2.2.4_heaptracker_addon.patch; \
+    fi
+
 # Build the final node binary
-RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET NIMFLAGS="${NIMFLAGS}" POSTGRES=${POSTGRES}
+# -d:disableMarchNative is appended here, not left to the caller. Without it
+# config.nims adds -march=native, and the image may then require CPU features
+# unavailable on the runtime host. NIMFLAGS is applied last, so a caller can
+# still add to it.
+RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET NIMFLAGS="${NIMFLAGS} -d:disableMarchNative" POSTGRES=${POSTGRES} DEBUG=${DEBUG} LOG_LEVEL=${LOG_LEVEL} HEAPTRACKER=${HEAPTRACK_BUILD}
 
 
 # PRODUCTION IMAGE -------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -30,16 +30,62 @@ export PATH := $(NIMBLE_TOOLDIR):$(HOME)/.nimble/bin:$(PATH)
 
 # NIM binary location
 NIM_BINARY := $(shell which nim 2>/dev/null)
-NPH := $(HOME)/.nimble/bin/nph
 
 NIMBLE := nimble
 
-NIMBLE_TASK_FLAGS = --useSystemNim --requires "$$(cat requires.generated)"
+# Nimble accepts the generated value only in attached --requires:<value>
+# form; a separate argument leaves the constraints unapplied.
+NIMBLE_TASK_FLAGS = --useSystemNim --requires:"$$(cat requires.generated)"
 
 NIMBLEDEPS_STAMP := nimbledeps/.nimble-setup
 
 # Compilation parameters
-NIM_PARAMS ?=
+#
+# NIM_PARAMS is the flag list the build receives. Make assembles it in this
+# order, and Nim keeps the last definition of a define, so a later entry wins
+# over an earlier one:
+#
+#   1. NIM_PARAMS from the environment, the caller's own contribution.
+#   2. the project's own flags, added through the rest of this file.
+#   3. NIMFLAGS from the caller, added at the end, so the caller wins.
+#
+# This file exports NIM_PARAMS, and several targets recurse: test, audit-deps,
+# the C library rebuilds, Android and iOS. A sub-make inherits the assembled
+# value, so appending to it again would add every project flag a second time.
+#
+# NIM_PARAMS_CALLER records step 1 alone. It is set only when it does not
+# already exist, so the first make captures the caller's value and every
+# sub-make inherits that same value rather than the assembled one. NIM_PARAMS
+# is then rebuilt from it, discarding whatever a sub-make inherited. Assembly
+# is therefore idempotent: a sub-make computes the same list as its parent, at
+# any depth.
+#
+# It is set with := and guarded by origin rather than written ?=, because ?=
+# creates a recursively expanded variable.
+#
+# A NIM_PARAMS on the make command line is unaffected by this. Make gives a
+# command line variable precedence over every assignment in this file, so it
+# replaces the whole list, the project's own flags included.
+ifeq ($(origin NIM_PARAMS_CALLER),undefined)
+  NIM_PARAMS_CALLER := $(NIM_PARAMS)
+endif
+export NIM_PARAMS_CALLER
+NIM_PARAMS := $(NIM_PARAMS_CALLER)
+
+# V selects verbosity. Callers pass V=1. Nat.mk uses HANDLE_OUTPUT to
+# silence the sub-makes.
+V := 0
+NIM_PARAMS := $(NIM_PARAMS) --verbosity:$(V)
+HANDLE_OUTPUT :=
+ifeq ($(V), 0)
+  NIM_PARAMS := $(NIM_PARAMS) --hints:off
+  HANDLE_OUTPUT := >/dev/null
+endif
+
+# The Jenkins jobs expose LOG_LEVEL as a build parameter.
+ifdef LOG_LEVEL
+  NIM_PARAMS := $(NIM_PARAMS) -d:chronicles_log_level="$(LOG_LEVEL)"
+endif
 
 ifeq ($(detected_OS),Windows)
   MINGW_PATH = /mingw64
@@ -55,7 +101,7 @@ endif
 ## Main ##
 ##########
 # The Makefile automatically bootstraps dependency setup when needed for build and test targets.
-.PHONY: all test clean examples deps nimble install-nim install-nimble
+.PHONY: all test clean examples deps nimble install-nim install-nimble print-nimble-path
 
 # default target
 all: | wakunode2 logosdeliverynode liblogosdelivery
@@ -75,9 +121,13 @@ else
 	$(MAKE) compile-test TEST_FILE="$(test_file)" TEST_NAME="$(call test_name)"
 endif
 
-# this prevents make from erroring on unknown targets
+# `make test <file> [name]` passes the file and the name as extra goals. Absorb
+# them here so make does not look for targets by those names. Any other unknown
+# target must still fail, or a stale invocation succeeds while doing nothing.
+ifeq ($(firstword $(MAKECMDGOALS)),test)
 %:
 	@true
+endif
 
 logos_delivery.nims:
 	ln -s logos_delivery.nimble $@
@@ -103,7 +153,7 @@ $(NIMBLEDEPS_STAMP): requires.generated logos_delivery.nimble | install-nimble b
 	# custom tasks as compilation options. --useSystemNim uses the Nim
 	# compiler on PATH and omits Nim from the local dependency installation.
 	# Custom task invocations use the same option through NIMBLE_TASK_FLAGS.
-	$(NIMBLE) setup --localdeps -y --useSystemNim --requires "$$(cat requires.generated)"
+	$(NIMBLE) setup --localdeps -y --useSystemNim --requires:"$$(cat requires.generated)"
 
 	$(MAKE) audit-deps
 
@@ -149,6 +199,11 @@ build:
 
 nimble: install-nimble
 
+# The build system puts NIMBLE_TOOLDIR first on PATH for its own invocations.
+# Print it so a shell can use the same Nimble.
+print-nimble-path:
+	@echo "$(NIMBLE_TOOLDIR)"
+
 ## Possible values: prod; debug
 TARGET ?= prod
 
@@ -172,7 +227,7 @@ endif
 
 # Debug/Release mode
 ifeq ($(DEBUG), 0)
-NIM_PARAMS := $(NIM_PARAMS) -d:release
+NIM_PARAMS := $(NIM_PARAMS) -d:release -d:lto_incremental -d:strip
 else
 NIM_PARAMS := $(NIM_PARAMS) -d:debug
 endif
@@ -192,6 +247,12 @@ endif
 ifeq ($(DEBUG_DISCV5), 1)
 NIM_PARAMS := $(NIM_PARAMS) -d:debugDiscv5
 endif
+
+# Callers set NIMFLAGS. The README, the workflows, the Jenkinsfiles and the
+# Dockerfiles use it. Only NIM_PARAMS reaches the build, so add NIMFLAGS to it
+# here, after the defines it may conflict with. Nim uses the last
+# definition of a define.
+NIM_PARAMS := $(NIM_PARAMS) $(NIMFLAGS)
 
 # Export NIM_PARAMS so nimble can access it
 export NIM_PARAMS
@@ -265,7 +326,7 @@ testwaku: | build-deps build rln-deps librln
 wakunode2: | build-deps build deps librln
 ifeq ($(detected_OS),Windows)
 	echo -e $(BUILD_MSG) "build/$@" && \
-		nim c --out:build/wakunode2 --mm:refc --cpu:amd64 $(NIM_PARAMS) -d:chronicles_log_level=TRACE apps/wakunode2/wakunode2.nim
+		nim c --out:build/wakunode2 --mm:refc --cpu:amd64 -d:chronicles_log_level=TRACE $(NIM_PARAMS) apps/wakunode2/wakunode2.nim
 else
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(NIMBLE) wakunode2 $(NIMBLE_TASK_FLAGS)
@@ -276,7 +337,7 @@ endif
 logosdeliverynode: | build-deps build deps librln
 ifeq ($(detected_OS),Windows)
 	echo -e $(BUILD_MSG) "build/$@" && \
-		nim c --out:build/logosdeliverynode --mm:refc --cpu:amd64 $(NIM_PARAMS) -d:chronicles_log_level=TRACE apps/logos_delivery_node/logosdeliverynode.nim
+		nim c --out:build/logosdeliverynode --mm:refc --cpu:amd64 -d:chronicles_log_level=TRACE $(NIM_PARAMS) apps/logos_delivery_node/logosdeliverynode.nim
 else
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(NIMBLE) logosdeliverynode $(NIMBLE_TASK_FLAGS)
@@ -320,7 +381,7 @@ lightpushwithmix: | build-deps build deps librln
 
 api_example: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim api_example $(NIM_PARAMS) logos_delivery.nims
+		nim api_example $(NIM_PARAMS) logos_delivery.nims
 
 build/%: | build-deps build deps librln
 	echo -e $(BUILD_MSG) "build/$*" && \
@@ -376,10 +437,10 @@ endif
 
 nph/%: | build-nph
 	echo -e $(FORMAT_MSG) "nph/$*" && \
-		$(NPH) $*
+		"$$(command -v nph)" $*
 
 print-nph-path:
-	@echo "$(NPH)"
+	@command -v nph
 
 clean:
 
@@ -392,23 +453,25 @@ docs: | build-deps build deps
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(NIMBLE) doc --run --index:on --project --out:.gh-pages logos-delivery/logos-delivery.nim logos_delivery.nims $(NIMBLE_TASK_FLAGS)
 
-coverage:
+coverage: | build-deps build rln-deps librln
 	echo -e $(BUILD_MSG) "build/$@" && \
-		./scripts/run_cov.sh -y
+		LIBRLN_FILE=$(LIBRLN_FILE) ./scripts/run_cov.sh -y
 
 #####################
 ## Container image ##
 #####################
 DOCKER_IMAGE_NIMFLAGS ?= -d:chronicles_colors:none -d:insecure -d:postgres
-DOCKER_IMAGE_NIMFLAGS := $(DOCKER_IMAGE_NIMFLAGS) $(HEAPTRACK_PARAMS)
 
 docker-image: MAKE_TARGET ?= wakunode2
+docker-image: DEBUG ?= 0
 docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)-$(GIT_VERSION)
 docker-image: DOCKER_IMAGE_NAME ?= wakuorg/nwaku:$(DOCKER_IMAGE_TAG)
 docker-image:
 	docker build \
 		--build-arg="MAKE_TARGET=$(MAKE_TARGET)" \
 		--build-arg="NIMFLAGS=$(DOCKER_IMAGE_NIMFLAGS)" \
+		--build-arg="DEBUG=$(DEBUG)" \
+		--build-arg="LOG_LEVEL=$(LOG_LEVEL)" \
 		--build-arg="HEAPTRACK_BUILD=$(HEAPTRACKER)" \
 		--label="commit=$(shell git rev-parse HEAD)" \
 		--label="version=$(GIT_VERSION)" \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ These instructions are generic. For more detailed instructions, see the source c
 
 Recommended and tested toolchain versions (these are installed when you follow the build instructions below):
 - Nim 2.2.6
-- Nimble 0.24.1
+- Nimble: `make nimble` installs the pinned revision. Do not install it by version: the release with the same number is a different build, and only the `git hash:` line of `nimble --version` tells them apart.
+
+`make` puts the pinned Nimble first on its own PATH, so building needs no setup. To use that same Nimble directly in a shell:
+
+```bash
+export PATH="$(make print-nimble-path):$PATH"
+```
 
 ### Prerequisites
 
@@ -91,17 +97,26 @@ pacman -S --noconfirm --needed mingw-w64-x86_64-libwinpthread-git
 pacman -S --noconfirm --needed mingw-w64-x86_64-zlib  
 pacman -S --noconfirm --needed mingw-w64-x86_64-openssl  
 pacman -S --noconfirm --needed mingw-w64-x86_64-python
+pacman -S --noconfirm --needed mingw-w64-x86_64-nasm
+```
+
+`make` does not install Nim on Windows: `install-nim` is skipped there, and dependency setup calls `nim`, so it must already be on PATH. Install the version `logos_delivery.nimble` declares in `RequiredNimVersion` yourself, with `choosenim` or the official Windows build. The `ci / build-windows` job installs the same version with `jiro4989/setup-nim-action`.
+
+Verify before building:
+```bash
+which upx gcc g++ make cmake cargo rustc python nasm nim
+nim --version
 ```
 
 #### 3. Build Wakunode
 - Open Git Bash as administrator  
-- clone nwaku and cd nwaku
+- clone the repository and cd into it
 - Execute: `./scripts/build_windows.sh`
 
 #### 4. Troubleshooting
-If `wakunode2.exe` isn't generated:  
+If `wakunode2.exe`, `logosdeliverynode.exe` or `liblogosdelivery` isn't generated:  
 - **Missing Dependencies**: Verify with:  
-  `which make cmake gcc g++ rustc cargo python3 upx`  
+  `which make cmake gcc g++ rustc cargo python3 upx nasm nim`  
   If missing, revisit Step 2 or ensure MSYS2 is at `C:\`  
 - **Installation Conflicts**: Remove existing MinGW/MSYS2/Git Bash installations and perform fresh install
 
@@ -151,7 +166,7 @@ Refer to [logos-delivery-js repo](https://github.com/logos-messaging/logos-deliv
 
 ## Formatting
 
-Nim files are expected to be formatted using the [`nph`](https://github.com/arnetheduck/nph) version present in `vendor/nph`.
+Nim files are expected to be formatted using [`nph`](https://github.com/arnetheduck/nph). `make build-nph` installs one if it is not already on your PATH.
 
 You can easily format file with the `make nph/<relative path to nim> file` command.
 For example:

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
@@ -22,7 +22,9 @@ RUN git submodule update --init --recursive
 RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
 
 # Build the final node binary
-RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS}"
+# -d:disableMarchNative is appended here. Without it config.nims adds
+# -march=native and the image may require CPU features the runtime host lacks.
+RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS} -d:disableMarchNative"
 
 
 # REFERENCE IMAGE as BASE for specialized PRODUCTION IMAGES----------------------------------------

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -54,7 +54,7 @@ pipeline {
     )
     choice(
       name: "LOWEST_LOG_LEVEL_ALLOWED",
-      choices: ['TRACE', 'DEGUG', 'INFO', 'NOTICE', 'WARN', 'ERROR', 'FATAL'],
+      choices: ['TRACE', 'DEBUG', 'INFO', 'NOTICE', 'WARN', 'ERROR', 'FATAL'],
       description: "Defines the log level, which will be available at runtime (Chronicles log level)"
     )
   }

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -56,7 +56,6 @@ pipeline {
       /* Avoid checking multiple times. */
       v2changed = versionWasChanged('v2')
       /* TODO: Re-add caching of Nim compiler. */
-      nix.shell("make ${params.MAKEFLAGS} V=${params.VERBOSITY} update", pure: false)
       nix.shell("make ${params.MAKEFLAGS} V=${params.VERBOSITY} deps", pure: false)
     } } }
 
@@ -65,7 +64,7 @@ pipeline {
         stage('V2') {
           when { expression { v2changed } }
           steps { script {
-            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} all")
+            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} LOG_LEVEL=${params.LOG_LEVEL} all")
           } }
         }
       }
@@ -76,7 +75,7 @@ pipeline {
         stage('V2') {
           when { expression { v2changed } }
           steps { script {
-            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} test")
+            nix.shell("make ${params.MAKEFLAGS} NIMFLAGS=\"${params.NIMFLAGS}\" V=${params.VERBOSITY} LOG_LEVEL=${params.LOG_LEVEL} test")
           } }
         }
       }

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -64,7 +64,7 @@ pipeline {
     )
     choice(
       name: "LOWEST_LOG_LEVEL_ALLOWED",
-      choices: ['TRACE', 'DEGUG', 'INFO', 'NOTICE', 'WARN', 'ERROR', 'FATAL'],
+      choices: ['TRACE', 'DEBUG', 'INFO', 'NOTICE', 'WARN', 'ERROR', 'FATAL'],
       description: "Defines the log level, which will be available at runtime (Chronicles log level)",
     )
     booleanParam(
@@ -90,11 +90,11 @@ pipeline {
             "--label=commit='${git.commit()}' " +
             "--label=version='${git.describe('--tags')}' " +
             "--build-arg=MAKE_TARGET='${params.MAKE_TARGET}' " +
-            "--build-arg=NIMFLAGS='${params.NIMFLAGS} -d:heaptracker ' " +
+            "--build-arg=NIMFLAGS='${params.NIMFLAGS}' " +
+            "--build-arg=HEAPTRACK_BUILD='1' " +
             "--build-arg=POSTGRES='1' " +
             "--build-arg=LOG_LEVEL='${params.LOWEST_LOG_LEVEL_ALLOWED}' "  +
             "--build-arg=DEBUG='${params.DEBUG ? "1" : "0"} ' " +
-            "--build-arg=NIM_COMMIT='NIM_COMMIT=heaptrack_support_v2.0.12' " +
             "--target='debug-with-heaptrack' ."
           )
         } else {

--- a/config.nims
+++ b/config.nims
@@ -79,12 +79,6 @@ when defined(macosx):
   # callback only READS the buffer (copyMem from pbytes), so the missing `const`
   # is benign — we demote the diagnostic back to a warning instead of failing.
   #
-  # Why it appeared now (not a change on our side): the `const` was introduced in
-  # nim-bearssl v0.2.9, published 2026-06-19 11:22 UTC. CI does not honor the
-  # locked bearssl (nimble.lock pins 0.2.8) and fresh-resolves to latest, so any
-  # run after 11:22 UTC picks up 0.2.9 and hits this. Earlier-running PRs that
-  # resolved 0.2.8 are green only by timing; re-running them now reproduces it.
-  #
   # Proper fix: chronos should declare `itemAppend`'s `pbytes` as `const pointer`.
   switch("passC", "-Wno-error=incompatible-function-pointer-types")
 

--- a/docs/operators/how-to/build.md
+++ b/docs/operators/how-to/build.md
@@ -44,7 +44,6 @@ cd nwaku
 
 ```sh
 # The first `make` invocation will update all Git submodules.
-# You'll run `make update` after each `git pull`, in the future, to keep those submodules up to date.
 make wakunode2
 ```
 

--- a/docs/tutorial/heaptrack.md
+++ b/docs/tutorial/heaptrack.md
@@ -42,18 +42,24 @@ nwaku supports heaptrack, but it needs a special compilation setting.
 
 ### Patch Nim compiler to register allocations on Heaptrack
 
-Currently, we rely on the official Nim repository. So we need to patch the Nim compiler to register allocations and deallocations on Heaptrack.
-For Nim 2.2.4 version, we created a patch that can be applied as:
+The hooks live in Nim's allocator, so the Nim that builds the node must be patched. `-d:heaptracker` on its own compiles to nothing, and `make HEAPTRACKER=1` only adds that define.
+
+The container build applies the patch for you:
+
 ```bash
-git apply --directory=vendor/nimbus-build-system/vendor/Nim docs/tutorial/nim.2.2.4_heaptracker_addon.patch
-git add .
-git commit -m "Add heaptrack support to Nim compiler - temporary patch"
+make docker-image HEAPTRACKER=1
 ```
 
-> Until heaptrack support is not available in official Nim, so it is important to keep it in the `nimbus-build-system` repository.
-> Commit ensures that `make update` will not override the patch unintentionally.
+It patches the Nim that `make deps` installed, then builds with the define.
 
-> We are planning to make it available through an official PR for Nim.
+For a local build on Linux, patch the Nim on your PATH first. The commands below use `readlink -f` and the patch loads a `.so`, so this route is Linux-only; on other platforms use the container route above.
+
+```bash
+NIM_ROOT=$(dirname "$(dirname "$(readlink -f "$(command -v nim)")")")
+git -C "$NIM_ROOT" apply "$PWD/docs/tutorial/nim.2.2.4_heaptracker_addon.patch"
+```
+
+> The patch is not upstream in Nim. Reinstalling or upgrading Nim removes it, so it must be reapplied.
 
 When the patch is applied, we can build wakunode2 with heaptrack support.
 

--- a/examples/golang/README.md
+++ b/examples/golang/README.md
@@ -2,11 +2,7 @@
 ## Pre-requisite
 liblogosdelivery.so is needed to be compiled and present in build folder. To create it:
 
-- Run only the first time and after changing the current commit
-```code
-make update
-```
-- Run the next every time you want to compile libwaku
+- Run this every time you want to compile liblogosdelivery
 ```code
 make POSTGRES=1 liblogosdelivery -j4
 ```

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -17,7 +17,10 @@ const RequiredNimVersion = "2.2.6"
   ## This is the nim compiler version that we are working on. Other versions may behave differently.
 const RequiredNimbleVersion = "0.24.1"
   ## Enforced nimble version to ensure a reproducible flow
-const RequiredNimbleRevision = "bc789ee6bcbfe315f81984a29318f6f8d4dcafa5"
+const RequiredNimbleRevision = "1a2b3ae900a8ccb307a118173e0c3a7cdfcfc121"
+  ## Release 0.24.1 discards the --requires constraints before it applies nimble.lock.
+  ## 5df81e6 fixes that and is unreleased. 1a2b3ae is three commits later, and also
+  ## stops the solver reporting an exhausted search budget as an unsatisfiable graph.
 
 ### Dependencies
 requires "nim == 2.2.6",
@@ -115,7 +118,7 @@ proc buildModule(filePath, params = ""): bool =
     echo "File to build not found: " & filePath
     return false
 
-  exec "nim c --out:build/" & filepath & ".bin --mm:refc " & getMyCPU() & getNimParams() & " " & params &
+  exec "nim c --out:build/" & filepath & ".bin --mm:refc " & getMyCPU() & " " & params & getNimParams() &
     " " & filePath
 
   # exec will raise exception if anything goes wrong
@@ -124,7 +127,7 @@ proc buildModule(filePath, params = ""): bool =
 proc buildBinary(name: string, srcDir = "./", params = "") =
   if not dirExists "build":
     mkDir "build"
-  exec "nim c --out:build/" & name & " --mm:refc " & getMyCPU() & getNimParams() & " " & params & " " &
+  exec "nim c --out:build/" & name & " --mm:refc " & getMyCPU() & " " & params & getNimParams() & " " &
     srcDir & name & ".nim"
 
 ## Emitted by `genBindings()` during the library build, so the header can never
@@ -145,11 +148,11 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
   if `type` == "static":
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      cBindingsFlags & getMyCPU() & getNimParams() & srcDir & "/" & srcFile
+      cBindingsFlags & getMyCPU() & " " & params & getNimParams() & " " & srcDir & "/" & srcFile
   else:
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      cBindingsFlags & getMyCPU() & getNimParams() & " " & srcDir & "/" & srcFile
+      cBindingsFlags & getMyCPU() & " " & params & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
   buildLibrary libName & ".dll", folderName,
@@ -333,9 +336,6 @@ task libLogosDeliveryIOS, "Build the mobile bindings for iOS":
   buildMobileIOS srcDir, extraParams
 
 proc test(name: string, params = "-d:chronicles_log_level=DEBUG") =
-  # XXX: When running `> NIM_PARAMS="-d:chronicles_log_level=INFO" make test2`
-  # I expect compiler flag to be overridden, however it stays with whatever is
-  # specified here.
   buildBinary name, "tests/", params
   exec "build/" & name
 

--- a/logos_delivery/waku/README.md
+++ b/logos_delivery/waku/README.md
@@ -18,7 +18,6 @@ See [specifications](https://rfc.vac.dev/waku/standards/core/10/waku2).
 
 ```bash
 # The first `make` invocation will update all Git submodules.
-# You'll run `make update` after each `git pull`, in the future, to keep those submodules up to date.
 make wakunode2
 
 # See available command line options

--- a/scripts/build_windows.sh
+++ b/scripts/build_windows.sh
@@ -21,7 +21,7 @@ echo "1. -.-.-.-- Set PATH -.-.-.-"
 export PATH="/c/msys64/usr/bin:/c/msys64/mingw64/bin:/c/msys64/usr/lib:/c/msys64/mingw64/lib:$PATH"
 
 echo "2. -.-.-.- Verify dependencies -.-.-.-"
-execute_command "which gcc g++ make cmake cargo upx rustc python"
+execute_command "which gcc g++ make cmake cargo upx rustc python nasm nim"
 
 echo "3. -.-.-.- Updating submodules -.-.-.-"
 execute_command "git submodule update --init --recursive"
@@ -29,32 +29,27 @@ execute_command "git submodule update --init --recursive"
 echo "4. -.-.-.- Creating tmp directory -.-.-.-"
 execute_command "mkdir -p tmp"
 
-echo "5. -.-.-.- Building Nim -.-.-.-"
-cd vendor/nimbus-build-system/vendor/Nim
-execute_command "./build_all.bat"
-cd ../../../..
+# Nim is installed separately, and make builds the C libraries itself:
+# Nat.mk builds miniupnpc and libnatpmp from the package nimble installed, and
+# libbacktrace is disabled by default. The vendor tree those steps used is gone.
 
-echo "6. -.-.-.- Building libunwind -.-.-.-"
-cd vendor/nim-libbacktrace
-execute_command "make all V=1 -j8"
-cd ../../
-
-echo "7. -.-.-.- Building miniupnpc -.-.-.- "
-cd vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc
-execute_command "make -f Makefile.mingw CC=gcc CXX=g++ libminiupnpc.a V=1 -j8"
-cd ../../../../..
-
-echo "8. -.-.-.- Building libnatpmp -.-.-.- "
-cd ./vendor/nim-nat-traversal/vendor/libnatpmp-upstream
-make CC="gcc -fPIC -D_WIN32_WINNT=0x0600 -DNATPMP_STATICLIB" libnatpmp.a V=1 -j8
-cd ../../../../
-
-echo "9. -.-.-.- Building wakunode2 -.-.-.- "
+echo "5. -.-.-.- Building wakunode2 -.-.-.- "
 execute_command "make wakunode2 LOG_LEVEL=DEBUG V=1 -j8"
 
-echo "10. -.-.-.- Building libwaku -.-.-.- "
-execute_command "make libwaku STATIC=0 LOG_LEVEL=DEBUG V=1 -j8"
+echo "6. -.-.-.- Building logosdeliverynode -.-.-.- "
+execute_command "make logosdeliverynode POSTGRES=1 LOG_LEVEL=DEBUG V=1 -j8"
 
-echo "Windows setup completed successfully!"
+echo "7. -.-.-.- Building liblogosdelivery -.-.-.- "
+execute_command "make liblogosdelivery STATIC=0 LOG_LEVEL=DEBUG V=1 -j8"
+
 echo "✓ Successful commands: $success_count"
 echo "✗ Failed commands: $failure_count"
+
+# execute_command records failures instead of stopping, so the exit status has
+# to carry them. Without this the script reports success after a failed build.
+if [ "$failure_count" -ne 0 ]; then
+    echo "Windows setup FAILED"
+    exit 1
+fi
+
+echo "Windows setup completed successfully!"

--- a/scripts/check_build_health.sh
+++ b/scripts/check_build_health.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Check that build configuration reaches the compiler.
+#
+# Usage:
+#
+#   scripts/check_build_health.sh
+#
+# The cases check four things:
+#
+#   the Nim flags a make variable produces
+#   the commands make would run for a target
+#   the generated constraints against nimble.lock
+#   the command a Nimble task emits
+#
+# A failed case prints the expected and the actual value.
+#
+# Examples:
+#
+#   Variable          Effect
+#   ----------------  ------------------------------------------------
+#   NIMFLAGS=-d:x     adds -d:x, after the defines it may conflict with
+#   NIM_PARAMS=-d:x   from the environment, the caller's own contribution,
+#                     kept across recursion; on the make command line it
+#                     replaces the whole set, project flags and NIMFLAGS too
+#   V=0               adds --verbosity:0 --hints:off, sets HANDLE_OUTPUT
+#   V=1               adds --verbosity:1, clears HANDLE_OUTPUT
+#   LOG_LEVEL=INFO    adds -d:chronicles_log_level="INFO"
+#   LOG_LEVEL empty   nothing
+#   DEBUG=0           adds -d:release -d:lto_incremental -d:strip
+#   DEBUG unset       adds -d:debug
+#   POSTGRES=1        adds -d:postgres
+#   DEBUG_DISCV5=1    adds -d:debugDiscv5
+
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+pass=0
+fail=0
+
+ok() {
+  printf '  PASS  %s\n' "$1"
+  pass=$((pass + 1))
+}
+
+no() {
+  printf '  FAIL  %s\n' "$1"
+  shift
+  local line
+  for line in "$@"; do
+    printf '          %s\n' "${line}"
+  done
+  fail=$((fail + 1))
+}
+
+# name, python program. The program prints "ok" or the reason it failed.
+expect_python() {
+  local name=$1 prog=$2
+  local got
+  got=$(python3 -c "${prog}" 2>&1)
+  if [ "${got}" = "ok" ]; then
+    ok "${name}"
+  else
+    no "${name}" "${got}"
+  fi
+}
+
+# Return the commands make would run for a target. -B ignores timestamps.
+recipe_of() {
+  make -Bn "$@" 2>/dev/null
+}
+
+# name, needle, make args...
+expect_recipe() {
+  local name=$1 needle=$2
+  shift 2
+  local got
+  got=$(recipe_of "$@")
+  case "${got}" in
+    *"${needle}"*) ok "${name}" ;;
+    *) no "${name}" "expected the recipe to contain: ${needle}" ;;
+  esac
+}
+
+# name, needle, make args...
+reject_recipe() {
+  local name=$1 needle=$2
+  shift 2
+  local got
+  got=$(recipe_of "$@")
+  case "${got}" in
+    *"${needle}"*) no "${name}" "expected the recipe NOT to contain: ${needle}" ;;
+    *) ok "${name}" ;;
+  esac
+}
+
+# Return the resolved NIM_PARAMS.
+nim_params() {
+  make -pn "$@" 2>/dev/null | grep -E '^NIM_PARAMS :?=' | head -1
+}
+
+# Return the value of a variable. Remove the name and the spaces.
+value_of() {
+  local name=$1
+  shift
+  make -pn "$@" 2>/dev/null \
+    | grep -E "^${name} :?=" | head -1 \
+    | sed -E "s/^${name} :?=[[:space:]]*//; s/[[:space:]]+\$//"
+}
+
+# Return a variable from a recipe environment. "make -pn" does not show
+# export directives.
+exported_value() {
+  local name=$1
+  shift
+  printf 'include Makefile\n_health_probe:\n\t@echo "$$%s"\n' "${name}" \
+    | make -s -f - "$@" _health_probe 2>/dev/null
+}
+
+# name, needle, make args...
+expect_flag() {
+  local name=$1 needle=$2
+  shift 2
+  local got
+  got=$(nim_params "$@")
+  case "${got}" in
+    *"${needle}"*) ok "${name}" ;;
+    *) no "${name}" "expected to contain: ${needle}" "actual: ${got:-<no NIM_PARAMS>}" ;;
+  esac
+}
+
+# name, needle, make args...
+reject_flag() {
+  local name=$1 needle=$2
+  shift 2
+  local got
+  got=$(nim_params "$@")
+  case "${got}" in
+    *"${needle}"*) no "${name}" "expected NOT to contain: ${needle}" "actual: ${got}" ;;
+    *) ok "${name}" ;;
+  esac
+}
+
+# name, make args... The invocation must fail. -n so nothing is built.
+expect_make_fails() {
+  local name=$1
+  shift
+  if make -n "$@" >/dev/null 2>&1; then
+    no "${name}" "make -n $* exited 0"
+  else
+    ok "${name}"
+  fi
+}
+
+# name, make args... The invocation must parse.
+expect_make_parses() {
+  local name=$1
+  shift
+  if make -n "$@" >/dev/null 2>&1; then
+    ok "${name}"
+  else
+    no "${name}" "make -n $* failed"
+  fi
+}
+
+# name, expected, actual
+expect_eq() {
+  if [ "$2" = "$3" ]; then
+    ok "$1"
+  else
+    no "$1" "expected: $2" "actual:   $3"
+  fi
+}
+
+echo "build health"
+echo
+
+# --------------------------------------------------------------------------
+# Callers set NIMFLAGS. The README, the workflows, the Jenkins jobs and the
+# Dockerfiles use it. Make computes NIM_PARAMS from it.
+# --------------------------------------------------------------------------
+expect_flag "NIMFLAGS reaches the compiler" \
+  "-d:health_sentinel" NIMFLAGS=-d:health_sentinel
+
+# Nim uses the last definition of a define. NIMFLAGS must come after the
+# project defines it may conflict with.
+ordering=$(nim_params NIMFLAGS=-d:health_sentinel)
+if [ -z "${ordering}" ]; then
+  no "NIMFLAGS wins over project defaults" "NIM_PARAMS did not resolve"
+elif [ "${ordering%%-d:health_sentinel*}" = "${ordering}" ]; then
+  no "NIMFLAGS wins over project defaults" "sentinel absent: ${ordering}"
+else
+  before=${ordering%%-d:health_sentinel*}
+  case "${before}" in
+    *git_version*) ok "NIMFLAGS wins over project defaults" ;;
+    *) no "NIMFLAGS wins over project defaults" \
+         "the caller's flag must come after the project defaults" \
+         "actual: ${ordering}" ;;
+  esac
+fi
+
+# NIM_PARAMS is exported and several targets recurse, so a sub-make must not
+# append the project's flags a second time.
+rec=$(mktemp)
+{
+  printf 'include Makefile\n'
+  printf '_outer:\n'
+  printf '\t@echo "OUTER $(NIM_PARAMS)"\n'
+  printf '\t@$(MAKE) -s -f %s _inner\n' "${rec}"
+  printf '_inner:\n'
+  printf '\t@echo "INNER $(NIM_PARAMS)"\n'
+} > "${rec}"
+rec_out=$(make -s -f "${rec}" _outer NIMFLAGS=-d:health_sentinel 2>/dev/null)
+rm -f "${rec}"
+expect_eq "a sub-make gets the same NIM_PARAMS" \
+  "$(printf '%s\n' "${rec_out}" | sed -n 's/^OUTER //p')" \
+  "$(printf '%s\n' "${rec_out}" | sed -n 's/^INNER //p')"
+
+# NIM_PARAMS on the make command line is not part of the assembly at all. Make
+# gives it precedence over every assignment in the Makefile, so neither the
+# project's flags nor NIMFLAGS are added to it.
+expect_eq "a command line NIM_PARAMS replaces the whole list" \
+  "-d:health_cli" \
+  "$(value_of NIM_PARAMS NIM_PARAMS=-d:health_cli NIMFLAGS=-d:health_sentinel)"
+
+# NIM_PARAMS from the environment is the caller's contribution and is kept.
+# NIMFLAGS is applied after the project's flags, so it still wins.
+env_base=$(NIM_PARAMS=-d:health_base nim_params NIMFLAGS=-d:health_sentinel)
+case "${env_base}" in
+  *-d:health_base*) ok "an environment NIM_PARAMS reaches the build" ;;
+  *) no "an environment NIM_PARAMS reaches the build" \
+       "expected to contain: -d:health_base" \
+       "actual: ${env_base:-<no NIM_PARAMS>}" ;;
+esac
+case "${env_base%%-d:health_sentinel*}" in
+  *-d:health_base*) ok "NIMFLAGS is applied after an environment NIM_PARAMS" ;;
+  *) no "NIMFLAGS is applied after an environment NIM_PARAMS" \
+       "actual: ${env_base:-<no NIM_PARAMS>}" ;;
+esac
+
+# The Nimble tasks read NIM_PARAMS with getEnv. Make must export it.
+seen=$(exported_value NIM_PARAMS NIMFLAGS=-d:health_sentinel)
+case "${seen}" in
+  *-d:health_sentinel*) ok "nimble tasks receive NIM_PARAMS in the environment" ;;
+  *) no "nimble tasks receive NIM_PARAMS in the environment" \
+       "a recipe saw: ${seen:-<empty>}" \
+       "getEnv(\"NIM_PARAMS\") in logos_delivery.nimble would not see the flags" ;;
+esac
+
+# --------------------------------------------------------------------------
+# V selects verbosity. The workflows pass V=1.
+# --------------------------------------------------------------------------
+expect_flag "V=1 sets --verbosity:1"           "--verbosity:1" V=1
+expect_flag "V=0 sets --verbosity:0"           "--verbosity:0" V=0
+expect_flag "V=0 quiets hints"                 "--hints:off"   V=0
+reject_flag "V=1 keeps hints"                  "--hints:off"   V=1
+
+# V also sets HANDLE_OUTPUT. Nat.mk uses it to silence the sub-makes.
+expect_eq "V=0 sets HANDLE_OUTPUT for Nat.mk" ">/dev/null" "$(value_of HANDLE_OUTPUT V=0)"
+expect_eq "V=1 clears HANDLE_OUTPUT"          ""            "$(value_of HANDLE_OUTPUT V=1)"
+
+# --------------------------------------------------------------------------
+# LOG_LEVEL is a Jenkins parameter. The image builds pass it to make.
+# --------------------------------------------------------------------------
+expect_flag "LOG_LEVEL selects the chronicles level" \
+  '-d:chronicles_log_level="INFO"' LOG_LEVEL=INFO
+reject_flag "an empty LOG_LEVEL is a no-op" \
+  "chronicles_log_level" LOG_LEVEL=
+
+# --------------------------------------------------------------------------
+# DEBUG is active at 0, not at 1. An unset DEBUG and DEBUG=0 differ.
+# --------------------------------------------------------------------------
+expect_flag "DEBUG=0 selects release"          "-d:release"          DEBUG=0
+expect_flag "DEBUG=0 keeps link-time optimisation" "-d:lto_incremental" DEBUG=0
+expect_flag "DEBUG=0 strips the binary"        "-d:strip"            DEBUG=0
+expect_flag "an unset DEBUG stays a debug build" "-d:debug"
+reject_flag "an unset DEBUG does not strip"    "-d:strip"
+
+# --------------------------------------------------------------------------
+# These knobs are one word in a different case.
+# --------------------------------------------------------------------------
+expect_flag "POSTGRES=1 enables the postgres driver" "-d:postgres"    POSTGRES=1
+reject_flag "POSTGRES unset leaves it out"           "-d:postgres"
+expect_flag "DEBUG_DISCV5=1 enables discv5 tracing"  "-d:debugDiscv5" DEBUG_DISCV5=1
+
+# --------------------------------------------------------------------------
+# `make test <file> [name]` passes the file and the name as extra goals, which
+# the catch-all absorbs. Every other unknown target must fail, or a stale
+# invocation succeeds while doing nothing.
+# --------------------------------------------------------------------------
+expect_make_fails  "an unknown target fails"            update
+expect_make_fails  "an arbitrary unknown target fails"  definitely-not-a-target
+expect_make_parses "make test <file> still parses"      test tests/all_tests_waku.nim
+
+# --------------------------------------------------------------------------
+# Nimble reads the constraints only from an attached --requires:<value>. A
+# separate argument leaves the value empty and Nimble discards nimble.lock.
+# --------------------------------------------------------------------------
+expect_recipe "setup attaches the constraints" \
+  '--requires:"$(cat requires.generated)"' nimbledeps/.nimble-setup
+reject_recipe "setup does not pass them as a separate argument" \
+  '--requires "' nimbledeps/.nimble-setup
+expect_recipe "custom tasks attach the constraints" \
+  '--requires:"$(cat requires.generated)"' wakunode2
+reject_recipe "custom tasks do not pass them as a separate argument" \
+  '--requires "' wakunode2
+
+# The constraints come from nimble.lock through the generator, and the audit
+# checks the result against the same lock.
+expect_recipe "setup regenerates the constraints first" \
+  "gen_requires.nims" nimbledeps/.nimble-setup
+expect_recipe "setup audits the result" \
+  "audit-deps" nimbledeps/.nimble-setup
+
+# --------------------------------------------------------------------------
+# The constraints are generated from nimble.lock. A named constraint must
+# give the locked version, a URL constraint the locked revision.
+# --------------------------------------------------------------------------
+expect_python "the constraints agree with nimble.lock" "import json
+lock = json.load(open(\"nimble.lock\"))[\"packages\"]
+gen = [c.strip() for c in open(\"requires.generated\").read().split(\";\") if c.strip()]
+def norm(u): return u.lower().rstrip(\"/\").removesuffix(\".git\")
+byurl = {norm(v[\"url\"]): v for v in lock.values() if \"url\" in v}
+bad = []
+for c in gen:
+    if \" == \" in c:
+        n, v = c.split(\" == \")
+        if lock.get(n, {}).get(\"version\") != v:
+            bad.append(c + \" (lock has \" + str(lock.get(n, {}).get(\"version\")) + \")\")
+    elif c.startswith(\"http\") and \"#\" in c:
+        u, rev = c.rsplit(\"#\", 1)
+        if byurl.get(norm(u), {}).get(\"vcsRevision\") != rev:
+            bad.append(c)
+    else:
+        bad.append(\"unrecognised form: \" + c)
+print(\"ok\" if not bad else \"constraints disagree with nimble.lock: \" + \"; \".join(bad[:3]))"
+
+# --------------------------------------------------------------------------
+# The Nimble tasks concatenate their own defaults with NIM_PARAMS. The
+# caller's value has to come last. An invalid flag stops Nim before it
+# compiles, and the command is printed before it runs.
+# --------------------------------------------------------------------------
+emitted=$(make wakunode2 \
+  NIMFLAGS="-d:chronicles_log_level=HEALTHSENTINEL --nonexistent-flag-xyz" 2>&1 \
+  | grep -oE 'nim c [^|]*' | head -1)
+if [ -z "${emitted}" ]; then
+  no "the task puts the caller's flags after its own" "no nim command was emitted"
+else
+  before=${emitted%%-d:chronicles_log_level=HEALTHSENTINEL*}
+  case "${before}" in
+    *chronicles_log_level=*) ok "the task puts the caller's flags after its own" ;;
+    *) no "the task puts the caller's flags after its own" \
+         "the task default did not appear before the caller's value" ;;
+  esac
+fi
+
+# --------------------------------------------------------------------------
+# The build installs a pinned Nimble revision and puts it first on PATH. The
+# release with the same version number is a different build and reports the
+# same version, so check the revision. The case above already ran a build,
+# which installs it.
+# --------------------------------------------------------------------------
+# print-nimble-path is what the README tells a developer to use, so test that,
+# not a second way of finding the same binary.
+tooldir=$(make print-nimble-path 2>/dev/null)
+expect_eq "print-nimble-path names the pinned revision" \
+  "$(value_of REQUIRED_NIMBLE_REVISION)" \
+  "$("${tooldir}/nimble" --version 2>/dev/null | sed -n 's/^git hash: //p')"
+
+# ~/.nimble/bin/nimble is a link that `nimble setup` rewrites. It must not
+# shadow the pinned binary.
+expect_eq "the pinned Nimble is the one make runs" \
+  "${tooldir}/nimble" \
+  "$(printf 'include Makefile\n_p:\n\t@command -v nimble\n' | make -s -f - _p 2>/dev/null)"
+
+echo
+echo "  ${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/scripts/gen_requires.nims
+++ b/scripts/gen_requires.nims
@@ -5,7 +5,7 @@
 # This script writes requires.generated, a supplemental requirements string
 # passed to:
 #
-#   nimble setup --requires "$(cat requires.generated)"
+#   nimble setup --requires:"$(cat requires.generated)"
 #
 # Nimble matches lock entries by package name in solveLockFileDeps
 # (src/nimblepkg/nimblesat.nim:1226). A URL requirement therefore may not

--- a/scripts/generate_nix_submodules.sh
+++ b/scripts/generate_nix_submodules.sh
@@ -8,7 +8,7 @@
 #
 # Run this script after:
 #   - Adding/removing submodules
-#   - Updating submodule commits (e.g. after 'make update')
+#   - Updating submodule commits
 #   - Any change to .gitmodules
 #
 # Compatible with macOS bash 3.x (no associative arrays).

--- a/scripts/install_nimble.sh
+++ b/scripts/install_nimble.sh
@@ -99,7 +99,10 @@ echo "Building nimble ${NIMBLE_VERSION} with $("${NIM_BIN}" --version | head -1)
 cd "${WORK_DIR}/nimble"
 # Nim reads nim.cfg and config.nims from the current directory; these
 # files add the vendored module paths used by the build.
-"${NIM_BIN}" c -d:release --path:src \
+#
+# --nimcache keeps this run's C and object files out of Nim's shared
+# "nimble" cache directory, which two runs of this script would clobber.
+"${NIM_BIN}" c -d:release --path:src --nimcache:"${WORK_DIR}/nimcache" \
   -o:"${WORK_DIR}/nimble_new" src/nimble.nim
 
 # Stage the executable under a separate pathname, then rename it over

--- a/scripts/run_cov.sh
+++ b/scripts/run_cov.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 
-# Check if env.sh has been loaded, or if this file is being ran from it.
-# Using NIMC as a proxy for this, as it's defined in the nimbus-build-system's env.sh.
-if [ -z "$NIMC" ]
+# Run this through `make coverage`, which supplies LIBRLN_FILE. The library is
+# named for the pinned zerokit release, so this script must not hardcode it.
+if [ -z "$LIBRLN_FILE" ]
 then
-    echo "[ERROR] This tool can only be ran from the Nimbus environment. Either:" 
-    echo "- Source env.sh 'source /path/to/env.sh', and then run the script directly '/path/to/scripts/run_cov.sh'." 
-    echo "- Run this script as a parameter to env.sh '/path/to/env.sh /path/to/scripts/run_cov.sh'."
+    echo "[ERROR] LIBRLN_FILE is not set. Run 'make coverage'."
     exit 1
 fi
 
+# set -e so a failed compile, test run, lcov or genhtml fails this script. The
+# cleanup below runs from a trap so it still happens on failure, and its exit
+# status cannot mask theirs.
+set -e
+
 # Check for lcov tool
-which lcov 1>/dev/null 2>&1
-if [ $? != 0 ]
+if ! command -v lcov >/dev/null 2>&1
 then
     echo "[ERROR] You need to have lcov installed in order to generate the test coverage report."
     exit 2
@@ -37,16 +39,18 @@ base_filepath="$REPO_ROOT/tests/test_all"
 nim_filepath=$base_filepath.nim
 info_filepath=$base_filepath.info
 
+cleanup() {
+    rm -rf "$info_filepath" "$base_filepath" nimcache
+    rm -f "$generated_not_to_break_here"
+}
+trap cleanup EXIT
+
 # Workaround a nim bug. See https://github.com/nim-lang/Nim/issues/12376
 touch $generated_not_to_break_here
 
 # Generate the coverage report
-nim --debugger:native --passC:--coverage --passL:--coverage --passL:librln_v0.3.4.a --passL:-lm c $nim_filepath
+nim --debugger:native --passC:--coverage --passL:--coverage --passL:"$LIBRLN_FILE" --passL:-lm c $nim_filepath
 lcov --base-directory . --directory . --zerocounters -q
 $base_filepath
 lcov --base-directory . --directory . --include "*/waku/**" --include "*/apps/**" --exclude "*/vendor/**" -c -o $info_filepath
 genhtml -o $output_directory $info_filepath
-
-# Cleanup
-rm -rf $info_filepath $base_filepath nimcache
-rm $generated_not_to_break_here

--- a/tests-e2e/scripts/prepare_lib.sh
+++ b/tests-e2e/scripts/prepare_lib.sh
@@ -6,7 +6,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LIBDIR="$ROOT/tests-e2e/vendor/logos-delivery-python-bindings/lib"
 
 cd "$ROOT"
-make update
 make V=1 liblogosdelivery
 
 mkdir -p "$LIBDIR"


### PR DESCRIPTION
## Description

This PR applies multiple fixes to the build system.

`nimble setup` and every task call now pass the generated constraints as `--requires:<value>`. Nimble reads the value only when a colon joins it to the option. The build also pins a Nimble revision (`1a2b3ae`) that actually applies those constraints before it applies the lock. Both those fixes now allow `nimble.lock` to drive local dependency resolution for logos-delivery build artifacts (downstream dependents are not restricted or affected).

`NIMFLAGS`, `V`, `HANDLE_OUTPUT` and `LOG_LEVEL` control the build again, and release builds carry `-d:lto_incremental` and `-d:strip`. Arguments in `NIMFLAGS` are applied after the project defaults and override them. A new script `scripts/check_build_health.sh` has been added with a CI job that runs it, which now verifies the build system's assumptions (e.g. how build flags are processed).

A `NIM_PARAMS` in the environment is the caller's own contribution and goes in first, so the project's defines follow it. The Makefile exports `NIM_PARAMS_CALLER` to carry that value into recursive `$(MAKE)` calls, which stops a sub-make appending the project's flags a second time. A `NIM_PARAMS` on the make command line is separate again and replaces the whole list.

The `nix/deps.nix freshness` job in `ci-daily.yml` regenerates `nix/deps.nix` from `nimble.lock` and diffs it against the committed file. The hashes in it come from `nix-prefetch-git`, so that tool is now taken from the nixpkgs revision `flake.lock` pins rather than from whichever channel the runner provides.

Several changes target the artifacts this project publishes, selecting release mode and keeping the images portable across CPUs. Another set improves UX, so that e.g. user-selected options are respected, commands fail instead of reporting success, and the documentation names the tools the build installs.

## Changes

* fix passing the generated constraints as `--requires:"$(cat requires.generated)"`
* bump `RequiredNimbleRevision` to `1a2b3ae` (fixes `--requires` handling)
* give each Nimble install its own nimcache in `scripts/install_nimble.sh`
* add `NIM_PARAMS := $(NIM_PARAMS) $(NIMFLAGS)` after the project defaults
* add `NIM_PARAMS_CALLER` to stop `NIM_PARAMS` recursion duplicating params
* restore `V`, `HANDLE_OUTPUT`, `LOG_LEVEL`, `-d:lto_incremental` and `-d:strip`
* move the Nimble task defaults before the exported caller flags in `logos_delivery.nimble`
* pass `params` through `buildLibrary` in `logos_delivery.nimble`
* move `-d:chronicles_log_level=TRACE` before `$(NIM_PARAMS)` in the Windows recipes
* add `scripts/check_build_health.sh` with a CI job for it
* add `DEBUG=0` to the workflows that publish images and release assets
* add `-d:disableMarchNative` at the Dockerfile boundaries that compile Nim
* replace the `NIM_PARAMS` workflow environment variable with `NIMFLAGS`
* correct the zerokit branch in `.gitmodules` from `v0.5.1` to `release-v2.0.1`
* correct the contract branch in `.gitmodules` from `master` to `main`
* limit `%: @true` to `make test <file>`
* add `print-nimble-path` to report the pinned Nimble directory
* resolve `nph` from `PATH` instead of `$(HOME)/.nimble/bin`
* delete the `ENV_SCRIPT` reference from the `api_example` recipe
* replace `-d:heaptracker` with `HEAPTRACK_BUILD=1` in the Jenkins release job
* delete `NIM_COMMIT` build argument from the Jenkins release job
* add `LOG_LEVEL` to the `Jenkinsfile.prs` make calls
* correct `DEGUG` to `DEBUG` in `Jenkinsfile.release` and `Jenkinsfile.lpt`
* log a warning when `DISCORD_WEBHOOK_URL` is unset in `ci-rln-simulator.yml`
* build examples and tools with `-j1` in `ci-daily.yml` to avoid corruption
* use `nix shell --inputs-from .` for `nix-prefetch-git` in `ci-daily.yml`
* fix `make coverage`
* fix `scripts/build_windows.sh`
* delete `make update` and `vendor/nph` references
* state the required Nim and Nimble versions in the README
* rewrite the local patch instructions in `docs/tutorial/heaptrack.md`

## Notes

* The macos and send-e2e test jobs are flaky; these are a separate issue
* `logos-messaging/logos-delivery-simulator` needs a PR to restore RLN E2E (`deploy_rln_contract.sh` must add Foundry to `PATH` before it calls `foundryup`) -- EDIT: draft PR here: https://github.com/logos-messaging/logos-delivery-simulator/pull/124
* `logos-messaging/logos-delivery-rlnv2-contract` needs a PR to write `branch = v1` (instead of `branch = "v1"`) in `.gitmodules`, so that `forge install` does not pass the quotes to `git checkout` -- EDIT: draft PR here: https://github.com/logos-messaging/logos-delivery-rlnv2-contract/pull/52
* `scripts/build_windows.sh` improvements are partially tested
* `scripts/run_cov.sh` improvements are untested

## Issue

Maintenance Y2026H2 #4043 