### PR TITLE
fix(build): enable mix and QUIC on every library build path

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -137,6 +137,10 @@ const cBindingsFlags =
   " -d:ffiGenBindings -d:targetLang=c -d:ffiOutputDir=" & cBindingsDir &
   " -d:ffiSrcPath=../liblogosdelivery.nim "
 
+## The Makefile does not export NIM_PARAMS, so its defines never reach here.
+const libFeatureFlags =
+  " -d:libp2p_mix_experimental_exit_is_dest -d:libp2p_quic_support "
+
 proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static", srcFile = "liblogosdelivery.nim", mainPrefix = "liblogosdelivery") =
   if not dirExists "build":
     mkDir "build"
@@ -145,11 +149,11 @@ proc buildLibrary(lib_name: string, srcDir = "./", params = "", `type` = "static
   if `type` == "static":
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:staticlib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      cBindingsFlags & getMyCPU() & " " & params & getNimParams() & " " & srcDir & "/" & srcFile
+      libFeatureFlags & cBindingsFlags & getMyCPU() & " " & params & getNimParams() & " " & srcDir & "/" & srcFile
   else:
     exec "nim c" & " --out:build/" & lib_name &
       " --threads:on --app:lib --opt:speed --noMain --mm:refc --header -d:metrics --nimMainPrefix:" & mainPrefix & " --skipParentCfg:off -d:discv5_protocol_id=d5waku " &
-      cBindingsFlags & getMyCPU() & " " & params & getNimParams() & " " & srcDir & "/" & srcFile
+      libFeatureFlags & cBindingsFlags & getMyCPU() & " " & params & getNimParams() & " " & srcDir & "/" & srcFile
 
 proc buildLibDynamicWindows(libName: string, folderName: string) =
   buildLibrary libName & ".dll", folderName,

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,8 @@ let
 
   nimDefineArgs = pkgs.lib.concatStringsSep " \\\n      " (
        [ "--define:disable_libbacktrace"
+         "--define:libp2p_mix_experimental_exit_is_dest"
+         "--define:libp2p_quic_support"
          "--define:git_version=${gitVersion}" ]
     ++ pkgs.lib.optional enablePostgres       "--define:postgres"
     ++ pkgs.lib.optional enableNimDebugDlOpen "--define:nimDebugDlOpen"
@@ -45,6 +47,9 @@ let
     if pkgs.stdenv.hostPlatform.isWindows then "dll"
     else if pkgs.stdenv.hostPlatform.isDarwin then "dylib"
     else "so";
+
+  # Mirrors the nimble buildLibrary proc: library targets only, not the apps.
+  libDefineArgs = [ "--define:discv5_protocol_id=d5waku" ];
 
   # Must match the nimble task: library/liblogosdelivery.h includes this path.
   cBindingsDir = "library/generated";
@@ -132,7 +137,7 @@ pkgs.stdenv.mkDerivation {
         "--noMain"
         "--header"
         "--nimMainPrefix:liblogosdelivery"
-      ] ++ cBindingsArgs;
+      ] ++ libDefineArgs ++ cBindingsArgs;
     }}
 
     echo "== Building liblogosdelivery (static) =="
@@ -144,7 +149,7 @@ pkgs.stdenv.mkDerivation {
         "--opt:size"
         "--noMain"
         "--nimMainPrefix:liblogosdelivery"
-      ];
+      ] ++ libDefineArgs;
     }}
     ''}
   '';


### PR DESCRIPTION
# Description

1. Added `-d:libp2p_mix_experimental_exit_is_dest` and `-d:libp2p_quic_support` to the nimble `buildLibrary` proc and to `nix/default.nix`. The Makefile sets both in `NIM_PARAMS` but never exports it, so `buildLibrary`'s `getNimParams()` read an empty value, and the Nix build calls `nim c` with its own define list — no library build had either flag, and a `mixify` lightpush returned `built without libp2p_mix_experimental_exit_is_dest` on every consumer of `liblogosdelivery`.
2. Added `-d:discv5_protocol_id=d5waku` to the Nix library builds, matching what `buildLibrary` already passes.

<details>
<summary>AI-made decisions</summary>

- Fixed the two library build paths rather than exporting `NIM_PARAMS` from the Makefile: exporting it would also push `-d:release -d:lto_incremental -d:strip` into every nimble build.
- `discv5_protocol_id` stays on the library targets only, as in the Makefile and the nimble proc; the app targets keep the upstream default. Worth a separate look — the apps and the library discovering under different protocol ids looks unintended.
- Left `--opt:size` and the absent `-d:release` in the Nix build alone: deliberate for the shipped library, not drift.
- The mix define is verified in the built artifact — the `built without …` branch is compiled out of the new `liblogosdelivery.so` and still present in a pre-change Nix build. `libp2p_quic_support` is parity with the Makefile and the app targets; I did not confirm a behavioural change from it.
- The mix suite is green today because `tests/messaging/test_send_service_mix.nim` calls `publishOverMix` directly, below the `when defined(...)` guard, so it never exercised the flag.

</details>
