### PR TITLE
test(mix): cover Delivery Mix-RLN coordination

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -94,7 +94,7 @@ requires "https://github.com/vacp2p/nim-boringssl#v0.0.11"
 requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 
 # Temporary pin to the mix commit that widens its libp2p requirement.
-requires "https://github.com/logos-co/nim-libp2p-mix#39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94"
+requires "https://github.com/richard-ramos/nim-libp2p-mix#75f8bd5386f08ea909332774ddbeb78599b89d92"
 
 # Draft integration pin; update to the final revision when the plugin PR lands.
 requires "https://github.com/logos-co/mix-rln-spam-protection-plugin#7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333"

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -21,7 +21,7 @@ const RequiredNimbleRevision = "bc789ee6bcbfe315f81984a29318f6f8d4dcafa5"
 
 ### Dependencies
 requires "nim == 2.2.6",
-  "chronos >= 4.2.0 & < 4.4.0",
+  "chronos == 4.2.5",
   "taskpools",
   # Logging & Configuration
   "chronicles",
@@ -69,6 +69,10 @@ requires "nim == 2.2.6",
 # URL requirements described above.
 # For commit-pinned releases, the preceding link records the associated
 # upstream release tag at the time the revision was selected.
+
+# nim-snappy's 0.1.0 package tracks master; pin the validated revision so
+# dependency setup remains reproducible.
+requires "https://github.com/status-im/nim-snappy#a99d113197e81bf764a3b005b0ade3f9f3758069"
 
 # v0.3.1-rc.0: https://github.com/logos-messaging/nim-ffi/releases/tag/v0.3.1-rc.0
 requires "https://github.com/logos-messaging/nim-ffi#07ee8e1d6500762bab290465457a8d23559de546"

--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -97,7 +97,7 @@ requires "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312
 requires "https://github.com/richard-ramos/nim-libp2p-mix#75f8bd5386f08ea909332774ddbeb78599b89d92"
 
 # Draft integration pin; update to the final revision when the plugin PR lands.
-requires "https://github.com/logos-co/mix-rln-spam-protection-plugin#7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333"
+requires "https://github.com/logos-co/mix-rln-spam-protection-plugin#2dee9aaa2214895805fded977543c2770db4dc16"
 
 proc getMyCPU(): string =
   ## Need to set cpu more explicit manner to avoid arch issues between dependencies

--- a/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/mix_conf_builder.nim
@@ -6,6 +6,7 @@ import
   libp2p_mix/curve25519
 import libp2p_mix/spam_protection
 import mix_rln_spam_protection/spam_protection as mix_rln
+import libp2p_mix/cover_traffic
 import ../waku_conf, logos_delivery/waku/waku_mix
 
 logScope:
@@ -21,6 +22,7 @@ type MixConfBuilder* = object
   mixKey: Opt[string]
   mixNodes: seq[MixNodePubInfo]
   spamProtection: Opt[SpamProtection]
+  coverTraffic: Opt[CoverTraffic]
   mixRlnConfig: Opt[mix_rln.MixRlnConfig]
 
 proc init*(T: type MixConfBuilder): MixConfBuilder =
@@ -34,6 +36,9 @@ proc withMixKey*(b: var MixConfBuilder, mixKey: string) =
 
 proc withMixNodes*(b: var MixConfBuilder, mixNodes: seq[MixNodePubInfo]) =
   b.mixNodes = mixNodes
+
+proc withCoverTraffic*(b: var MixConfBuilder, coverTraffic: CoverTraffic) =
+  b.coverTraffic = Opt.some(coverTraffic)
 
 proc withSpamProtection*(b: var MixConfBuilder, spamProtection: SpamProtection) =
   b.spamProtection = Opt.some(spamProtection)
