### PR TITLE
test: rewrite the remaining smoke tests (migration 3)

### DIFF
--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -24,7 +24,10 @@ when os == "Linux" and
     defined(postgres):
   import ./waku_archive/test_driver_postgres_query, ./waku_archive/test_driver_postgres
 
-import ./wakunode_rest/test_rest_store
+import
+  ./wakunode_rest/test_rest_filter,
+  ./wakunode_rest/test_rest_relay,
+  ./wakunode_rest/test_rest_store
 
 # Waku store test suite
 import ./waku_store/test_all

--- a/tests/node/test_wakunode_sharding.nim
+++ b/tests/node/test_wakunode_sharding.nim
@@ -34,6 +34,19 @@ const
   listenPort = Port(0)
   # every shard id hardcoded below is the gen-zero derivation over 65536 shards
   autoShardCount = 65536'u32
+  # every content topic below resolves to a different shard
+  contentTopics = [
+    "/myapp/1/latest/proto", "/waku/2/content/test.js",
+    "/app/22/sometopic/someencoding", "/toychat/2/huilong/proto",
+    "/statusim/1/community/cbor", "/app/27/sometopic/someencoding",
+    "/app/29/sometopic/someencoding", "/app/20/sometopic/someencoding",
+  ]
+  # Automatically generated from the contentTopics above
+  shards = [
+    "/waku/2/rs/0/18728", "/waku/2/rs/0/15257", "/waku/2/rs/0/52594",
+    "/waku/2/rs/0/58355", "/waku/2/rs/0/4404", "/waku/2/rs/0/18525",
+    "/waku/2/rs/0/45782", "/waku/2/rs/0/45503",
+  ]
 
 proc waitForTopicPeer(
     node: WakuNode, topic: PubsubTopic, peer: PeerId, timeout = 5.seconds
@@ -46,6 +59,29 @@ proc waitForTopicPeer(
         return
     await sleepAsync(10.milliseconds)
   raiseAssert $peer & " never announced a subscription to " & topic
+
+proc subscribeToAllContentTopics(
+    server, client: WakuNode
+): Future[seq[Future[bool]]] {.async.} =
+  ## Connects the client to the server, both subscribed to every content topic,
+  ## and checks each one delivers.
+  let serverHandlers =
+    contentTopics.mapIt(server.subscribeToContentTopicWithHandler(it))
+  for contentTopic in contentTopics:
+    client.subscribe((kind: ContentSub, topic: contentTopic), noopRawHandler()).isOkOr:
+      raiseAssert "Failed to subscribe to content topic " & contentTopic & ": " & error
+
+  await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+  for shard in shards:
+    await client.waitForTopicPeer(shard, server.switch.peerInfo.peerId)
+
+  for i, contentTopic in contentTopics:
+    discard await client.publish(
+      Opt.some(shards[i]),
+      WakuMessage(payload: "message1".toBytes(), contentTopic: contentTopic),
+    )
+    assertResultOk(await serverHandlers[i].waitForResult(FUTURE_TIMEOUT))
+  serverHandlers
 
 suite "Sharding":
   var
@@ -153,6 +189,88 @@ suite "Sharding":
       check serverResult2.isErr()
       assertResultOk(clientResult2)
 
+    asyncTest "Unsubscribing from some pubsub topics keeps the others delivering":
+      # Given a connected server and client subscribed to eight pubsub topics
+      let
+        contentTopic = "myContentTopic"
+        topics = toSeq(1 .. 8).mapIt("/waku/2/rs/0/" & $it)
+        serverHandlers = topics.mapIt(server.subscribeCompletionHandler(it))
+      for topic in topics:
+        client.subscribe((kind: PubsubSub, topic: topic), noopRawHandler()).isOkOr:
+          raiseAssert "Failed to subscribe to topic " & topic & ": " & error
+
+      await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      for topic in topics:
+        await client.waitForTopicPeer(topic, server.switch.peerInfo.peerId)
+
+      for i, topic in topics:
+        discard await client.publish(
+          Opt.some(topic),
+          WakuMessage(payload: "message1".toBytes(), contentTopic: contentTopic),
+        )
+        assertResultOk(await serverHandlers[i].waitForResult(FUTURE_TIMEOUT))
+
+      # When both nodes unsubscribe from the first three topics
+      for node in [server, client]:
+        for topic in topics[0 .. 2]:
+          node.unsubscribe((kind: PubsubUnsub, topic: topic)).isOkOr:
+            raiseAssert "Failed to unsubscribe from topic " & topic & ": " & error
+      for handler in serverHandlers:
+        handler.reset()
+
+      # Then the unsubscribed topics stop delivering
+      for i in 0 .. 2:
+        discard await client.publish(
+          Opt.some(topics[i]),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopic),
+        )
+        check (await serverHandlers[i].waitForResult(FUTURE_TIMEOUT)).isErr()
+
+      # Then the other topics keep delivering
+      for i in 3 .. topics.high:
+        discard await client.publish(
+          Opt.some(topics[i]),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopic),
+        )
+        assertResultOk(await serverHandlers[i].waitForResult(FUTURE_TIMEOUT))
+
+    asyncTest "Unsubscribing from all pubsub topics stops delivery":
+      # Given a connected server and client subscribed to eight pubsub topics
+      let
+        contentTopic = "myContentTopic"
+        topics = toSeq(1 .. 8).mapIt("/waku/2/rs/0/" & $it)
+        serverHandlers = topics.mapIt(server.subscribeCompletionHandler(it))
+      for topic in topics:
+        client.subscribe((kind: PubsubSub, topic: topic), noopRawHandler()).isOkOr:
+          raiseAssert "Failed to subscribe to topic " & topic & ": " & error
+
+      await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      for topic in topics:
+        await client.waitForTopicPeer(topic, server.switch.peerInfo.peerId)
+
+      for i, topic in topics:
+        discard await client.publish(
+          Opt.some(topic),
+          WakuMessage(payload: "message1".toBytes(), contentTopic: contentTopic),
+        )
+        assertResultOk(await serverHandlers[i].waitForResult(FUTURE_TIMEOUT))
+
+      # When both nodes unsubscribe from every topic
+      for node in [server, client]:
+        for topic in topics:
+          node.unsubscribe((kind: PubsubUnsub, topic: topic)).isOkOr:
+            raiseAssert "Failed to unsubscribe from topic " & topic & ": " & error
+      for handler in serverHandlers:
+        handler.reset()
+
+      # Then no topic delivers anymore
+      for i, topic in topics:
+        discard await client.publish(
+          Opt.some(topic),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopic),
+        )
+        check (await serverHandlers[i].waitForResult(FUTURE_TIMEOUT)).isErr()
+
   suite "Automatic Sharding Mechanics":
     asyncTest "Content Topic-Based Shard Dialing":
       # Given a connected server and client subscribed to the same content topic (with two different formats)
