### PR TITLE
fix: fix tests (e2e, macos)

### DIFF
--- a/logos_delivery/waku/node/waku_node/ping.nim
+++ b/logos_delivery/waku/node/waku_node/ping.nim
@@ -44,10 +44,17 @@ proc pingPeer(node: WakuNode, peerId: PeerId): Future[Result[void, string]] {.as
       return err("pingPeer failed dialing peer peerId: " & $peerId)
     defer:
       # Always close the stream
-      try:
-        await stream.close()
-      except CatchableError as e:
-        debug "Error closing ping connection", peerId = peerId, error = e.msg
+      let closeFut =
+        try:
+          stream.close()
+        except CatchableError as e:
+          debug "Error closing ping connection", peerId = peerId, error = e.msg
+          nil
+      if not closeFut.isNil():
+        try:
+          await closeFut
+        except CatchableError as e:
+          debug "Error closing ping connection", peerId = peerId, error = e.msg
 
     # Perform ping
     let pingDuration = await node.libp2pPing.ping(stream)

--- a/logos_delivery/waku/node/waku_node/ping.nim
+++ b/logos_delivery/waku/node/waku_node/ping.nim
@@ -44,6 +44,8 @@ proc pingPeer(node: WakuNode, peerId: PeerId): Future[Result[void, string]] {.as
       return err("pingPeer failed dialing peer peerId: " & $peerId)
     defer:
       # Always close the stream
+      # Workaround for Nim 2.2.6 mishandling `try: await` inside defer (Nim issue 25330)
+      # TODO: revert to a plain await on Nim >= 2.2.8
       let closeFut =
         try:
           stream.close()

--- a/tests-e2e/tests/wrappers_tests/conftest.py
+++ b/tests-e2e/tests/wrappers_tests/conftest.py
@@ -25,6 +25,7 @@ def build_node_config(**overrides):
         "lightpush": False,
         "peerExchange": False,
         "discv5Discovery": False,
+        "nat": "none",
     }
     config.update(overrides)
     return config


### PR DESCRIPTION
## Description

This PR fixes two failing tests in CI (`test-macos-15` and `send-api-e2e-tests`).

 ̶T̶h̶e̶ ̶k̶e̶e̶p̶a̶l̶i̶v̶e̶ ̶p̶i̶n̶g̶ ̶i̶n̶ ̶`̶w̶a̶k̶u̶_̶n̶o̶d̶e̶/̶p̶i̶n̶g̶.̶n̶i̶m̶`̶ ̶a̶w̶a̶i̶t̶s̶ ̶`̶s̶t̶r̶e̶a̶m̶.̶c̶l̶o̶s̶e̶(̶)̶`̶ ̶i̶n̶ ̶a̶ ̶`̶d̶e̶f̶e̶r̶`̶.̶ ̶`̶L̶P̶S̶t̶r̶e̶a̶m̶.̶c̶l̶o̶s̶e̶`̶ ̶i̶s̶ ̶a̶ ̶r̶a̶w̶ ̶a̶s̶y̶n̶c̶,̶ ̶s̶o̶ ̶i̶t̶ ̶c̶a̶n̶ ̶r̶e̶t̶u̶r̶n̶ ̶a̶ ̶n̶i̶l̶ ̶f̶u̶t̶u̶r̶e̶,̶ ̶a̶n̶d̶ ̶a̶w̶a̶i̶t̶i̶n̶g̶ ̶n̶i̶l̶ ̶r̶a̶i̶s̶e̶s̶ ̶a̶n̶ ̶`̶A̶s̶s̶e̶r̶t̶i̶o̶n̶D̶e̶f̶e̶c̶t̶`̶ ̶t̶h̶a̶t̶ ̶t̶h̶e̶ ̶s̶u̶r̶r̶o̶u̶n̶d̶i̶n̶g̶ ̶`̶e̶x̶c̶e̶p̶t̶ ̶C̶a̶t̶c̶h̶a̶b̶l̶e̶E̶r̶r̶o̶r̶`̶ ̶c̶a̶n̶n̶o̶t̶ ̶c̶a̶t̶c̶h̶.̶ ̶N̶i̶l̶-̶c̶h̶e̶c̶k̶i̶n̶g̶ ̶t̶h̶e̶ ̶f̶u̶t̶u̶r̶e̶ ̶f̶i̶x̶e̶s̶ ̶i̶t̶.̶  EDIT:  Nim 2.2.6 rewrote the closure-iterator transformation. Issue 25330 reports that a finally containing try..except with a yield inside is mishandled, with the iterator returning the type's default value. For a Future that default is nil, which is exactly what chronos reports as "yielded nil". defer: expands to finally, so the old pingPeer had precisely this shape. Both 25330 and 25261 are listed as fixed in the Nim 2.2.8 release notes.

The second flake is triggered by tests running NAT discovery, which they shouldn't. Turning off NAT discovery in e2e test nodes solves the flake and cuts the suite runtime by ~4 minutes.

## Changes

* nil-check the `stream.close()` future in `pingPeer`
* set `nat` to `none` in the e2e test node config

## Notes

Postmortem notes:

* Tests running NAT for no reason and screwing with test timing isn't what actually crashed; rather, they disturbed something _else_ that then crashes. So the bug of having tests trying to resolve NAT is actually helping expose some _other_ issue either in the tests or the code. But here we just patch up the issue of tests having NAT discovery enabled at all for no good reason (stalls, increases testing time needlessly).
* Having "nat = none" everywhere is a smell; this is probably a NAT defaults issue in configuration. Once that's fixed, we don't have to explicitly turn off NAT in tests, test harnesses and other places.

## Issue

Maintenance Y2026H2 #4043