@@ -56,6 +61,7 @@ proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
           MixConf(
             mixKey: mixPrivKey,
             mixPubKey: mixPubKey,
+            coverTraffic: b.coverTraffic,
             mixNodes: b.mixNodes,
             spamProtection: b.spamProtection,
             mixRlnConfig: b.mixRlnConfig,
@@ -73,6 +79,7 @@ proc build*(b: MixConfBuilder): Result[Opt[MixConf], string] =
             mixNodes: b.mixNodes,
             spamProtection: b.spamProtection,
             mixRlnConfig: b.mixRlnConfig,
+            coverTraffic: b.coverTraffic,
           )
         )
       )

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -434,6 +434,7 @@ proc setupProtocols(
         mixConf.mixKey,
         mixConf.mixnodes,
         spamProtection = spamProtection,
+        coverTraffic = mixConf.coverTraffic,
       )
     ).isOkOr:
       return err("failed to mount waku mix protocol: " & $error)

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -9,6 +9,7 @@ import
   libp2p/extended_peer_record,
   libp2p/protocols/kademlia/types,
   libp2p/protocols/service_discovery/types as sd_types,
+  libp2p_mix/cover_traffic,
   libp2p_mix/spam_protection,
   mix_rln_spam_protection/spam_protection as mix_rln,
   secp256k1,
@@ -68,6 +69,7 @@ type MixConf* = ref object
   mixPubKey*: Curve25519Key
   mixnodes*: seq[MixNodePubInfo]
   spamProtection*: Opt[SpamProtection]
+  coverTraffic*: Opt[CoverTraffic]
   mixRlnConfig*: Opt[mix_rln.MixRlnConfig]
 
 type StoreServiceConf* = object

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -23,6 +23,7 @@ import
   libp2p/transports/wstransport,
   libp2p/utils/offsettedseq,
   libp2p_mix,
+  libp2p_mix/cover_traffic,
   libp2p_mix/mix_protocol,
   libp2p_mix/spam_protection,
   mix_rln_spam_protection/spam_protection as mix_rln,
@@ -359,6 +360,7 @@ proc mountMix*(
     mixPrivKey: Curve25519Key,
     mixnodes: seq[MixNodePubInfo],
     spamProtection: Opt[SpamProtection] = Opt.none(SpamProtection),
+    coverTraffic: Opt[CoverTraffic] = Opt.none(CoverTraffic),
 ): Future[Result[void, string]] {.async.} =
   info "Mounting mix protocol", nodeId = node.info #TODO log the config used
 
@@ -376,6 +378,7 @@ proc mountMix*(
     mixPrivKey,
     mixnodes,
     spamProtection = spamProtection,
+    coverTraffic = coverTraffic,
   ).valueOr:
     error "Waku Mix protocol initialization failed", err = error
     return

--- a/logos_delivery/waku/waku_mix/protocol.nim
+++ b/logos_delivery/waku/waku_mix/protocol.nim
@@ -12,6 +12,7 @@ import
   libp2p_mix/delay_strategy,
   libp2p_mix/spam_protection,
   libp2p/[multiaddress, peerid],
+  libp2p_mix/cover_traffic,
   eth/common/keys
 
 import
@@ -79,6 +80,7 @@ proc new*(
     mixPrivKey: Curve25519Key,
     bootnodes: seq[MixNodePubInfo],
     spamProtection: Opt[SpamProtection] = Opt.none(SpamProtection),
+    coverTraffic: Opt[CoverTraffic] = Opt.none(CoverTraffic),
 ): WakuMixResult[T] =
   let mixPubKey = public(mixPrivKey)
   info "mixPubKey", mixPubKey = mixPubKey
@@ -107,6 +109,7 @@ proc new*(
             ExponentialDelayStrategy.new(meanDelay = 50'u16, rng = crypto.newRng())
           )
         ),
+    coverTraffic = coverTraffic,
   )
 
   processBootNodes(bootnodes, peermgr, m)