@@ -243,6 +361,124 @@ suite "Sharding":
       # Then the client receives the message but the server does not
       assertResultOk(clientResult2)
       check serverResult2.isErr()
+
+    asyncTest "Unsubscribing from some content topics keeps the others delivering":
+      # Given a connected server and client delivering on every content topic
+      let serverHandlers = await subscribeToAllContentTopics(server, client)
+
+      # When both nodes unsubscribe from the first three content topics
+      for node in [server, client]:
+        for contentTopic in contentTopics[0 .. 2]:
+          node.unsubscribe((kind: ContentUnsub, topic: contentTopic)).isOkOr:
+            raiseAssert "Failed to unsubscribe from " & contentTopic & ": " & error
+      for handler in serverHandlers:
+        handler.reset()
+
+      # Then the unsubscribed content topics stop delivering
+      for i in 0 .. 2:
+        discard await client.publish(
+          Opt.some(shards[i]),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopics[i]),
+        )
+        check (await serverHandlers[i].waitForResult(FUTURE_TIMEOUT)).isErr()
+
+      # Then the other content topics keep delivering
+      for i in 3 .. contentTopics.high:
+        discard await client.publish(
+          Opt.some(shards[i]),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopics[i]),
+        )
+        assertResultOk(await serverHandlers[i].waitForResult(FUTURE_TIMEOUT))
+
+    asyncTest "Unsubscribing one content topic silences other content topics on its shard":
+      # Given a one-shard network, so both content topics resolve to the same shard
+      for node in [server, client]:
+        node.mountAutoSharding(DefaultClusterId, 1).isOkOr:
+          raiseAssert "mountAutoSharding failed: " & error
+
+      let
+        contentTopic1 = "/toychat/2/huilong/proto"
+        contentTopic2 = "/0/toychat2/2/huilong/proto"
+        shard = "/waku/2/rs/0/0"
+      for contentTopic in [contentTopic1, contentTopic2]:
+        let contentShard = server.wakuAutoSharding.get().getShard(contentTopic).valueOr:
+            raiseAssert "getShard failed: " & $error
+        require $contentShard == shard
+
+      let serverHandler1 = server.subscribeToContentTopicWithHandler(contentTopic1)
+      for contentTopic in [contentTopic1, contentTopic2]:
+        client.subscribe((kind: ContentSub, topic: contentTopic), noopRawHandler()).isOkOr:
+          raiseAssert "Failed to subscribe to content topic " & contentTopic & ": " &
+            error
+
+      await client.connectToNodes(@[server.switch.peerInfo.toRemotePeerInfo()])
+      await client.waitForTopicPeer(shard, server.switch.peerInfo.peerId)
+
+      discard await client.publish(
+        Opt.some(shard),
+        WakuMessage(payload: "message1".toBytes(), contentTopic: contentTopic1),
+      )
+      assertResultOk(await serverHandler1.waitForResult(FUTURE_TIMEOUT))
+
+      # When both nodes unsubscribe only from contentTopic2
+      for node in [server, client]:
+        node.unsubscribe((kind: ContentUnsub, topic: contentTopic2)).isOkOr:
+          raiseAssert "Failed to unsubscribe from " & contentTopic2 & ": " & error
+
+      # Then contentTopic1 stops delivering too: unsubscribing one content topic
+      # drops the whole shard subscription
+      serverHandler1.reset()
+      discard await client.publish(
+        Opt.some(shard),
+        WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopic1),
+      )
+      check (await serverHandler1.waitForResult(FUTURE_TIMEOUT)).isErr()
+
+    asyncTest "Unsubscribing from all content topics stops delivery":
+      # Given a connected server and client delivering on every content topic
+      let serverHandlers = await subscribeToAllContentTopics(server, client)
+
+      # When both nodes unsubscribe from every content topic
+      for node in [server, client]:
+        for contentTopic in contentTopics:
+          node.unsubscribe((kind: ContentUnsub, topic: contentTopic)).isOkOr:
+            raiseAssert "Failed to unsubscribe from " & contentTopic & ": " & error
+      for handler in serverHandlers:
+        handler.reset()
+
+      # Then no content topic delivers anymore
+      for i, contentTopic in contentTopics:
+        discard await client.publish(
+          Opt.some(shards[i]),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopic),
+        )
+        check (await serverHandlers[i].waitForResult(FUTURE_TIMEOUT)).isErr()
+
+    asyncTest "Resubscribing after unsubscribing from all content topics restores delivery":
+      # Given a connected server and client delivering on every content topic
+      discard await subscribeToAllContentTopics(server, client)
+
+      # When both nodes unsubscribe from every content topic and then resubscribe
+      for node in [server, client]:
+        for contentTopic in contentTopics:
+          node.unsubscribe((kind: ContentUnsub, topic: contentTopic)).isOkOr:
+            raiseAssert "Failed to unsubscribe from " & contentTopic & ": " & error
+      let resubscribedHandlers =
+        contentTopics.mapIt(server.subscribeToContentTopicWithHandler(it))
+      for contentTopic in contentTopics:
+        client.subscribe((kind: ContentSub, topic: contentTopic), noopRawHandler()).isOkOr:
+          raiseAssert "Failed to subscribe to content topic " & contentTopic & ": " &
+            error
+      for shard in shards:
+        await client.waitForTopicPeer(shard, server.switch.peerInfo.peerId)
+
+      # Then every content topic delivers again
+      for i, contentTopic in contentTopics:
+        discard await client.publish(
+          Opt.some(shards[i]),
+          WakuMessage(payload: "message2".toBytes(), contentTopic: contentTopic),
+        )
+        assertResultOk(await resubscribedHandlers[i].waitForResult(FUTURE_TIMEOUT))
 
   suite "Application Layer Integration":
     suite "App Protocol Compatibility":

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -120,8 +120,6 @@ suite "Waku v2 Rest API - Filter V2":
     )
     let response = await restFilterTest.client.filterPostSubscriptions(requestBody)
 
