### PR TITLE
fix(ffi): accept every address of a peer, not just one

### DIFF
--- a/logos_delivery/waku/api/peer_manager.nim
+++ b/logos_delivery/waku/api/peer_manager.nim
@@ -40,8 +40,10 @@ proc disconnectAllPeers*(self: Waku): Future[Result[bool, string]] {.async.} =
 proc dialPeer*(
     self: Waku, peerAddr: string, protocol: string, timeoutMs: int
 ): Future[Result[bool, string]] {.async.} =
+  ## Dials one peer over `protocol`. `peerAddr` is one fully qualified
+  ## multiaddress, or several for the same peer separated by commas.
   try:
-    let remotePeerInfo = parsePeerInfo(peerAddr).valueOr:
+    let remotePeerInfo = parsePeerAddrList(peerAddr).valueOr:
       return err($error)
     let conn = await self.node.peerManager.dialPeer(remotePeerInfo, protocol)
     if conn.isNone():

--- a/logos_delivery/waku/api/ping.nim
+++ b/logos_delivery/waku/api/ping.nim
@@ -12,8 +12,10 @@ proc pingPeer*(
     self: Waku, peerAddr: string, timeoutMs: int
 ): Future[Result[int64, string]] {.async.} =
   ## Pings the peer; `timeoutMs <= 0` means no timeout. Returns RTT in nanos.
+  ## `peerAddr` is one fully qualified multiaddress, or several for the same
+  ## peer separated by commas.
   try:
-    let peerInfo = parsePeerInfo(peerAddr).valueOr:
+    let peerInfo = parsePeerAddrList(peerAddr).valueOr:
       return err("pingPeer failed to parse peer addr: " & $error)
 
     proc doPing(): Future[Result[Duration, string]] {.async.} =