--- a/nimble.lock
+++ b/nimble.lock
@@ -667,8 +667,8 @@
       }
     },
     "mix_rln_spam_protection": {
-      "version": "#7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333",
-      "vcsRevision": "7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333",
+      "version": "#2dee9aaa2214895805fded977543c2770db4dc16",
+      "vcsRevision": "2dee9aaa2214895805fded977543c2770db4dc16",
       "url": "https://github.com/logos-co/mix-rln-spam-protection-plugin",
       "downloadMethod": "git",
       "dependencies": [

--- a/nimble.lock
+++ b/nimble.lock
@@ -647,9 +647,9 @@
       }
     },
     "libp2p_mix": {
-      "version": "#39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94",
-      "vcsRevision": "39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94",
-      "url": "https://github.com/logos-co/nim-libp2p-mix",
+      "version": "#75f8bd5386f08ea909332774ddbeb78599b89d92",
+      "vcsRevision": "75f8bd5386f08ea909332774ddbeb78599b89d92",
+      "url": "https://github.com/richard-ramos/nim-libp2p-mix",
       "downloadMethod": "git",
       "dependencies": [
         "nim",

--- a/nimble.lock
+++ b/nimble.lock
@@ -258,8 +258,8 @@
       }
     },
     "snappy": {
-      "version": "0.1.0",
-      "vcsRevision": "da2f0c7b6ce9053106e9bb098204fe5319038387",
+      "version": "#a99d113197e81bf764a3b005b0ade3f9f3758069",
+      "vcsRevision": "a99d113197e81bf764a3b005b0ade3f9f3758069",
       "url": "https://github.com/status-im/nim-snappy",
       "downloadMethod": "git",
       "dependencies": [
@@ -271,7 +271,7 @@
         "testutils"
       ],
       "checksums": {
-        "sha1": "d02c6657cc4df57c03ec8b84d0dd74007f6ebd07"
+        "sha1": "72fb32f879c2d0f4296e18e946d15daae993e32b"
       }
     },
     "serialization": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -305,9 +305,9 @@
   };
 
   libp2p_mix = pkgs.fetchgit {
-    url = "https://github.com/logos-co/nim-libp2p-mix";
-    rev = "39d2ac78da7b7f33562eb7cd95d6280ca9fa0e94";
-    sha256 = "098db702wviph33mzvlj4b20cpj10csfya2yx80rwlppc2brxqc4";
+    url = "https://github.com/richard-ramos/nim-libp2p-mix";
+    rev = "75f8bd5386f08ea909332774ddbeb78599b89d92";
+    sha256 = "1l7yy9ihm1zcrw0bvg8qy6d44s8lkjxbxb1vbc4pryc7jkxryw9h";
     fetchSubmodules = true;
   };
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -138,8 +138,8 @@
 
   snappy = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-snappy";
-    rev = "da2f0c7b6ce9053106e9bb098204fe5319038387";
-    sha256 = "1jmjh1b70wkhzmyzvp46y50x3i1f0hkdrpy6msvqix60xwkxf1zy";
+    rev = "a99d113197e81bf764a3b005b0ade3f9f3758069";
+    sha256 = "0fbr352m01psi3f25c3gi95yimrjmvsh10wckywscn0603iqzpjl";
     fetchSubmodules = true;
   };
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -313,8 +313,8 @@
 
   mix_rln_spam_protection = pkgs.fetchgit {
     url = "https://github.com/logos-co/mix-rln-spam-protection-plugin";
-    rev = "7e9bbc1c231e025a17dd0dd8ce6a4457e34ac333";
-    sha256 = "01dggifhxbl93mqgyjhnfc6d28l2iskh3zxlsllgjrrd6gfd9pla";
+    rev = "2dee9aaa2214895805fded977543c2770db4dc16";
+    sha256 = "0d0k2k95zrlm4bw2cjnxcc63zgwvkz6hlycj31v1h4syd3a2brzk";
     fetchSubmodules = true;
   };
 

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -62,7 +62,8 @@ import
   ./test_waku_rendezvous,
   ./test_waku_metadata,
   ./waku_discv5/test_waku_discv5,
-  ./waku_kademlia/test_waku_kademlia
+  ./waku_kademlia/test_waku_kademlia,
+  ./waku_mix/test_mix_rln_delivery
 
 # Waku Keystore test suite
 import ./test_waku_keystore_keyfile, ./test_waku_keystore

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -8,6 +8,7 @@ import
   results,
   testutils/unittests
 import libp2p_mix/spam_protection
+import libp2p_mix/cover_traffic
 import mix_rln_spam_protection/spam_protection as mix_rln
 import
   logos_delivery/waku/factory/waku_conf,
@@ -408,6 +409,18 @@ suite "Waku Conf Builder - rate limits":
     assert res.isOk(), $res.error
 
 suite "Waku Conf Builder - Mix-RLN":
