### PR TITLE
test(e2e): hard-exit the s01 helper after it reports its result

### DIFF
--- a/tests-e2e/tests/wrappers_tests/helpers/send_invalid_handle.py
+++ b/tests-e2e/tests/wrappers_tests/helpers/send_invalid_handle.py
@@ -17,6 +17,7 @@ Cases:
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -146,7 +147,10 @@ def main() -> int:
 
     _ensure_bindings_on_path()
     CASES[case](marker)
-    return 0
+    # liblogosdelivery threads outlive destroy; finalizing the interpreter under them segfaults.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4194

# Description

1. The s01 helper now flushes and `os._exit(0)`s right after printing its result line. Its interpreter shutdown segfaulted under liblogosdelivery's pooled threads, which outlive `logosdelivery_destroy`, so `test_s01_send_on_destroyed_handle` failed on the subprocess exit code even though the send had already been rejected with `ctx is not a valid FFI context`. Same treatment #4151 gave the pytest process.

<details>
<summary>AI-made decisions</summary>

- Kept the test's assertion on the exit code: a real missing C-ABI guard still segfaults before the marker is printed, so it is still caught.
- The library keeping worker threads alive after destroy is the underlying cause and is out of scope here, as it was for #4151.

</details>