-    echo "response", $response
-
     let subscribedPeer1 = restFilterTest.serviceNode.wakuFilter.subscriptions.findSubscribedPeers(
       DefaultPubsubTopic, DefaultContentTopic
     )

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -324,6 +324,50 @@ suite "Waku v2 Rest API - Relay":
     await restServer.closeWait()
     await node.stop()
 
+  asyncTest "Post a message to a not subscribed pubsub topic - POST /relay/v1/messages/{topic}":
+    # Given
+    let node = testWakuNode()
+    (await node.mountRelay()).isOkOr:
+      assert false, "Failed to mount relay"
+    await node.start()
+
+    # RPC server setup
+    var restPort = Port(0)
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress, restPort).tryGet()
+
+    restPort = restServer.httpServer.address.port # update with bound port for client use
+
+    let cache = MessageCache.init()
+
+    installRelayApiHandlers(restServer.router, node, cache)
+    restServer.start()
+    defer:
+      await restServer.stop()
+      await restServer.closeWait()
+      await node.stop()
+
+    let client = newRestHttpClient(initTAddress(restAddress, restPort))
+
+    check node.wakuRelay.subscribedTopics.toSeq().len == 0
+
+    # When
+    let response = await client.relayPostMessagesV1(
+      DefaultPubsubTopic,
+      RelayWakuMessage(
+        payload: base64.encode("TEST-PAYLOAD"),
+        contentTopic: Opt.some(DefaultContentTopic),
+        timestamp: Opt.some(now()),
+      ),
+    )
+
+    # Then
+    check:
+      response.status == 400
+      $response.contentType == $MIMETYPE_TEXT
+      response.data ==
+        "Failed to publish: Node not subscribed to topic: " & DefaultPubsubTopic
+
   # Autosharding API
 
   asyncTest "Subscribe a node to an array of content topics - POST /relay/v1/auto/subscriptions":