+  test "cover traffic configuration is retained":
+    var builder = MixConfBuilder.init()
+    let scheduler = ConstantRateCoverTraffic.new(totalSlots = 10)
+    builder.withEnabled(true)
+    builder.withCoverTraffic(scheduler)
+
+    let conf = builder.build().expect("Mix configuration should build").get()
+
+    check:
+      conf.coverTraffic.isSome()
+      conf.coverTraffic.get() == CoverTraffic(scheduler)
+
   test "Mix-RLN configuration is retained":
     var builder = MixConfBuilder.init()
     let config = mix_rln.defaultConfig()

--- a/tests/waku_mix/test_mix_rln_delivery.nim
+++ b/tests/waku_mix/test_mix_rln_delivery.nim
@@ -1,0 +1,148 @@
+{.used.}
+
+import
+  chronos,
+  results,
+  stew/byteutils,
+  testutils/unittests,
+  libp2p_mix/[curve25519, spam_protection],
+  mix_rln_spam_protection/spam_protection as mix_rln
+
+import
+  logos_delivery/api/events/kernel_events,
+  logos_delivery/waku/[waku_core, waku_node],
+  ../testlib/[wakucore, wakunode]
+
+const
+  TestShardCount = 8'u32
+  PropagationTimeout = 10.seconds
+
+proc newMixRlnNode(): Future[Result[WakuNode, string]] {.async.} =
+  let node = newTestWakuNode(generateSecp256k1Key(), quicEnabled = false)
+  await node.start()
+
+  node.mountAutoSharding(DefaultClusterId, TestShardCount).isOkOr:
+    await node.stop()
+    return err("failed to mount autosharding: " & error)
+
+  (await node.mountRelay()).isOkOr:
+    await node.stop()
+    return err("failed to mount relay: " & error)
+
+  let mixRln = mix_rln.MixRlnSpamProtection.new(mix_rln.defaultConfig()).valueOr:
+    await node.stop()
+    return err("failed to create Mix-RLN: " & error)
+
+  (await mixRln.init()).isOkOr:
+    await node.stop()
+    return err("failed to initialize Mix-RLN: " & error)
+
+  let (mixPrivateKey, _) = generateKeyPair().valueOr:
+    await node.stop()
+    return err("failed to generate Mix key: " & error)
+
+  node.wakuMixRln = mixRln
+  (
+    await node.mountMix(
+      DefaultClusterId,
+      mixPrivateKey,
+      @[],
+      spamProtection = Opt.some(SpamProtection(mixRln)),
+    )
+  ).isOkOr:
+    await node.stop()
+    return err("failed to mount Mix: " & error)
+
+  await node.wakuMix.start()
+
+  node.mountMixRlnCoordination().isOkOr:
+    await node.stop()
+    return err("failed to mount Mix-RLN coordination: " & error)
+
+  (await mixRln.start()).isOkOr:
+    await node.stop()
+    return err("failed to start Mix-RLN: " & error)
+
+  return ok(node)
+
+proc waitForMemberCount(
+    spamProtection: mix_rln.MixRlnSpamProtection, expected: int
+): Future[bool] {.async.} =
+  let deadline = Moment.now() + PropagationTimeout
+  while Moment.now() < deadline:
+    if spamProtection.getMemberCount() == expected:
+      return true
+    await sleepAsync(50.milliseconds)
+  return false
+
+suite "WakuNode - Mix-RLN Delivery integration":
+  asyncTest "coordination and proofs use Delivery's existing switch":
+    let node1Result = await newMixRlnNode()
+    require node1Result.isOk()
+    let node1 = node1Result.get()
+
+    let node2Result = await newMixRlnNode()
+    if node2Result.isErr():
+      await node1.stop()
+    require node2Result.isOk()
+    let node2 = node2Result.get()
+
+    var metadataListener = Opt.none(MessageSeenEventListener)
+    try:
+      check:
+        node1.wakuMix.switch == node1.switch
+        node2.wakuMix.switch == node2.switch
+
+      await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+      await sleepAsync(2.seconds)
+
+      let node1Registration = await node1.wakuMixRln.registerSelf()
+      require node1Registration.isOk()
+      check node1Registration.get() == 0
+      require await waitForMemberCount(node2.wakuMixRln, 1)
+
+      let node2Registration = await node2.wakuMixRln.registerSelf()
+      require node2Registration.isOk()
+      check node2Registration.get() == 1
+      require await waitForMemberCount(node1.wakuMixRln, 2)
+      check node2.wakuMixRln.getMemberCount() == 2
+
+      let proofMetadataSeen = newFuture[void]("Mix-RLN proof metadata seen")
+      let proofMetadataTopic = node1.wakuMixRln.getProofMetadataContentTopic()
+      let handler = proc(
+          event: MessageSeenEvent
+      ): Future[void] {.async: (raises: []).} =
+        if event.message.contentTopic == proofMetadataTopic and
+            not proofMetadataSeen.finished():
+          proofMetadataSeen.complete()
+
+      metadataListener = Opt.some(
+        MessageSeenEvent.listen(node1.brokerCtx, handler).expect(
+          "proof metadata listener should register"
+        )
+      )
+
+      let bindingData = "delivery-mix-rln-e2e".toBytes()
+      let proofResult = node1.wakuMixRln.generateProof(bindingData)
+      require proofResult.isOk()
+      let proof = proofResult.get().proof
+
+      let invalidResult =
+        node2.wakuMixRln.verifyProof(proof, "different-binding".toBytes())
+      require invalidResult.isOk()
+      check invalidResult.get() == false
+
+      let validResult = node2.wakuMixRln.verifyProof(proof, bindingData)
+      require validResult.isOk()
+      check validResult.get() == true
+
+      require await proofMetadataSeen.withTimeout(PropagationTimeout)
+      await sleepAsync(100.milliseconds)
+
+      let duplicateResult = node1.wakuMixRln.verifyProof(proof, bindingData)
+      require duplicateResult.isOk()
+      check duplicateResult.get() == false
+    finally:
+      metadataListener.withValue(listener):
+        await MessageSeenEvent.dropListener(node1.brokerCtx, listener)
+      await allFutures(node1.stop(), node2.stop())

