### PR TITLE
build(nimble): pin nim-websock by commit instead of tag

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -44,7 +44,7 @@ requires "nim == 2.2.6",
   "dnsdisc",
   "dnsclient",
   "httputils >= 0.4.1",
-  "https://github.com/status-im/nim-websock#v0.4.0",
+  "https://github.com/status-im/nim-websock#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d",
   # Cryptography
   "nimcrypto == 0.6.4", # 0.6.4 used in libp2p. Version 0.7.3 makes test to crash on Ubuntu.
   "https://github.com/status-im/nim-secp256k1#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",


### PR DESCRIPTION
Closes #4190

# Description

1. Pinned `nim-websock` in `logos_delivery.nimble` to the commit `nimble.lock` records for `#v0.4.0`, instead of the tag. The tag pin left libp2p's `nim-websock >= 0.4.0` URL requirement to be re-resolved with `git ls-remote` on every `nimble <task>` after setup, the only dependency still reaching GitHub at build time. One failed lookup broke the 2026-09-02 nightly macOS examples build with `Unable to identify url: https://github.com/status-im/nim-websock`.

<details>
<summary>AI-made decisions</summary>

- Kept the URL form rather than a `websock == 0.4.0` name pin: `scripts/gen_requires.nims` skips packages the nimble file pins by URL, and a name-form pin leaves libp2p's URL-form range to resolve online.
- `nimble.lock` and the installed package are unchanged; `make audit-deps` passes. With an empty package cache, a task after setup now shows no `Fetching … nim-websock` line, where before it showed two.

</details>