--- a/logos_delivery/waku/api/store.nim
+++ b/logos_delivery/waku/api/store.nim
@@ -34,11 +34,13 @@ proc storeQueryToAny*(
 proc storeQuery*(
     self: Waku, request: StoreQueryRequest, peer: string, timeoutMs: int
 ): Future[Result[StoreQueryResponse, string]] {.async.} =
+  ## Runs a store query against one store peer. `peer` is one fully qualified
+  ## multiaddress, or several for the same peer separated by commas.
   try:
     if self.node.wakuStoreClient.isNil():
       return err("wakuStoreClient is not mounted")
 
-    let remotePeer = parsePeerInfo(peer).valueOr:
+    let remotePeer = parsePeerAddrList(peer).valueOr:
       return err("storeQuery failed to parse peer addr: " & $error)
 
     let queryFut = self.node.wakuStoreClient.query(request, remotePeer)

--- a/logos_delivery/waku/waku_core/peers.nim
+++ b/logos_delivery/waku/waku_core/peers.nim
@@ -241,8 +241,7 @@ proc parsePeerInfo*(maddrs: varargs[string]): Result[RemotePeerInfo, string] =
 
 proc parsePeerAddrList*(peerAddrs: string): Result[RemotePeerInfo, string] =
   ## Parses a comma-separated list of fully qualified multiaddresses, all
-  ## belonging to the same peer, into one dialable RemotePeerInfo. Entries are
-  ## stripped and empty ones ignored, so a single address parses unchanged.
+  ## belonging to the same peer, into one dialable RemotePeerInfo.
   var maddrs: seq[string]
   for entry in peerAddrs.split(','):
     let addrStr = entry.strip()

--- a/logos_delivery/waku/waku_core/peers.nim
+++ b/logos_delivery/waku/waku_core/peers.nim
@@ -239,6 +239,21 @@ proc parsePeerInfo*(maddrs: varargs[string]): Result[RemotePeerInfo, string] =
 
   parsePeerInfo(multiAddresses)
 
+proc parsePeerAddrList*(peerAddrs: string): Result[RemotePeerInfo, string] =
+  ## Parses a comma-separated list of fully qualified multiaddresses, all
+  ## belonging to the same peer, into one dialable RemotePeerInfo. Entries are
+  ## stripped and empty ones ignored, so a single address parses unchanged.
+  var maddrs: seq[string]
+  for entry in peerAddrs.split(','):
+    let addrStr = entry.strip()
+    if addrStr.len > 0:
+      maddrs.add(addrStr)
+
+  if maddrs.len == 0:
+    return err("no peer address given")
+
+  parsePeerInfo(maddrs)
+
 proc parseUrlPeerAddr*(peerAddr: Opt[string]): Result[Opt[RemotePeerInfo], string] =
   # Checks whether the peerAddr parameter represents a valid p2p multiaddress.
   # The param must be in the format `(ip4|ip6)/tcp/p2p/$peerId` but URL-encoded

--- a/tests/waku_core/test_peers.nim
+++ b/tests/waku_core/test_peers.nim
@@ -147,6 +147,67 @@ suite "Waku Core - Peers":
     check:
       parsePeerInfo(address).isErr()
 
+  test "Peer address list parses a single address":
+    ## Given
+    let address =
+      "/ip4/127.0.0.1/tcp/65002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+
+    ## When
+    let remotePeerInfoRes = parsePeerAddrList(address)
+    require remotePeerInfoRes.isOk()
+
+    ## Then
+    let remotePeerInfo = remotePeerInfoRes.value
+    check:
+      $(remotePeerInfo.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+      remotePeerInfo.addrs.len == 1
+
+  test "Peer address list keeps every address of the peer":
+    ## Given
+    let addresses =
+      "/ip4/127.0.0.1/tcp/65002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc," &
+      "/ip4/10.0.0.1/tcp/65003/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+
+    ## When
+    let remotePeerInfoRes = parsePeerAddrList(addresses)
+    require remotePeerInfoRes.isOk()
+
+    ## Then
+    let remotePeerInfo = remotePeerInfoRes.value
+    check:
+      $(remotePeerInfo.peerId) == "16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc"
+      remotePeerInfo.addrs.len == 2
+      $(remotePeerInfo.addrs[0][0].tryGet()) == "/ip4/127.0.0.1"
+      $(remotePeerInfo.addrs[1][0].tryGet()) == "/ip4/10.0.0.1"
+
+  test "Peer address list tolerates whitespace and empty entries":
+    ## Given
+    let addresses =
+      " /ip4/127.0.0.1/tcp/65002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc , ," &
+      " /ip4/10.0.0.1/tcp/65003/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc "
+
+    ## Then
+    let remotePeerInfoRes = parsePeerAddrList(addresses)
+    require remotePeerInfoRes.isOk()
+    check:
+      remotePeerInfoRes.value.addrs.len == 2
+
+  test "Peer address list rejects addresses of different peers":
+    ## Given
+    let addresses =
+      "/ip4/127.0.0.1/tcp/65002/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc," &
+      "/ip4/10.0.0.1/tcp/65003/p2p/16Uiu2HAmVGHwfEi4kiNvuK6xVwGB2WeHoZNU1FgTUgZ8QvxiMqQw"
+
+    ## Then
+    check:
+      parsePeerAddrList(addresses).isErr()
+
+  test "Peer address list rejects an empty list":
+    ## Then
+    check:
+      parsePeerAddrList("").isErr()
+      parsePeerAddrList(" , ").isErr()
+
   test "ENRs capabilities are filled when creating RemotePeerInfo":
     let
       enrSeqNum = 1u64


### PR DESCRIPTION
## Description

`waku_store_query`, `waku_ping_peer` and `waku_dial_peer` hand their peer argument to `parsePeerInfo` as a single multiaddress. A caller that has several addresses for one peer — which is what libp2p hands out, and what `AddrInfo`-shaped APIs carry — can therefore only ever offer one of them, and has to guess which.

Nothing else on this surface behaves that way: `waku_connect` already splits its argument on commas, and `parsePeerInfo` already has a `varargs` overload that collects several addresses under one `RemotePeerInfo` and errors if they name different peers. Only these three entry points were missing the join.

Found from the Go side, where `StoreQuery`/`PingPeer` take a `peer.AddrInfo`: joining the addresses with commas fails to parse, so the binding has to silently drop all but the first (logos-delivery-go-bindings#130).

## Changes

- `parsePeerAddrList` in `waku_core/peers.nim`: splits a comma-separated list, strips entries, ignores empty ones, and delegates to the existing `varargs` `parsePeerInfo`. A single address parses exactly as before, so this is backwards compatible and needs no ABI change.
- `storeQuery`, `pingPeer` and `dialPeer` in the Waku API layer use it, and their doc comments state the contract.
- Unit tests in `tests/waku_core/test_peers.nim` for the single address, several addresses of one peer, whitespace and empty entries, a list mixing peer ids, and an empty list.

Verified with `nix build .#liblogosdelivery` and by running the parsing cases against the real dependency set; `nph --check` is clean.

## Issue

Follow-up to logos-delivery-go-bindings#130.