--- a/tests/waku_mix/test_mix_rln_delivery.nim
+++ b/tests/waku_mix/test_mix_rln_delivery.nim
@@ -19,7 +19,6 @@ const
 
 proc newMixRlnNode(): Future[Result[WakuNode, string]] {.async.} =
   let node = newTestWakuNode(generateSecp256k1Key(), quicEnabled = false)
-  await node.start()
 
   node.mountAutoSharding(DefaultClusterId, TestShardCount).isOkOr:
     await node.stop()
@@ -53,11 +52,11 @@ proc newMixRlnNode(): Future[Result[WakuNode, string]] {.async.} =
     await node.stop()
     return err("failed to mount Mix: " & error)
 
-  await node.wakuMix.start()
-
   node.mountMixRlnCoordination().isOkOr:
     await node.stop()
     return err("failed to mount Mix-RLN coordination: " & error)
+
+  await node.start()
 
   (await mixRln.start()).isOkOr:
     await node.stop()
@@ -129,8 +128,7 @@ suite "WakuNode - Mix-RLN Delivery integration":
 
       let invalidResult =
         node2.wakuMixRln.verifyProof(proof, "different-binding".toBytes())
-      require invalidResult.isOk()
-      check invalidResult.get() == false
+      check invalidResult.isErr()
 
       let validResult = node2.wakuMixRln.verifyProof(proof, bindingData)
       require validResult.isOk()


### PR DESCRIPTION
## Summary

Add a two-node integration test for the Delivery Mix-RLN adapter. It verifies that:

- Mix runs on each `WakuNode`'s existing libp2p switch
- RLN membership registrations propagate between nodes through Delivery Relay
- proofs reject an incorrect binding, accept the correct binding, and reject reuse after proof metadata propagates

The test mounts Relay, Mix, and Mix-RLN coordination before starting the Delivery node, matching the libp2p protocol lifecycle. It also pins the moving `nim-snappy` 0.1.0 branch and Delivery's existing Chronos lock resolution so Nimble 0.24.1 dependency setup remains reproducible, with the Nix pin kept in sync.

## Risk Assessment

This is stacked on #4182 and does not change a production API. Dependency resolution is made stricter by exact pins.

Registration is intentionally sequential because concurrent distributed member-index allocation and history synchronization remain follow-up work. The test covers Delivery coordination and proof handling; it does not exercise a full multi-hop Sphinx payload route.

## References

- Parent adapter PR: #4182
- Delivery injection PR: #4181