### PR DESCRIPTION
## Description

Third PR of the migration of the e2e tests from `logos-messaging/logos-delivery-interop-tests` into this repo. 19/424 (4%) of the interop tests are resolved: 7 ported, 7 rewritten as in-process tests, 5 closed as already covered. That closes out the smoke set.

It lands the seven smoke verdicts marked rewrite. Each one comes down to subscription-state bookkeeping or the REST publish guard, nothing that needs a container, so they become Nim tests under `make test` instead of pytest ports. Two orphaned REST suites come on, the relay one gains the publish-without-subscription case, and six node tests cover partial and full unsubscribe plus resubscribe for both content topics and pubsub topics.

A content-topic unsubscribe drops the whole shard subscription. `node.unsubscribe` maps `ContentUnsub` to unsubscribing everything on the resolved shard, with the strict per-content-topic version commented out in `node/waku_node/relay.nim`. Sibling content topics on that shard go silent. The sharding suite already runs autosharding over 65536 shards, which puts the eight content topics on distinct shards and keeps partial unsubscribe meaningful. A one-shard test pins the shard-wide drop as it stands today.

The table lists the verdict for each smoke test this PR resolves, linked to its interop source at `2b5fde90c`.

| Test | Verdict | Gate | Reason |
|---|---|---|---|
| [test_filter_ping_on_subscribed_peer](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_ping.py#L9) | rewrite (in-process REST) | PR gate | `GET /filter/v2/subscriptions/{requestId}` answers 200 for a subscribed peer. `tests/wakunode_rest/test_rest_filter.nim` already asserts that and the 404 after unsubscribe-all, so wiring it into `tests/all_tests_waku.nim` is the whole rewrite. |
| [test_relay_no_subscription](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L13) | rewrite (in-process REST) | PR gate | `POST /relay/v1/messages/{topic}` on a node with no subscription is rejected. The new case in `tests/wakunode_rest/test_rest_relay.nim` pins the guard's 400 and its exact message. |
| [test_unsubscribe_from_some_content_topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/sharding/test_relay_auto_sharding.py#L83) | rewrite (in-process nodes) | PR gate | Eight content topics on distinct shards, unsubscribe three, those stop delivering while the other five keep delivering. Lands in `tests/node/test_wakunode_sharding.nim`. |
| [test_unsubscribe_from_all_content_topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/sharding/test_relay_auto_sharding.py#L97) | rewrite (in-process nodes) | PR gate | Unsubscribe all eight content topics and no publish delivers anye/test_wakunode_sharding.nim`. |
| [test_resubscribe_to_unsubscribed_content_topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/sharding/test_relay_auto_sharding.py#L121) | rewrite (in-process nodes) | PR gate | Resubscribing after a full unsubscribe restores delivery on every content topic, so no shard state sticks. Lands in `tests/node/test_wakunode_sharding.nim`. |
| [test_unsubscribe_from_some_pubsub_topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/sharding/test_relay_static_sharding.py#L54) | rewrite (in-process nodes) | PR gate | Static-shard variant over eight pubsub topics, unsubscribe three, those stop delivering while the rest keep delivering. Lands in `tests/node/test_wakunode_sharding.nim`. |          | [test_unsubscribe_from_all_pubsub_topics](https://github.com/logos-messaging/logos-delivery-ic10e73380c1583f691123c373e311faa/tests/sharding/test_relay_static_sharding.py#L66) | rewrite(in-process nodes) | PR gate | Unsubscribe all eight pubsub topics and no publish delivers any more. Lands in `tests/node/test_wakunode_sharding.nim`. |                                                            
## Changes                                                                                                                                                                                                          
- Wire `tests/wakunode_rest/test_rest_filter.nim` and `tests/wakunode_rest/test_rest_relay.nim` into `tests/all_tests_waku.nim`. The filter suite comes on unchanged apart from a stray debug echo. The relay suite spawns anvil per test, which the RLN suites in `make test` already need.
- Add the publish-without-subscription case to `tests/wakunode_rest/test_rest_relay.nim`.
- Add six unsubscribe and resubscribe tests to `tests/node/test_wakunode_sharding.nim`, content-topic and pubsub-topic variants, plus the one-shard test that pins the shard-wide drop.