### PR TITLE
fix(examples): migrate every FFI example to the current signatures, build them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,12 @@ jobs:
         # job, which already forces -j1.
         run: make V=1 -j1 all
 
+      # The C/C++ FFI examples are the only consumers of the generated header
+      # that a compiler can check. Nothing built them, so they silently drifted
+      # out of sync with it; building them here keeps that from recurring.
+      - name: Build FFI examples
+        run: make V=1 -j1 ffi-examples
+
       - name: Audit installed deps
         run: make audit-deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,6 @@ jobs:
         # job, which already forces -j1.
         run: make V=1 -j1 all
 
-      # The C/C++ FFI examples are the only consumers of the generated header
-      # that a compiler can check. Nothing built them, so they silently drifted
-      # out of sync with it; building them here keeps that from recurring.
       - name: Build FFI examples
         run: make V=1 -j1 ffi-examples
 

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,6 @@ all: | wakunode2 logosdeliverynode liblogosdelivery
 
 examples: | example2 chat2 chat2bridge
 
-# The C/C++ examples link against liblogosdelivery, so they are the only thing
-# that catches drift between the generated FFI header and its consumers. They
-# need nothing but a compiler once the library is built, so CI builds them.
 ffi-examples: | cwaku_example cppwaku_example logosdelivery_example
 
 test_file := $(word 2,$(MAKECMDGOALS))

--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,17 @@ endif
 ## Main ##
 ##########
 # The Makefile automatically bootstraps dependency setup when needed for build and test targets.
-.PHONY: all test clean examples deps nimble install-nim install-nimble print-nimble-path
+.PHONY: all test clean examples ffi-examples deps nimble install-nim install-nimble print-nimble-path
 
 # default target
 all: | wakunode2 logosdeliverynode liblogosdelivery
 
 examples: | example2 chat2 chat2bridge
+
+# The C/C++ examples link against liblogosdelivery, so they are the only thing
+# that catches drift between the generated FFI header and its consumers. They
+# need nothing but a compiler once the library is built, so CI builds them.
+ffi-examples: | cwaku_example cppwaku_example logosdelivery_example
 
 test_file := $(word 2,$(MAKECMDGOALS))
 define test_name

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -97,7 +97,8 @@ void signal_cond()
   pthread_mutex_unlock(&mutex);
 }
 
-void event_handler(int callerRet, const char *msg, size_t len, void *userData)
+// LogosDeliveryScalarRawFn: `msg` is a byte run of `len` bytes.
+void event_handler(int callerRet, char *msg, size_t len, void *userData)
 {
   if (callerRet == RET_ERR)
   {
@@ -112,6 +113,37 @@ void event_handler(int callerRet, const char *msg, size_t len, void *userData)
   signal_cond();
 }
 
+// LogosDelivery*ReplyFn: entry points taking a request struct report through
+// this shape instead, with the failure text in its own argument.
+void reply_handler(int errCode, const char *reply, const char *errMsg, void *userData)
+{
+  if (errCode == RET_ERR)
+  {
+    printf("Error: %s\n", errMsg != NULL ? errMsg : "(no message)");
+    exit(1);
+  }
+  else if (errCode == RET_OK && reply != NULL)
+  {
+    printf("Receiving event: %s\n", reply);
+  }
+
+  signal_cond();
+}
+
+// LogosDeliveryCreateRawFn: like the reply shape, but carries the context
+// address rather than a payload.
+void create_handler(int errCode, const char *ctxAddr, const char *errMsg, void *userData)
+{
+  if (errCode == RET_ERR)
+  {
+    printf("Error: %s\n", errMsg != NULL ? errMsg : "(no message)");
+    exit(1);
+  }
+
+  signal_cond();
+}
+
+// FFICallback: the event-listener registry shape.
 void on_event_received(int callerRet, const char *msg, size_t len, void *userData)
 {
   if (callerRet == RET_ERR)
@@ -126,30 +158,30 @@ void on_event_received(int callerRet, const char *msg, size_t len, void *userDat
 }
 
 char *contentTopic = NULL;
-void handle_content_topic(int callerRet, const char *msg, size_t len, void *userData)
+void handle_content_topic(int errCode, const char *reply, const char *errMsg, void *userData)
 {
   if (contentTopic != NULL)
   {
     free(contentTopic);
   }
 
-  contentTopic = malloc(len * sizeof(char) + 1);
-  strcpy(contentTopic, msg);
+  contentTopic = malloc(strlen(reply) + 1);
+  strcpy(contentTopic, reply);
   signal_cond();
 }
 
 char *publishResponse = NULL;
-void handle_publish_ok(int callerRet, const char *msg, size_t len, void *userData)
+void handle_publish_ok(int errCode, const char *reply, const char *errMsg, void *userData)
 {
-  printf("Publish Ok: %s %lu\n", msg, len);
+  printf("Publish Ok: %s\n", reply);
 
   if (publishResponse != NULL)
   {
     free(publishResponse);
   }
 
-  publishResponse = malloc(len * sizeof(char) + 1);
-  strcpy(publishResponse, msg);
+  publishResponse = malloc(strlen(reply) + 1);
+  strcpy(publishResponse, reply);
 }
 
 #define MAX_MSG_SIZE 65535
@@ -159,13 +191,12 @@ void publish_message(const char *msg)
   char jsonWakuMsg[MAX_MSG_SIZE];
   char *msgPayload = b64_encode(msg, strlen(msg));
 
-  WAKU_CALL(waku_content_topic(ctx,
-                               handle_content_topic,
-                               userData,
-                               "appName",
-                               1,
-                               "contentTopicName",
-                               "encoding"));
+  WakuContentTopicReq contentTopicReq = {
+      .appName = "appName",
+      .appVersion = 1,
+      .contentTopicName = "contentTopicName",
+      .encoding = "encoding"};
+  WAKU_CALL(waku_content_topic(ctx, handle_content_topic, userData, &contentTopicReq));
   snprintf(jsonWakuMsg,
            MAX_MSG_SIZE,
            "{\"payload\":\"%s\",\"contentTopic\":\"%s\"}",
@@ -173,12 +204,11 @@ void publish_message(const char *msg)
 
   free(msgPayload);
 
-  WAKU_CALL(waku_relay_publish(ctx,
-                               event_handler,
-                               userData,
-                               "/waku/2/rs/16/32",
-                               jsonWakuMsg,
-                               10000 /*timeout ms*/));
+  WakuRelayPublishReq publishReq = {
+      .pubSubTopic = "/waku/2/rs/16/32",
+      .jsonWakuMessage = jsonWakuMsg,
+      .timeoutMs = 10000};
+  WAKU_CALL(waku_relay_publish(ctx, reply_handler, userData, &publishReq));
 }
 
 void show_help_and_exit()
@@ -187,13 +217,13 @@ void show_help_and_exit()
   exit(1);
 }
 
-void print_default_pubsub_topic(int callerRet, const char *msg, size_t len, void *userData)
+void print_default_pubsub_topic(int callerRet, char *msg, size_t len, void *userData)
 {
   printf("Default pubsub topic: %s\n", msg);
   signal_cond();
 }
 
-void print_waku_version(int callerRet, const char *msg, size_t len, void *userData)
+void print_waku_version(int callerRet, char *msg, size_t len, void *userData)
 {
   printf("Git Version: %s\n", msg);
   signal_cond();
@@ -237,10 +267,8 @@ void handle_user_input()
     char pubsubTopic[128];
     scanf("%127s", pubsubTopic);
 
-    WAKU_CALL(waku_relay_subscribe(ctx,
-                                   event_handler,
-                                   userData,
-                                   pubsubTopic));
+    WakuRelaySubscribeReq subscribeReq = {.pubSubTopic = pubsubTopic};
+    WAKU_CALL(waku_relay_subscribe(ctx, reply_handler, userData, &subscribeReq));
     printf("The subscription went well\n");
 
     show_main_menu();
@@ -303,7 +331,8 @@ int main(int argc, char **argv)
            cfgNode.port,
            cfgNode.store ? "true" : "false");
 
-  ctx = logosdelivery_create_node(jsonConfig, event_handler, userData);
+  LogosdeliveryCreateNodeCtorReq createReq = {.configJson = jsonConfig};
+  ctx = logosdelivery_create_node(&createReq, create_handler, userData);
   waitForCallback();
 
   WAKU_CALL(waku_default_pubsub_topic(ctx, print_default_pubsub_topic, userData));
@@ -327,15 +356,14 @@ int main(int argc, char **argv)
 
   WAKU_CALL(waku_listen_addresses(ctx, event_handler, userData));
 
-  WAKU_CALL(waku_relay_subscribe(ctx,
-                                 event_handler,
-                                 userData,
-                                "/waku/2/rs/16/32"));
+  WakuRelaySubscribeReq mainSubscribeReq = {.pubSubTopic = "/waku/2/rs/16/32"};
+  WAKU_CALL(waku_relay_subscribe(ctx, reply_handler, userData, &mainSubscribeReq));
 
-  WAKU_CALL(waku_discv5_update_bootnodes(ctx,
-                                         event_handler,
-                                         userData,
-                                         "[\"enr:-QEkuEBIkb8q8_mrorHndoXH9t5N6ZfD-jehQCrYeoJDPHqT0l0wyaONa2-piRQsi3oVKAzDShDVeoQhy0uwN1xbZfPZAYJpZIJ2NIJpcIQiQlleim11bHRpYWRkcnO4bgA0Ni9ub2RlLTAxLmdjLXVzLWNlbnRyYWwxLWEud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwA2Ni9ub2RlLTAxLmdjLXVzLWNlbnRyYWwxLWEud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQKnGt-GSgqPSf3IAPM7bFgTlpczpMZZLF3geeoNNsxzSoN0Y3CCdl-DdWRwgiMohXdha3UyDw\",\"enr:-QEkuEB3WHNS-xA3RDpfu9A2Qycr3bN3u7VoArMEiDIFZJ66F1EB3d4wxZN1hcdcOX-RfuXB-MQauhJGQbpz3qUofOtLAYJpZIJ2NIJpcIQI2SVcim11bHRpYWRkcnO4bgA0Ni9ub2RlLTAxLmFjLWNuLWhvbmdrb25nLWMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwA2Ni9ub2RlLTAxLmFjLWNuLWhvbmdrb25nLWMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQPK35Nnz0cWUtSAhBp7zvHEhyU_AqeQUlqzLiLxfP2L4oN0Y3CCdl-DdWRwgiMohXdha3UyDw\"]"));
+  WakuDiscv5UpdateBootnodesReq bootnodesReq = {
+      .bootnodes =
+          "[\"enr:-QEkuEBIkb8q8_mrorHndoXH9t5N6ZfD-jehQCrYeoJDPHqT0l0wyaONa2-piRQsi3oVKAzDShDVeoQhy0uwN1xbZfPZAYJpZIJ2NIJpcIQiQlleim11bHRpYWRkcnO4bgA0Ni9ub2RlLTAxLmdjLXVzLWNlbnRyYWwxLWEud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwA2Ni9ub2RlLTAxLmdjLXVzLWNlbnRyYWwxLWEud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQKnGt-GSgqPSf3IAPM7bFgTlpczpMZZLF3geeoNNsxzSoN0Y3CCdl-DdWRwgiMohXdha3UyDw\",\"enr:-QEkuEB3WHNS-xA3RDpfu9A2Qycr3bN3u7VoArMEiDIFZJ66F1EB3d4wxZN1hcdcOX-RfuXB-MQauhJGQbpz3qUofOtLAYJpZIJ2NIJpcIQI2SVcim11bHRpYWRkcnO4bgA0Ni9ub2RlLTAxLmFjLWNuLWhvbmdrb25nLWMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQZ2XwA2Ni9ub2RlLTAxLmFjLWNuLWhvbmdrb25nLWMud2FrdS5zYW5kYm94LnN0YXR1cy5pbQYfQN4DgnJzkwABCAAAAAEAAgADAAQABQAGAAeJc2VjcDI1NmsxoQPK35Nnz0cWUtSAhBp7zvHEhyU_AqeQUlqzLiLxfP2L4oN0Y3CCdl-DdWRwgiMohXdha3UyDw\"]"};
+  WAKU_CALL(
+      waku_discv5_update_bootnodes(ctx, reply_handler, userData, &bootnodesReq));
 
   WAKU_CALL(waku_get_peerids_from_peerstore(ctx,
                                             event_handler,

--- a/examples/cpp/waku.cpp
+++ b/examples/cpp/waku.cpp
@@ -104,6 +104,7 @@ void handle_error(const char *msg, size_t len)
     exit(1);
 }
 
+// FFICallback: the event-listener registry shape.
 template <class F>
 auto cify(F &&f)
 {
@@ -113,6 +114,34 @@ auto cify(F &&f)
         last_callback_ret = callerRet;
         signal_cond();
         return fn(msg, len);
+    };
+}
+
+// LogosDeliveryScalarRawFn: `msg` is a byte run of `len` bytes.
+template <class F>
+auto cifyRaw(F &&f)
+{
+    static F fn = std::forward<F>(f);
+    return [](int callerRet, char *msg, size_t len, void *userData)
+    {
+        last_callback_ret = callerRet;
+        signal_cond();
+        return fn(msg, len);
+    };
+}
+
+// LogosDelivery*ReplyFn (and CreateRawFn, which has the same signature):
+// entry points taking a request struct report failure in its own argument.
+template <class F>
+auto cifyReply(F &&f)
+{
+    static F fn = std::forward<F>(f);
+    return [](int errCode, const char *reply, const char *errMsg, void *userData)
+    {
+        last_callback_ret = errCode;
+        signal_cond();
+        const char *text = reply != nullptr ? reply : (errMsg != nullptr ? errMsg : "");
+        return fn(text, strlen(text));
     };
 }
 
@@ -154,11 +183,12 @@ void handle_user_input(void *ctx)
         char pubsubTopic[128];
         scanf("%127s", pubsubTopic);
 
+        WakuRelaySubscribeReq subscribeReq = {.pubSubTopic = pubsubTopic};
         WAKU_CALL(waku_relay_subscribe(ctx,
-                                       cify([&](const char *msg, size_t len)
-                                            { event_handler(msg, len); }),
+                                       cifyReply([&](const char *msg, size_t len)
+                                                 { event_handler(msg, len); }),
                                        nullptr,
-                                       pubsubTopic));
+                                       &subscribeReq));
         printf("The subscription went well\n");
 
         show_main_menu();
@@ -166,18 +196,20 @@ void handle_user_input(void *ctx)
     break;
 
     case CONNECT_TO_OTHER_NODE_MENU:
+    {
         printf("Connecting to a node. Please indicate the peer Multiaddress:\n");
         printf("e.g.: /ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmVFXtAfSj4EiR7mL2KvL4EE2wztuQgUSBoj2Jx2KeXFLN\n");
         char peerAddr[512];
         scanf("%511s", peerAddr);
+        WakuConnectReq connectReq = {.peerMultiAddr = peerAddr, .timeoutMs = 10000};
         WAKU_CALL(waku_connect(ctx,
-                               cify([&](const char *msg, size_t len)
-                                    { event_handler(msg, len); }),
+                               cifyReply([&](const char *msg, size_t len)
+                                         { event_handler(msg, len); }),
                                nullptr,
-                               peerAddr,
-                               10000 /* timeoutMs */));
+                               &connectReq));
         show_main_menu();
-        break;
+    }
+    break;
 
     case PUBLISH_MESSAGE_MENU:
     {
@@ -190,27 +222,29 @@ void handle_user_input(void *ctx)
         b64_encode(msg, strlen(msg), msgPayload);
 
         std::string contentTopic;
+        WakuContentTopicReq contentTopicReq = {.appName = "appName",
+                                               .appVersion = 1,
+                                               .contentTopicName = "contentTopicName",
+                                               .encoding = "encoding"};
         waku_content_topic(ctx,
-                           cify([&contentTopic](const char *msg, size_t len)
-                                { contentTopic = msg; }),
+                           cifyReply([&contentTopic](const char *msg, size_t len)
+                                     { contentTopic = msg; }),
                            nullptr,
-                           "appName",
-                           1,
-                           "contentTopicName",
-                           "encoding");
+                           &contentTopicReq);
 
         snprintf(jsonWakuMsg,
                  2048,
                  "{\"payload\":\"%s\",\"contentTopic\":\"%s\"}",
                  msgPayload.data(), contentTopic.c_str());
 
+        WakuRelayPublishReq publishReq = {.pubSubTopic = "/waku/2/rs/16/32",
+                                          .jsonWakuMessage = jsonWakuMsg,
+                                          .timeoutMs = 10000};
         WAKU_CALL(waku_relay_publish(ctx,
-                                     cify([&](const char *msg, size_t len)
-                                          { event_handler(msg, len); }),
+                                     cifyReply([&](const char *msg, size_t len)
+                                               { event_handler(msg, len); }),
                                      nullptr,
-                                     "/waku/2/rs/16/32",
-                                     jsonWakuMsg,
-                                     10000 /*timeout ms*/));
+                                     &publishReq));
 
         show_main_menu();
     }
@@ -256,10 +290,14 @@ int main(int argc, char **argv)
              cfgNode.port);
 
     void *ctx =
-        logosdelivery_create_node(jsonConfig,
-                 cify([](const char *msg, size_t len)
-                      { std::cout << "logosdelivery_create_node feedback: " << msg << std::endl; }),
-                 nullptr);
+        [&]() {
+            LogosdeliveryCreateNodeCtorReq createReq = {.configJson = jsonConfig};
+            return logosdelivery_create_node(
+                &createReq,
+                cifyReply([](const char *msg, size_t len)
+                          { std::cout << "logosdelivery_create_node feedback: " << msg << std::endl; }),
+                nullptr);
+        }();
     waitForCallback();
 
     // Node creation is asynchronous: logosdelivery_create_node returns a non-null
@@ -271,10 +309,7 @@ int main(int argc, char **argv)
         std::cerr << "Failed to create the node. Aborting." << std::endl;
         if (ctx != nullptr)
         {
-            logosdelivery_destroy(ctx,
-                                  cify([](const char *msg, size_t len) {}),
-                                  nullptr);
-            waitForCallback();
+            logosdelivery_destroy(ctx);
         }
         return 1;
     }
@@ -284,26 +319,27 @@ int main(int argc, char **argv)
     WAKU_CALL(
         waku_default_pubsub_topic(
             ctx,
-            cify([&defaultPubsubTopic](const char *msg, size_t len)
-                 { defaultPubsubTopic = msg; }),
+            cifyRaw([&defaultPubsubTopic](const char *msg, size_t len)
+                    { defaultPubsubTopic = msg; }),
             nullptr));
 
     std::cout << "Default pubsub topic: " << defaultPubsubTopic << std::endl;
 
     WAKU_CALL(waku_version(ctx,
-                           cify([&](const char *msg, size_t len)
-                                { std::cout << "Git Version: " << msg << std::endl; }),
+                           cifyRaw([&](const char *msg, size_t len)
+                                   { std::cout << "Git Version: " << msg << std::endl; }),
                            nullptr));
 
     printf("Bind addr: %s:%u\n", cfgNode.host, cfgNode.port);
     printf("Waku Relay enabled: %s\n", cfgNode.relay == 1 ? "YES" : "NO");
 
     std::string pubsubTopic;
+    WakuPubsubTopicReq pubsubTopicReq = {.topicName = "example"};
     WAKU_CALL(waku_pubsub_topic(ctx,
-                                cify([&](const char *msg, size_t len)
-                                     { pubsubTopic = msg; }),
+                                cifyReply([&](const char *msg, size_t len)
+                                          { pubsubTopic = msg; }),
                                 nullptr,
-                                "example"));
+                                &pubsubTopicReq));
 
     std::cout << "Custom pubsub topic: " << pubsubTopic << std::endl;
 
@@ -317,20 +353,22 @@ int main(int argc, char **argv)
         logosdelivery_add_event_listener(ctx, eventName, onEvent, nullptr);
 
     WAKU_CALL(logosdelivery_start_node(ctx,
-                         cify([&](const char *msg, size_t len)
-                              { event_handler(msg, len); }),
+                         cifyRaw([&](const char *msg, size_t len)
+                                 { event_handler(msg, len); }),
                          nullptr));
 
+    WakuRelaySubscribeReq defaultSubscribeReq = {
+        .pubSubTopic = defaultPubsubTopic.c_str()};
     WAKU_CALL(waku_relay_subscribe(ctx,
-                                   cify([&](const char *msg, size_t len)
-                                        { event_handler(msg, len); }),
+                                   cifyReply([&](const char *msg, size_t len)
+                                             { event_handler(msg, len); }),
                                    nullptr,
-                                   defaultPubsubTopic.c_str()));
+                                   &defaultSubscribeReq));
 
     std::string myPeerId;
     WAKU_CALL(waku_get_my_peerid(ctx,
-                                 cify([&myPeerId](const char *msg, size_t len)
-                                      { myPeerId = msg; }),
+                                 cifyRaw([&myPeerId](const char *msg, size_t len)
+                                         { myPeerId = msg; }),
                                  nullptr));
 
     std::cout << "My peer id: " << myPeerId << std::endl;

--- a/examples/golang/waku.go
+++ b/examples/golang/waku.go
@@ -7,6 +7,7 @@ package main
 	#include "../../library/liblogosdelivery_kernel.h"
 	#include <stdio.h>
 	#include <stdlib.h>
+	#include <string.h>
 
 	extern void globalEventCallback(int ret, char* msg, size_t len, void* userData);
 
@@ -50,13 +51,27 @@ package main
 		return m->ret;
 	}
 
-	// resp must be set != NULL in case interest on retrieving data from the callback
+	// LogosDeliveryScalarRawFn. resp must be set != NULL in case interest on
+	// retrieving data from the callback
 	static void callback(int ret, char* msg, size_t len, void* resp) {
 		if (resp != NULL) {
 			Resp* m = (Resp*) resp;
 			m->ret = ret;
 			m->msg = msg;
 			m->len = len;
+		}
+	}
+
+	// LogosDelivery*ReplyFn (and CreateRawFn, same signature): entry points
+	// taking a request struct report failure in its own argument rather than
+	// in msg, so they need their own shim onto the same Resp.
+	static void replyCallback(int errCode, const char* reply, const char* errMsg, void* resp) {
+		if (resp != NULL) {
+			Resp* m = (Resp*) resp;
+			const char* text = reply != NULL ? reply : (errMsg != NULL ? errMsg : "");
+			m->ret = errCode;
+			m->msg = (char*) text;
+			m->len = strlen(text);
 		}
 	}
 
@@ -71,32 +86,33 @@ package main
 
 	static void* cGoWakuNew(const char* configJson, void* resp) {
 		// We pass NULL because we are not interested in retrieving data from this callback
-		void* ret = logosdelivery_create_node(configJson, (FFICallBack) callback, resp);
+		void* ret = logosdelivery_create_node(
+			&(LogosdeliveryCreateNodeCtorReq){.configJson = configJson}, replyCallback, resp);
 		return ret;
 	}
 
 	static void cGoWakuStart(void* wakuCtx, void* resp) {
-		WAKU_CALL(logosdelivery_start_node(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL(logosdelivery_start_node(wakuCtx, callback, resp));
 	}
 
 	static void cGoWakuStop(void* wakuCtx, void* resp) {
-		WAKU_CALL(logosdelivery_stop_node(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL(logosdelivery_stop_node(wakuCtx, callback, resp));
 	}
 
 	static void cGoWakuDestroy(void* wakuCtx, void* resp) {
-		WAKU_CALL(logosdelivery_destroy(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL(logosdelivery_destroy(wakuCtx));
 	}
 
 	static void cGoWakuStartDiscV5(void* wakuCtx, void* resp) {
-		WAKU_CALL(waku_start_discv5(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL(waku_start_discv5(wakuCtx, callback, resp));
 	}
 
 	static void cGoWakuStopDiscV5(void* wakuCtx, void* resp) {
-		WAKU_CALL(waku_stop_discv5(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL(waku_stop_discv5(wakuCtx, callback, resp));
 	}
 
 	static void cGoWakuVersion(void* wakuCtx, void* resp) {
-		WAKU_CALL(waku_version(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL(waku_version(wakuCtx, callback, resp));
 	}
 
 	static void cGoWakuSetEventCallback(void* wakuCtx) {
@@ -129,22 +145,15 @@ package main
 							char* encoding,
 							void* resp) {
 
-		WAKU_CALL( waku_content_topic(wakuCtx,
-							(FFICallBack) callback,
-							resp,
-							appName,
-							appVersion,
-							contentTopicName,
-							encoding
-							) );
+		WAKU_CALL( waku_content_topic(wakuCtx, replyCallback, resp, &(WakuContentTopicReq){.appName = appName, .appVersion = appVersion, .contentTopicName = contentTopicName, .encoding = encoding}) );
 	}
 
 	static void cGoWakuPubsubTopic(void* wakuCtx, char* topicName, void* resp) {
-		WAKU_CALL( waku_pubsub_topic(wakuCtx, (FFICallBack) callback, resp, topicName) );
+		WAKU_CALL( waku_pubsub_topic(wakuCtx, replyCallback, resp, &(WakuPubsubTopicReq){.topicName = topicName}) );
 	}
 
 	static void cGoWakuDefaultPubsubTopic(void* wakuCtx, void* resp) {
-		WAKU_CALL (waku_default_pubsub_topic(wakuCtx, (FFICallBack) callback, resp));
+		WAKU_CALL (waku_default_pubsub_topic(wakuCtx, callback, resp));
 	}
 
 	static void cGoWakuRelayPublish(void* wakuCtx,
@@ -153,37 +162,20 @@ package main
                        int timeoutMs,
 					   void* resp) {
 
-		WAKU_CALL (waku_relay_publish(wakuCtx,
-											 (FFICallBack) callback,
-                       resp,
-                       pubSubTopic,
-                       jsonWakuMessage,
-                       timeoutMs
-                       ));
+		WAKU_CALL (waku_relay_publish(wakuCtx, replyCallback, resp, &(WakuRelayPublishReq){.pubSubTopic = pubSubTopic, .jsonWakuMessage = jsonWakuMessage, .timeoutMs = timeoutMs}));
 	}
 
 	static void cGoWakuRelaySubscribe(void* wakuCtx, char* pubSubTopic, void* resp) {
-		WAKU_CALL ( waku_relay_subscribe(wakuCtx,
-							(FFICallBack) callback,
-							resp,
-							pubSubTopic) );
+		WAKU_CALL ( waku_relay_subscribe(wakuCtx, replyCallback, resp, &(WakuRelaySubscribeReq){.pubSubTopic = pubSubTopic}) );
 	}
 
 	static void cGoWakuRelayUnsubscribe(void* wakuCtx, char* pubSubTopic, void* resp) {
 
-		WAKU_CALL ( waku_relay_unsubscribe(wakuCtx,
-							(FFICallBack) callback,
-							resp,
-							pubSubTopic) );
+		WAKU_CALL ( waku_relay_unsubscribe(wakuCtx, replyCallback, resp, &(WakuRelayUnsubscribeReq){.pubSubTopic = pubSubTopic}) );
 	}
 
 	static void cGoWakuConnect(void* wakuCtx, char* peerMultiAddr, int timeoutMs, void* resp) {
-		WAKU_CALL( waku_connect(wakuCtx,
-						(FFICallBack) callback,
-						resp,
-						peerMultiAddr,
-						timeoutMs
-						) );
+		WAKU_CALL( waku_connect(wakuCtx, replyCallback, resp, &(WakuConnectReq){.peerMultiAddr = peerMultiAddr, .timeoutMs = timeoutMs}) );
 	}
 
 	static void cGoWakuDialPeerById(void* wakuCtx,
@@ -192,45 +184,35 @@ package main
 									int timeoutMs,
 									void* resp) {
 
-		WAKU_CALL( waku_dial_peer_by_id(wakuCtx,
-						(FFICallBack) callback,
-						resp,
-						peerId,
-						protocol,
-						timeoutMs
-						) );
+		WAKU_CALL( waku_dial_peer_by_id(wakuCtx, replyCallback, resp, &(WakuDialPeerByIdReq){.peerId = peerId, .protocol = protocol, .timeoutMs = timeoutMs}) );
 	}
 
 	static void cGoWakuDisconnectPeerById(void* wakuCtx, char* peerId, void* resp) {
-		WAKU_CALL( waku_disconnect_peer_by_id(wakuCtx,
-						(FFICallBack) callback,
-						resp,
-						peerId
-						) );
+		WAKU_CALL( waku_disconnect_peer_by_id(wakuCtx, replyCallback, resp, &(WakuDisconnectPeerByIdReq){.peerId = peerId}) );
 	}
 
 	static void cGoWakuListenAddresses(void* wakuCtx, void* resp) {
-		WAKU_CALL (waku_listen_addresses(wakuCtx, (FFICallBack) callback, resp) );
+		WAKU_CALL (waku_listen_addresses(wakuCtx, callback, resp) );
 	}
 
 	static void cGoWakuGetMyENR(void* ctx, void* resp) {
-		WAKU_CALL (waku_get_my_enr(ctx, (FFICallBack) callback, resp) );
+		WAKU_CALL (waku_get_my_enr(ctx, callback, resp) );
 	}
 
 	static void cGoWakuGetMyPeerId(void* ctx, void* resp) {
-		WAKU_CALL (waku_get_my_peerid(ctx, (FFICallBack) callback, resp) );
+		WAKU_CALL (waku_get_my_peerid(ctx, callback, resp) );
 	}
 
 	static void cGoWakuListPeersInMesh(void* ctx, char* pubSubTopic, void* resp) {
-		WAKU_CALL (waku_relay_get_num_peers_in_mesh(ctx, (FFICallBack) callback, resp, pubSubTopic) );
+		WAKU_CALL (waku_relay_get_num_peers_in_mesh(ctx, replyCallback, resp, &(WakuRelayGetNumPeersInMeshReq){.pubSubTopic = pubSubTopic}) );
 	}
 
 	static void cGoWakuGetNumConnectedPeers(void* ctx, char* pubSubTopic, void* resp) {
-		WAKU_CALL (waku_relay_get_num_connected_peers(ctx, (FFICallBack) callback, resp, pubSubTopic) );
+		WAKU_CALL (waku_relay_get_num_connected_peers(ctx, replyCallback, resp, &(WakuRelayGetNumConnectedPeersReq){.pubSubTopic = pubSubTopic}) );
 	}
 
 	static void cGoWakuGetPeerIdsFromPeerStore(void* wakuCtx, void* resp) {
-		WAKU_CALL (waku_get_peerids_from_peerstore(wakuCtx, (FFICallBack) callback, resp) );
+		WAKU_CALL (waku_get_peerids_from_peerstore(wakuCtx, callback, resp) );
 	}
 
 	static void cGoWakuLightpushPublish(void* wakuCtx,
@@ -238,12 +220,7 @@ package main
 					const char* jsonWakuMessage,
 					void* resp) {
 
-		WAKU_CALL (waku_lightpush_publish(wakuCtx,
-						(FFICallBack) callback,
-						resp,
-						pubSubTopic,
-						jsonWakuMessage
-						));
+		WAKU_CALL (waku_lightpush_publish(wakuCtx, replyCallback, resp, &(WakuLightpushPublishReq){.pubSubTopic = pubSubTopic, .jsonWakuMessage = jsonWakuMessage}));
 	}
 
 	static void cGoWakuStoreQuery(void* wakuCtx,
@@ -252,35 +229,21 @@ package main
 					int timeoutMs,
 					void* resp) {
 
-		WAKU_CALL (waku_store_query(wakuCtx,
-									(FFICallBack) callback,
-									resp,
-									jsonQuery,
-									peerAddr,
-									timeoutMs
-									));
+		WAKU_CALL (waku_store_query(wakuCtx, replyCallback, resp, &(WakuStoreQueryReq){.jsonQuery = jsonQuery, .peerAddr = peerAddr, .timeoutMs = timeoutMs}));
 	}
 
 	static void cGoWakuPeerExchangeQuery(void* wakuCtx,
 								uint64_t numPeers,
 								void* resp) {
 
-		WAKU_CALL (waku_peer_exchange_request(wakuCtx,
-									(FFICallBack) callback,
-									resp,
-									numPeers
-									));
+		WAKU_CALL (waku_peer_exchange_request(wakuCtx, callback, resp, numPeers));
 	}
 
 	static void cGoWakuGetPeerIdsByProtocol(void* wakuCtx,
 									 const char* protocol,
 									 void* resp) {
 
-		WAKU_CALL (waku_get_peerids_by_protocol(wakuCtx,
-									(FFICallBack) callback,
-									resp,
-									protocol
-									));
+		WAKU_CALL (waku_get_peerids_by_protocol(wakuCtx, replyCallback, resp, &(WakuGetPeeridsByProtocolReq){.protocol = protocol}));
 	}
 
 */

--- a/examples/golang/waku.go
+++ b/examples/golang/waku.go
@@ -8,23 +8,68 @@ package main
 	#include <stdio.h>
 	#include <stdlib.h>
 	#include <string.h>
+	#include <pthread.h>
 
 	extern void globalEventCallback(int ret, char* msg, size_t len, void* userData);
 
+	// The library answers on its own thread, so a Resp carries the handshake
+	// as well as the payload. `msg` is owned here: the buffer handed to a
+	// callback is only valid for that call.
 	typedef struct {
 		int ret;
 		char* msg;
 		size_t len;
+		int done;
+		pthread_mutex_t mtx;
+		pthread_cond_t cond;
 	} Resp;
 
 	static void* allocResp() {
-		return calloc(1, sizeof(Resp));
+		Resp* r = calloc(1, sizeof(Resp));
+		pthread_mutex_init(&r->mtx, NULL);
+		pthread_cond_init(&r->cond, NULL);
+		return r;
 	}
 
 	static void freeResp(void* resp) {
 		if (resp != NULL) {
-			free(resp);
+			Resp* r = (Resp*) resp;
+			pthread_mutex_destroy(&r->mtx);
+			pthread_cond_destroy(&r->cond);
+			free(r->msg);
+			free(r);
 		}
+	}
+
+	// Blocks until the reply lands. Without this the caller reads a zeroed
+	// Resp, and since RET_OK is 0 that looks like success with an empty body.
+	static void waitResp(void* resp) {
+		if (resp == NULL) {
+			return;
+		}
+		Resp* m = (Resp*) resp;
+		pthread_mutex_lock(&m->mtx);
+		while (!m->done) {
+			pthread_cond_wait(&m->cond, &m->mtx);
+		}
+		pthread_mutex_unlock(&m->mtx);
+	}
+
+	static void completeResp(Resp* m, int ret, const char* text, size_t len) {
+		pthread_mutex_lock(&m->mtx);
+		m->ret = ret;
+		free(m->msg);
+		m->msg = malloc(len + 1);
+		if (m->msg != NULL) {
+			if (len > 0 && text != NULL) {
+				memcpy(m->msg, text, len);
+			}
+			m->msg[len] = '\0';
+			m->len = len;
+		}
+		m->done = 1;
+		pthread_cond_signal(&m->cond);
+		pthread_mutex_unlock(&m->mtx);
 	}
 
 	static char* getMyCharPtr(void* resp) {
@@ -55,10 +100,7 @@ package main
 	// retrieving data from the callback
 	static void callback(int ret, char* msg, size_t len, void* resp) {
 		if (resp != NULL) {
-			Resp* m = (Resp*) resp;
-			m->ret = ret;
-			m->msg = msg;
-			m->len = len;
+			completeResp((Resp*) resp, ret, msg, len);
 		}
 	}
 
@@ -67,11 +109,8 @@ package main
 	// in msg, so they need their own shim onto the same Resp.
 	static void replyCallback(int errCode, const char* reply, const char* errMsg, void* resp) {
 		if (resp != NULL) {
-			Resp* m = (Resp*) resp;
 			const char* text = reply != NULL ? reply : (errMsg != NULL ? errMsg : "");
-			m->ret = errCode;
-			m->msg = (char*) text;
-			m->len = strlen(text);
+			completeResp((Resp*) resp, errCode, text, strlen(text));
 		}
 	}
 
@@ -88,15 +127,18 @@ package main
 		// We pass NULL because we are not interested in retrieving data from this callback
 		void* ret = logosdelivery_create_node(
 			&(LogosdeliveryCreateNodeCtorReq){.configJson = configJson}, replyCallback, resp);
+		waitResp(resp);
 		return ret;
 	}
 
 	static void cGoWakuStart(void* wakuCtx, void* resp) {
 		WAKU_CALL(logosdelivery_start_node(wakuCtx, callback, resp));
+		waitResp(resp);
 	}
 
 	static void cGoWakuStop(void* wakuCtx, void* resp) {
 		WAKU_CALL(logosdelivery_stop_node(wakuCtx, callback, resp));
+		waitResp(resp);
 	}
 
 	static void cGoWakuDestroy(void* wakuCtx, void* resp) {
@@ -105,14 +147,17 @@ package main
 
 	static void cGoWakuStartDiscV5(void* wakuCtx, void* resp) {
 		WAKU_CALL(waku_start_discv5(wakuCtx, callback, resp));
+		waitResp(resp);
 	}
 
 	static void cGoWakuStopDiscV5(void* wakuCtx, void* resp) {
 		WAKU_CALL(waku_stop_discv5(wakuCtx, callback, resp));
+		waitResp(resp);
 	}
 
 	static void cGoWakuVersion(void* wakuCtx, void* resp) {
 		WAKU_CALL(waku_version(wakuCtx, callback, resp));
+		waitResp(resp);
 	}
 
 	static void cGoWakuSetEventCallback(void* wakuCtx) {
@@ -146,14 +191,17 @@ package main
 							void* resp) {
 
 		WAKU_CALL( waku_content_topic(wakuCtx, replyCallback, resp, &(WakuContentTopicReq){.appName = appName, .appVersion = appVersion, .contentTopicName = contentTopicName, .encoding = encoding}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuPubsubTopic(void* wakuCtx, char* topicName, void* resp) {
 		WAKU_CALL( waku_pubsub_topic(wakuCtx, replyCallback, resp, &(WakuPubsubTopicReq){.topicName = topicName}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuDefaultPubsubTopic(void* wakuCtx, void* resp) {
 		WAKU_CALL (waku_default_pubsub_topic(wakuCtx, callback, resp));
+		waitResp(resp);
 	}
 
 	static void cGoWakuRelayPublish(void* wakuCtx,
@@ -163,19 +211,23 @@ package main
 					   void* resp) {
 
 		WAKU_CALL (waku_relay_publish(wakuCtx, replyCallback, resp, &(WakuRelayPublishReq){.pubSubTopic = pubSubTopic, .jsonWakuMessage = jsonWakuMessage, .timeoutMs = timeoutMs}));
+		waitResp(resp);
 	}
 
 	static void cGoWakuRelaySubscribe(void* wakuCtx, char* pubSubTopic, void* resp) {
 		WAKU_CALL ( waku_relay_subscribe(wakuCtx, replyCallback, resp, &(WakuRelaySubscribeReq){.pubSubTopic = pubSubTopic}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuRelayUnsubscribe(void* wakuCtx, char* pubSubTopic, void* resp) {
 
 		WAKU_CALL ( waku_relay_unsubscribe(wakuCtx, replyCallback, resp, &(WakuRelayUnsubscribeReq){.pubSubTopic = pubSubTopic}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuConnect(void* wakuCtx, char* peerMultiAddr, int timeoutMs, void* resp) {
 		WAKU_CALL( waku_connect(wakuCtx, replyCallback, resp, &(WakuConnectReq){.peerMultiAddr = peerMultiAddr, .timeoutMs = timeoutMs}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuDialPeerById(void* wakuCtx,
@@ -185,34 +237,42 @@ package main
 									void* resp) {
 
 		WAKU_CALL( waku_dial_peer_by_id(wakuCtx, replyCallback, resp, &(WakuDialPeerByIdReq){.peerId = peerId, .protocol = protocol, .timeoutMs = timeoutMs}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuDisconnectPeerById(void* wakuCtx, char* peerId, void* resp) {
 		WAKU_CALL( waku_disconnect_peer_by_id(wakuCtx, replyCallback, resp, &(WakuDisconnectPeerByIdReq){.peerId = peerId}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuListenAddresses(void* wakuCtx, void* resp) {
 		WAKU_CALL (waku_listen_addresses(wakuCtx, callback, resp) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuGetMyENR(void* ctx, void* resp) {
 		WAKU_CALL (waku_get_my_enr(ctx, callback, resp) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuGetMyPeerId(void* ctx, void* resp) {
 		WAKU_CALL (waku_get_my_peerid(ctx, callback, resp) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuListPeersInMesh(void* ctx, char* pubSubTopic, void* resp) {
 		WAKU_CALL (waku_relay_get_num_peers_in_mesh(ctx, replyCallback, resp, &(WakuRelayGetNumPeersInMeshReq){.pubSubTopic = pubSubTopic}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuGetNumConnectedPeers(void* ctx, char* pubSubTopic, void* resp) {
 		WAKU_CALL (waku_relay_get_num_connected_peers(ctx, replyCallback, resp, &(WakuRelayGetNumConnectedPeersReq){.pubSubTopic = pubSubTopic}) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuGetPeerIdsFromPeerStore(void* wakuCtx, void* resp) {
 		WAKU_CALL (waku_get_peerids_from_peerstore(wakuCtx, callback, resp) );
+		waitResp(resp);
 	}
 
 	static void cGoWakuLightpushPublish(void* wakuCtx,
@@ -221,6 +281,7 @@ package main
 					void* resp) {
 
 		WAKU_CALL (waku_lightpush_publish(wakuCtx, replyCallback, resp, &(WakuLightpushPublishReq){.pubSubTopic = pubSubTopic, .jsonWakuMessage = jsonWakuMessage}));
+		waitResp(resp);
 	}
 
 	static void cGoWakuStoreQuery(void* wakuCtx,
@@ -230,6 +291,7 @@ package main
 					void* resp) {
 
 		WAKU_CALL (waku_store_query(wakuCtx, replyCallback, resp, &(WakuStoreQueryReq){.jsonQuery = jsonQuery, .peerAddr = peerAddr, .timeoutMs = timeoutMs}));
+		waitResp(resp);
 	}
 
 	static void cGoWakuPeerExchangeQuery(void* wakuCtx,
@@ -237,6 +299,7 @@ package main
 								void* resp) {
 
 		WAKU_CALL (waku_peer_exchange_request(wakuCtx, callback, resp, numPeers));
+		waitResp(resp);
 	}
 
 	static void cGoWakuGetPeerIdsByProtocol(void* wakuCtx,
@@ -244,6 +307,7 @@ package main
 									 void* resp) {
 
 		WAKU_CALL (waku_get_peerids_by_protocol(wakuCtx, replyCallback, resp, &(WakuGetPeeridsByProtocolReq){.protocol = protocol}));
+		waitResp(resp);
 	}
 
 */

--- a/examples/ios/WakuExample/WakuNode.swift
+++ b/examples/ios/WakuExample/WakuNode.swift
@@ -126,13 +126,15 @@ actor WakuActor {
     // Using a simple static reference (safe because we only have one instance)
     private static var sharedEventContinuation: AsyncStream<String>.Continuation?
 
-    private static let eventCallback: WakuCallBack = { ret, msg, len, userData in
+    // FFICallback: the event-listener registry shape.
+    private static let eventCallback: FFICallback = { ret, msg, len, userData in
         guard ret == RET_OK, let msg = msg else { return }
         let str = String(cString: msg)
         WakuActor.sharedEventContinuation?.yield(str)
     }
 
-    private static let syncCallback: WakuCallBack = { ret, msg, len, userData in
+    // LogosDeliveryScalarRawFn: `msg` is a byte run of `len` bytes.
+    private static let syncCallback: LogosDeliveryScalarRawFn = { ret, msg, len, userData in
         guard let userData = userData else { return }
         let context = Unmanaged<CallbackContext>.fromOpaque(userData).takeUnretainedValue()
         let success = (ret == RET_OK)
@@ -142,6 +144,18 @@ actor WakuActor {
         }
         context.resumeOnce(returning: (success, resultStr))
     }
+
+    // LogosDelivery*ReplyFn, shared by every entry point that takes a request
+    // struct: no length, and the failure text arrives in its own argument.
+    private static let syncReplyCallback:
+        @convention(c) (Int32, UnsafePointer<CChar>?, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = {
+            ret, reply, errMsg, userData in
+            guard let userData = userData else { return }
+            let context = Unmanaged<CallbackContext>.fromOpaque(userData).takeUnretainedValue()
+            let success = (ret == RET_OK)
+            let text = reply ?? errMsg
+            context.resumeOnce(returning: (success, text.map { String(cString: $0) }))
+        }
 
     // MARK: - Stream Setup
 
@@ -244,7 +258,7 @@ actor WakuActor {
             print("[WakuActor] Node stopped")
 
             // Destroy
-            _ = await self.callWakuSync { logosdelivery_destroy(ctxToStop, WakuActor.syncCallback, $0) }
+            logosdelivery_destroy(ctxToStop)
             print("[WakuActor] Node destroyed")
         }
     }
@@ -270,13 +284,14 @@ actor WakuActor {
         """
 
         let result = await callWakuSync { userData in
-            waku_lightpush_publish(
-                context,
-                self.defaultPubsubTopic,
-                jsonMessage,
-                WakuActor.syncCallback,
-                userData
-            )
+            _ = self.defaultPubsubTopic.withCString { topicPtr in
+                jsonMessage.withCString { msgPtr in
+                    var req = WakuLightpushPublishReq(
+                        pubSubTopic: topicPtr, jsonWakuMessage: msgPtr)
+                    return waku_lightpush_publish(
+                        context, WakuActor.syncReplyCallback, userData, &req)
+                }
+            }
         }
 
         if result.success {
@@ -320,14 +335,17 @@ actor WakuActor {
             let userDataPtr = Unmanaged.passRetained(callbackCtx).toOpaque()
 
             // Set up a simple callback for logosdelivery_create_node
-            let newCtx = logosdelivery_create_node(config, { ret, msg, len, userData in
-                guard let userData = userData else { return }
-                let context = Unmanaged<CallbackContext>.fromOpaque(userData).takeUnretainedValue()
-                context.success = (ret == RET_OK)
-                if let msg = msg {
-                    context.result = String(cString: msg)
-                }
-            }, userDataPtr)
+            let newCtx = config.withCString { configPtr -> UnsafeMutableRawPointer? in
+                var req = LogosdeliveryCreateNodeCtorReq(configJson: configPtr)
+                return logosdelivery_create_node(&req, { ret, reply, errMsg, userData in
+                    guard let userData = userData else { return }
+                    let context = Unmanaged<CallbackContext>.fromOpaque(userData).takeUnretainedValue()
+                    context.success = (ret == RET_OK)
+                    if let text = reply ?? errMsg {
+                        context.result = String(cString: text)
+                    }
+                }, userDataPtr)
+            }
 
             // Small delay to ensure callback completes
             DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
@@ -377,7 +395,10 @@ actor WakuActor {
         print("[WakuActor] Connecting to static peer...")
 
         let result = await callWakuSync { userData in
-            waku_connect(context, self.staticPeer, 10000, WakuActor.syncCallback, userData)
+            _ = self.staticPeer.withCString { peerPtr in
+                var req = WakuConnectReq(peerMultiAddr: peerPtr, timeoutMs: 10000)
+                return waku_connect(context, WakuActor.syncReplyCallback, userData, &req)
+            }
         }
 
         if result.success {
@@ -397,13 +418,14 @@ actor WakuActor {
         let topic = contentTopic ?? defaultContentTopic
 
         let result = await callWakuSync { userData in
-            waku_filter_subscribe(
-                context,
-                self.defaultPubsubTopic,
-                topic,
-                WakuActor.syncCallback,
-                userData
-            )
+            _ = self.defaultPubsubTopic.withCString { topicPtr in
+                topic.withCString { contentPtr in
+                    var req = WakuFilterSubscribeReq(
+                        pubSubTopic: topicPtr, contentTopics: contentPtr)
+                    return waku_filter_subscribe(
+                        context, WakuActor.syncReplyCallback, userData, &req)
+                }
+            }
         }
 
         isSubscribing = false
@@ -424,13 +446,10 @@ actor WakuActor {
         guard let context = ctx else { return false }
 
         let result = await callWakuSync { userData in
-            waku_ping_peer(
-                context,
-                self.staticPeer,
-                10000,
-                WakuActor.syncCallback,
-                userData
-            )
+            _ = self.staticPeer.withCString { peerPtr in
+                var req = WakuPingPeerReq(peerAddr: peerPtr, timeoutMs: 10000)
+                return waku_ping_peer(context, WakuActor.syncReplyCallback, userData, &req)
+            }
         }
 
         return result.success

--- a/examples/mobile/android/app/src/main/jni/waku_ffi.c
+++ b/examples/mobile/android/app/src/main/jni/waku_ffi.c
@@ -41,6 +41,7 @@ void free_cb_result(cb_result *result) {
 
 // callback executed by libwaku functions. It expects user_data to be a
 // cb_result*.
+// LogosDeliveryScalarRawFn / FFICallback shape.
 void on_response(int ret, const char *msg, size_t len, void *user_data) {
   if (ret != RET_OK) {
     char errMsg[300];
@@ -180,11 +181,26 @@ void Java_com_mobile_WakuModule_wakuSetup(JNIEnv *env, jobject thiz) {
   LOGD("log example for debugging purposes...")
 }
 
+// LogosDeliveryScalarRawFn: same reporting, non-const msg.
+static void on_response_raw(int ret, char *msg, size_t len, void *user_data) {
+  on_response(ret, msg, len, user_data);
+}
+
+// LogosDelivery*ReplyFn and CreateRawFn: no length, and the failure text
+// arrives in its own argument.
+static void on_response_reply(int errCode, const char *reply,
+                              const char *errMsg, void *user_data) {
+  const char *text = reply != NULL ? reply : (errMsg != NULL ? errMsg : "");
+  on_response(errCode, text, strlen(text), user_data);
+}
+
 jobject Java_com_mobile_WakuModule_wakuNew(JNIEnv *env, jobject thiz,
                                            jstring configJson) {
   const char *config = (*env)->GetStringUTFChars(env, configJson, 0);
   cb_result *result = NULL;
-  void *wakuPtr = logosdelivery_create_node(config, on_response, (void *)&result);
+  void *wakuPtr = logosdelivery_create_node(
+      &(LogosdeliveryCreateNodeCtorReq){.configJson = config}, on_response_reply,
+      (void *)&result);
   jobject response = to_jni_ptr(env, result, wakuPtr);
   (*env)->ReleaseStringUTFChars(env, configJson, config);
   free_cb_result(result);
@@ -194,7 +210,7 @@ jobject Java_com_mobile_WakuModule_wakuNew(JNIEnv *env, jobject thiz,
 jobject Java_com_mobile_WakuModule_wakuStart(JNIEnv *env, jobject thiz,
                                              jlong wakuPtr) {
   cb_result *result = NULL;
-  logosdelivery_start_node((void *)wakuPtr, on_response, &result);
+  logosdelivery_start_node((void *)wakuPtr, on_response_raw, &result);
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   return response;
@@ -203,7 +219,7 @@ jobject Java_com_mobile_WakuModule_wakuStart(JNIEnv *env, jobject thiz,
 jobject Java_com_mobile_WakuModule_wakuVersion(JNIEnv *env, jobject thiz,
                                                jlong wakuPtr) {
   cb_result *result = NULL;
-  waku_version((void *)wakuPtr, on_response, (void *)&result);
+  waku_version((void *)wakuPtr, on_response_raw, (void *)&result);
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   return response;
@@ -212,7 +228,7 @@ jobject Java_com_mobile_WakuModule_wakuVersion(JNIEnv *env, jobject thiz,
 jobject Java_com_mobile_WakuModule_wakuStop(JNIEnv *env, jobject thiz,
                                             jlong wakuPtr) {
   cb_result *result = NULL;
-  logosdelivery_stop_node((void *)wakuPtr, on_response, &result);
+  logosdelivery_stop_node((void *)wakuPtr, on_response_raw, &result);
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   return response;
@@ -221,7 +237,7 @@ jobject Java_com_mobile_WakuModule_wakuStop(JNIEnv *env, jobject thiz,
 jobject Java_com_mobile_WakuModule_wakuDestroy(JNIEnv *env, jobject thiz,
                                                jlong wakuPtr) {
   cb_result *result = NULL;
-  logosdelivery_destroy((void *)wakuPtr, on_response, &result);
+  logosdelivery_destroy((void *)wakuPtr);
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   return response;
@@ -233,7 +249,8 @@ jobject Java_com_mobile_WakuModule_wakuConnect(JNIEnv *env, jobject thiz,
                                                jint timeoutMs) {
   cb_result *result = NULL;
   const char *peer = (*env)->GetStringUTFChars(env, peerMultiAddr, 0);
-  waku_connect((void *)wakuPtr, peer, timeoutMs, on_response, &result);
+  waku_connect((void *)wakuPtr, on_response_reply, &result,
+               &(WakuConnectReq){.peerMultiAddr = peer, .timeoutMs = timeoutMs});
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   (*env)->ReleaseStringUTFChars(env, peerMultiAddr, peer);
@@ -244,7 +261,7 @@ jobject Java_com_mobile_WakuModule_wakuListenAddresses(JNIEnv *env,
                                                        jobject thiz,
                                                        jlong wakuPtr) {
   cb_result *result = NULL;
-  waku_listen_addresses((void *)wakuPtr, on_response, (void *)&result);
+  waku_listen_addresses((void *)wakuPtr, on_response_raw, (void *)&result);
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   return response;
@@ -258,8 +275,10 @@ jobject Java_com_mobile_WakuModule_wakuRelayPublish(JNIEnv *env, jobject thiz,
   cb_result *result = NULL;
   const char *topic = (*env)->GetStringUTFChars(env, pubsubTopic, 0);
   const char *msg = (*env)->GetStringUTFChars(env, jsonWakuMessage, 0);
-  waku_relay_publish((void *)wakuPtr, topic, msg, timeoutMs, on_response,
-                     (void *)&result);
+  waku_relay_publish((void *)wakuPtr, on_response_reply, (void *)&result,
+                     &(WakuRelayPublishReq){.pubSubTopic = topic,
+                                            .jsonWakuMessage = msg,
+                                            .timeoutMs = timeoutMs});
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   (*env)->ReleaseStringUTFChars(env, pubsubTopic, topic);
@@ -272,7 +291,8 @@ jobject Java_com_mobile_WakuModule_wakuRelaySubscribe(JNIEnv *env, jobject thiz,
                                                       jstring pubsubTopic) {
   cb_result *result = NULL;
   const char *topic = (*env)->GetStringUTFChars(env, pubsubTopic, 0);
-  waku_relay_subscribe((void *)wakuPtr, topic, on_response, (void *)&result);
+  waku_relay_subscribe((void *)wakuPtr, on_response_reply, (void *)&result,
+                       &(WakuRelaySubscribeReq){.pubSubTopic = topic});
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   (*env)->ReleaseStringUTFChars(env, pubsubTopic, topic);
@@ -285,7 +305,8 @@ jobject Java_com_mobile_WakuModule_wakuRelayUnsubscribe(JNIEnv *env,
                                                         jstring pubsubTopic) {
   cb_result *result = NULL;
   const char *topic = (*env)->GetStringUTFChars(env, pubsubTopic, 0);
-  waku_relay_unsubscribe((void *)wakuPtr, topic, on_response, (void *)&result);
+  waku_relay_unsubscribe((void *)wakuPtr, on_response_reply, (void *)&result,
+                         &(WakuRelayUnsubscribeReq){.pubSubTopic = topic});
   jobject response = to_jni_result(env, result);
   free_cb_result(result);
   (*env)->ReleaseStringUTFChars(env, pubsubTopic, topic);

--- a/examples/nodejs/waku_addon.c
+++ b/examples/nodejs/waku_addon.c
@@ -86,7 +86,8 @@ static void CallJs(napi_env env, napi_value js_cb, void* context, void* data) {
   free(data);
 }
 
-void handle_waku_version(int callerRet, const char* msg, size_t len) {
+// LogosDeliveryScalarRawFn
+void handle_waku_version(int callerRet, char* msg, size_t len, void* userData) {
   if (ref_version_callback == NULL) {
     napi_throw_type_error(my_env, NULL, "ERROR in event_handler. ref_version_callback == NULL");
   }
@@ -112,7 +113,8 @@ void handle_waku_version(int callerRet, const char* msg, size_t len) {
 
 // This function is directly passed as a callback to the libwaku and it
 // calls a NodeJs function if it has been set.
-void event_handler(int callerRet, const char* msg, size_t len) {
+// FFICallback: the event-listener registry shape.
+void event_handler(int callerRet, const char* msg, size_t len, void* userData) {
   if (thsafe_fn == NULL) {
   // if (ref_event_callback == NULL) {
     napi_throw_type_error(my_env, NULL, "ERROR in event_handler. ref_event_callback == NULL");
@@ -124,7 +126,20 @@ void event_handler(int callerRet, const char* msg, size_t len) {
   NAPI_CALL(napi_call_threadsafe_function(thsafe_fn, allocated_msg, napi_tsfn_nonblocking));
 }
 
-void handle_error(int callerRet, const char* msg, size_t len) {
+// LogosDelivery*ReplyFn: failure text arrives in its own argument.
+// LogosDeliveryScalarRawFn view of the same reporting.
+void event_handler_raw(int callerRet, char* msg, size_t len, void* userData) {
+  event_handler(callerRet, msg, len, userData);
+}
+
+// LogosDeliveryCreateRawFn view: no length, failure text in its own argument.
+void event_handler_create(int errCode, const char* reply, const char* errMsg, void* userData) {
+  const char* text = reply != NULL ? reply : (errMsg != NULL ? errMsg : "");
+  event_handler(errCode, text, strlen(text), userData);
+}
+
+void handle_error(int errCode, const char* reply, const char* errMsg, void* userData) {
+  const char* msg = reply != NULL ? reply : (errMsg != NULL ? errMsg : "");
   if (ref_on_error_callback == NULL) {
     napi_throw_type_error(my_env, NULL, "ERROR in event_handler. ref_on_error_callback == NULL");
   }
@@ -145,16 +160,17 @@ void handle_error(int callerRet, const char* msg, size_t len) {
 }
 
 char* contentTopic = NULL;
-void handle_content_topic(int callerRet, const char* msg, size_t len) {
+void handle_content_topic(int errCode, const char* reply, const char* errMsg, void* userData) {
     if (contentTopic != NULL) {
         free(contentTopic);
     }
 
-    contentTopic = malloc(len * sizeof(char) + 1);
-    strcpy(contentTopic, msg);
+    contentTopic = malloc(strlen(reply) + 1);
+    strcpy(contentTopic, reply);
 }
 
-void handle_default_pubsub_topic(int callerRet, const char* msg, size_t len) {
+// LogosDeliveryScalarRawFn
+void handle_default_pubsub_topic(int callerRet, char* msg, size_t len, void* userData) {
   if (ref_def_pubsub_topic_callback == NULL) {
     napi_throw_type_error(my_env, NULL,
            "ERROR in event_handler. ref_def_pubsub_topic_callback == NULL");
@@ -200,7 +216,9 @@ static napi_value WakuNew(napi_env env, napi_callback_info info) {
   str_size = str_size + 1;
   napi_get_value_string_utf8(env, args[0], jsonConfig, str_size, &str_size_read);
 
-  ctx = logosdelivery_create_node(jsonConfig, event_handler, userData);
+  ctx = logosdelivery_create_node(
+      &(LogosdeliveryCreateNodeCtorReq){.configJson = jsonConfig},
+      event_handler_create, userData);
 
   free(jsonConfig);
 
@@ -298,7 +316,7 @@ static napi_value WakuSetEventCallback(napi_env env, napi_callback_info info) {
 }
 
 static napi_value WakuStart(napi_env env, napi_callback_info info) {
-  logosdelivery_start_node(ctx, event_handler, userData);
+  logosdelivery_start_node(ctx, event_handler_raw, userData);
   return NULL;
 }
 
@@ -355,7 +373,9 @@ static napi_value WakuConnect(napi_env env, napi_callback_info info) {
   my_env = env;
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
 
-  WAKU_CALL(waku_connect(ctx, peers, timeoutMs, handle_error, userData));
+  WAKU_CALL(waku_connect(ctx, handle_error, userData,
+                         &(WakuConnectReq){.peerMultiAddr = peers,
+                                          .timeoutMs = timeoutMs}));
 
   // Free allocated memory
   free(peers);
@@ -426,13 +446,12 @@ static napi_value WakuRelayPublish(napi_env env, napi_callback_info info) {
   char *msgPayload = b64_encode((unsigned char*) msg, strlen(msg));
 
   // TODO: move all the 'waku_content_topic' logic inside the libwaku
-  WAKU_CALL( waku_content_topic(ctx,
-                                "appName",
-                                1,
-                                content_topic_name,
-                                "encoding",
-                                handle_content_topic,
-                                userData) );
+  WAKU_CALL( waku_content_topic(ctx, handle_content_topic, userData,
+                                &(WakuContentTopicReq){
+                                    .appName = "appName",
+                                    .appVersion = 1,
+                                    .contentTopicName = content_topic_name,
+                                    .encoding = "encoding"}) );
   snprintf(jsonWakuMsg,
            1024,
            "{\"payload\":\"%s\",\"content_topic\":\"%s\"}",
@@ -465,12 +484,11 @@ static napi_value WakuRelayPublish(napi_env env, napi_callback_info info) {
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
 
   // Perform the actual 'publish'
-  WAKU_CALL( waku_relay_publish(ctx,
-                                pubsub_topic,
-                                jsonWakuMsg,
-                                timeoutMs,
-                                handle_error,
-                                userData) );
+  WAKU_CALL( waku_relay_publish(ctx, handle_error, userData,
+                                &(WakuRelayPublishReq){
+                                    .pubSubTopic = pubsub_topic,
+                                    .jsonWakuMessage = jsonWakuMsg,
+                                    .timeoutMs = timeoutMs}) );
   free(pubsub_topic);
   free(content_topic_name);
 
@@ -551,7 +569,8 @@ static napi_value WakuRelaySubscribe(napi_env env, napi_callback_info info) {
   NAPI_CALL(napi_create_reference(env, cb, 1, &ref_on_error_callback));
 
   // Calling the actual 'subscribe' waku function
-  WAKU_CALL( waku_relay_subscribe(ctx, pubsub_topic, handle_error, userData) );
+  WAKU_CALL( waku_relay_subscribe(ctx, handle_error, userData,
+                                  &(WakuRelaySubscribeReq){.pubSubTopic = pubsub_topic}) );
 
   free(pubsub_topic);
 

--- a/examples/python/waku.py
+++ b/examples/python/waku.py
@@ -99,37 +99,33 @@ libwaku.logosdelivery_create_node.argtypes = [ctypes.POINTER(CreateNodeCtorReq),
                              ctypes.c_void_p]
 
 create_req = CreateNodeCtorReq(configJson=bytes(json_config, 'utf-8'))
+on_create_cb = reply_callback_type(
+    #onErrCb
+    lambda ret, reply, err, user_data:
+      print("Error calling logosdelivery_create_node: %s",
+            (err or b"").decode('utf-8')))
 ctx = libwaku.logosdelivery_create_node(ctypes.byref(create_req),
-                       reply_callback_type(
-                           #onErrCb
-                           lambda ret, reply, err, user_data:
-                             print("Error calling logosdelivery_create_node: %s",
-                                   (err or b"").decode('utf-8'))
-                           ),
-                           ctypes.c_void_p(0))
+                       on_create_cb,
+                       ctypes.c_void_p(0))
 
 # Retrieve the current version of the library
 libwaku.waku_version.argtypes = [ctypes.c_void_p,
                                  callback_type,
                                  ctypes.c_void_p]
-libwaku.waku_version(ctx,
-                     callback_type(lambda ret, msg, len, user_data:
-                                  print("Git Version: %s" %
-                                        msg.decode('utf-8'))),
-                     ctypes.c_void_p(0))
+on_version_cb = callback_type(lambda ret, msg, len, user_data:
+                              print("Git Version: %s" % msg.decode('utf-8')))
+libwaku.waku_version(ctx, on_version_cb, ctypes.c_void_p(0))
 
 # Retrieve the default pubsub topic
 default_pubsub_topic = ""
 libwaku.waku_default_pubsub_topic.argtypes = [ctypes.c_void_p,
                                  callback_type,
                                  ctypes.c_void_p]
-libwaku.waku_default_pubsub_topic(ctx,
-                                  callback_type(
-                                        lambda ret, msg, len, user_data: (
-                                            globals().update(default_pubsub_topic = msg.decode('utf-8')),
-                                            print("Default pubsub topic: %s" % msg.decode('utf-8')))
-                                  ),
-                                  ctypes.c_void_p(0))
+on_default_topic_cb = callback_type(
+    lambda ret, msg, len, user_data: (
+        globals().update(default_pubsub_topic = msg.decode('utf-8')),
+        print("Default pubsub topic: %s" % msg.decode('utf-8'))))
+libwaku.waku_default_pubsub_topic(ctx, on_default_topic_cb, ctypes.c_void_p(0))
 
 print("Bind addr: {}:{}".format(args.host, args.port))
 print("Waku Relay enabled: {}".format(args.relay))
@@ -153,11 +149,10 @@ for event_name in [b"onMessageSent", b"onMessageError", b"onMessagePropagated",
 libwaku.logosdelivery_start_node.argtypes = [ctypes.c_void_p,
                                callback_type,
                                ctypes.c_void_p]
-libwaku.logosdelivery_start_node(ctx,
-                   callback_type(lambda ret, msg, len, user_data:
-                                  print("Error in logosdelivery_start_node: %s" %
-                                        msg.decode('utf-8'))),
-                   ctypes.c_void_p(0))
+on_start_cb = callback_type(lambda ret, msg, len, user_data:
+                            print("Error in logosdelivery_start_node: %s" %
+                                  msg.decode('utf-8')))
+libwaku.logosdelivery_start_node(ctx, on_start_cb, ctypes.c_void_p(0))
 
 # Subscribe to the default pubsub topic
 libwaku.waku_relay_subscribe.argtypes = [ctypes.c_void_p,
@@ -165,14 +160,11 @@ libwaku.waku_relay_subscribe.argtypes = [ctypes.c_void_p,
                                          ctypes.c_void_p,
                                          ctypes.POINTER(RelaySubscribeReq)]
 subscribe_req = RelaySubscribeReq(pubSubTopic=default_pubsub_topic.encode('utf-8'))
-libwaku.waku_relay_subscribe(ctx,
-                             reply_callback_type(
-                                    #onErrCb
-                                    lambda ret, reply, err, user_data:
-                                        print("Error calling waku_relay_subscribe: %s" %
-                                                (err or b"").decode('utf-8'))
-                             ),
-                             ctypes.c_void_p(0),
+on_subscribe_cb = reply_callback_type(
+    #onErrCb
+    lambda ret, reply, err, user_data:
+        print("Error calling waku_relay_subscribe: %s" % (err or b"").decode('utf-8')))
+libwaku.waku_relay_subscribe(ctx, on_subscribe_cb, ctypes.c_void_p(0),
                              ctypes.byref(subscribe_req))
 
 libwaku.waku_connect.argtypes = [ctypes.c_void_p,
@@ -180,12 +172,11 @@ libwaku.waku_connect.argtypes = [ctypes.c_void_p,
                                  ctypes.c_void_p,
                                  ctypes.POINTER(ConnectReq)]
 connect_req = ConnectReq(peerMultiAddr=args.peer.encode('utf-8'), timeoutMs=10000)
-libwaku.waku_connect(ctx,
-                     # onErrCb
-                     reply_callback_type(
-                         lambda ret, reply, err, user_data:
-                           print("Error calling waku_connect: %s" % (err or b"").decode('utf-8'))),
-                     ctypes.c_void_p(0),
+on_connect_cb = reply_callback_type(
+    # onErrCb
+    lambda ret, reply, err, user_data:
+      print("Error calling waku_connect: %s" % (err or b"").decode('utf-8')))
+libwaku.waku_connect(ctx, on_connect_cb, ctypes.c_void_p(0),
                      ctypes.byref(connect_req))
 
 # app = Flask(__name__)

--- a/examples/python/waku.py
+++ b/examples/python/waku.py
@@ -28,7 +28,7 @@ contains the '{_lib_path}' library.
 """)
     exit(1)
 
-def handle_event(ret, msg, user_data):
+def handle_event(ret, msg, msg_len, user_data):
     print("Event received: %s" % msg)
 
 def call_waku(func):
@@ -66,20 +66,45 @@ json_config = "{ \
                   int(args.port),
                   args.key)
 
-callback_type = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t)
+# ctypes binds by name, so nothing here is checked against
+# library/generated/logosdelivery.h: a stale signature imports and runs, and
+# only misbehaves once it is called. Keep these in step with the header by hand.
+
+# LogosDeliveryScalarRawFn, and the FFICallback event-listener shape.
+callback_type = ctypes.CFUNCTYPE(
+    None, ctypes.c_int, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_void_p)
+
+# LogosDelivery*ReplyFn, and CreateRawFn: no length, and the failure text
+# arrives in its own argument.
+reply_callback_type = ctypes.CFUNCTYPE(
+    None, ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p)
+
+
+class CreateNodeCtorReq(ctypes.Structure):
+    _fields_ = [("configJson", ctypes.c_char_p)]
+
+
+class RelaySubscribeReq(ctypes.Structure):
+    _fields_ = [("pubSubTopic", ctypes.c_char_p)]
+
+
+class ConnectReq(ctypes.Structure):
+    _fields_ = [("peerMultiAddr", ctypes.c_char_p), ("timeoutMs", ctypes.c_uint32)]
+
 
 # Node creation
 libwaku.logosdelivery_create_node.restype = ctypes.c_void_p
-libwaku.logosdelivery_create_node.argtypes = [ctypes.c_char_p,
-                             callback_type,
+libwaku.logosdelivery_create_node.argtypes = [ctypes.POINTER(CreateNodeCtorReq),
+                             reply_callback_type,
                              ctypes.c_void_p]
 
-ctx = libwaku.logosdelivery_create_node(bytes(json_config, 'utf-8'),
-                       callback_type(
+create_req = CreateNodeCtorReq(configJson=bytes(json_config, 'utf-8'))
+ctx = libwaku.logosdelivery_create_node(ctypes.byref(create_req),
+                       reply_callback_type(
                            #onErrCb
-                           lambda ret, msg, len:
+                           lambda ret, reply, err, user_data:
                              print("Error calling logosdelivery_create_node: %s",
-                                   msg.decode('utf-8'))
+                                   (err or b"").decode('utf-8'))
                            ),
                            ctypes.c_void_p(0))
 
@@ -88,7 +113,7 @@ libwaku.waku_version.argtypes = [ctypes.c_void_p,
                                  callback_type,
                                  ctypes.c_void_p]
 libwaku.waku_version(ctx,
-                     callback_type(lambda ret, msg, len:
+                     callback_type(lambda ret, msg, len, user_data:
                                   print("Git Version: %s" %
                                         msg.decode('utf-8'))),
                      ctypes.c_void_p(0))
@@ -100,7 +125,7 @@ libwaku.waku_default_pubsub_topic.argtypes = [ctypes.c_void_p,
                                  ctypes.c_void_p]
 libwaku.waku_default_pubsub_topic(ctx,
                                   callback_type(
-                                        lambda ret, msg, len: (
+                                        lambda ret, msg, len, user_data: (
                                             globals().update(default_pubsub_topic = msg.decode('utf-8')),
                                             print("Default pubsub topic: %s" % msg.decode('utf-8')))
                                   ),
@@ -129,39 +154,39 @@ libwaku.logosdelivery_start_node.argtypes = [ctypes.c_void_p,
                                callback_type,
                                ctypes.c_void_p]
 libwaku.logosdelivery_start_node(ctx,
-                   callback_type(lambda ret, msg, len:
+                   callback_type(lambda ret, msg, len, user_data:
                                   print("Error in logosdelivery_start_node: %s" %
                                         msg.decode('utf-8'))),
                    ctypes.c_void_p(0))
 
 # Subscribe to the default pubsub topic
 libwaku.waku_relay_subscribe.argtypes = [ctypes.c_void_p,
-                                         callback_type,
+                                         reply_callback_type,
                                          ctypes.c_void_p,
-                                         ctypes.c_char_p]
+                                         ctypes.POINTER(RelaySubscribeReq)]
+subscribe_req = RelaySubscribeReq(pubSubTopic=default_pubsub_topic.encode('utf-8'))
 libwaku.waku_relay_subscribe(ctx,
-                             callback_type(
+                             reply_callback_type(
                                     #onErrCb
-                                    lambda ret, msg, len:
+                                    lambda ret, reply, err, user_data:
                                         print("Error calling waku_relay_subscribe: %s" %
-                                                msg.decode('utf-8'))
+                                                (err or b"").decode('utf-8'))
                              ),
                              ctypes.c_void_p(0),
-                             default_pubsub_topic.encode('utf-8'))
+                             ctypes.byref(subscribe_req))
 
 libwaku.waku_connect.argtypes = [ctypes.c_void_p,
-                                 callback_type,
+                                 reply_callback_type,
                                  ctypes.c_void_p,
-                                 ctypes.c_char_p,
-                                 ctypes.c_int]
+                                 ctypes.POINTER(ConnectReq)]
+connect_req = ConnectReq(peerMultiAddr=args.peer.encode('utf-8'), timeoutMs=10000)
 libwaku.waku_connect(ctx,
                      # onErrCb
-                     callback_type(
-                         lambda ret, msg, len:
-                           print("Error calling waku_connect: %s" % msg.decode('utf-8'))),
+                     reply_callback_type(
+                         lambda ret, reply, err, user_data:
+                           print("Error calling waku_connect: %s" % (err or b"").decode('utf-8'))),
                      ctypes.c_void_p(0),
-                     args.peer.encode('utf-8'),
-                     10000)
+                     ctypes.byref(connect_req))
 
 # app = Flask(__name__)
 # @app.route("/")

--- a/examples/qt/main_qt.cpp
+++ b/examples/qt/main_qt.cpp
@@ -4,7 +4,10 @@
 
 #include "waku_handler.h"
 
-void event_handler(int callerRet, const char* msg, size_t len, void* userData) {
+// LogosDeliveryCreateRawFn: node creation reports the context address, and any
+// failure text in its own argument.
+void event_handler(int errCode, const char* reply, const char* errMsg, void* userData) {
+    const char* msg = reply != nullptr ? reply : (errMsg != nullptr ? errMsg : "");
     printf("Receiving message %s\n", msg);
 }
 

--- a/examples/qt/waku_handler.h
+++ b/examples/qt/waku_handler.h
@@ -7,8 +7,14 @@
 class WakuHandler : public QObject {
     Q_OBJECT
 private:
+    // FFICallback shape.
     static void event_handler(int callerRet, const char* msg, size_t len, void* userData) {
         printf("Receiving message %s\n", msg);
+    }
+
+    // LogosDeliveryScalarRawFn: same reporting, non-const msg.
+    static void event_handler_raw(int callerRet, char* msg, size_t len, void* userData) {
+        event_handler(callerRet, msg, len, userData);
     }
 
     static void on_event_received(int callerRet, const char* msg, size_t len, void* userData) {
@@ -24,8 +30,10 @@ private:
 public:
     WakuHandler() : QObject(), ctx(nullptr) {}
 
-    void initialize(const QString& jsonConfig, WakuCallBack event_handler, void* userData) {
-        ctx = logosdelivery_create_node(jsonConfig.toUtf8().constData(), WakuCallBack(event_handler), userData);
+    void initialize(const QString& jsonConfig, LogosDeliveryCreateRawFn onCreated, void* userData) {
+        const QByteArray config = jsonConfig.toUtf8();
+        LogosdeliveryCreateNodeCtorReq createReq = {config.constData()};
+        ctx = logosdelivery_create_node(&createReq, onCreated, userData);
 
         for (const char *eventName :
              {"onMessageSent", "onMessageError", "onMessagePropagated",
@@ -39,7 +47,7 @@ public:
 
     Q_INVOKABLE void start() {
         if (ctx) {
-            logosdelivery_start_node(ctx, event_handler, nullptr);
+            logosdelivery_start_node(ctx, event_handler_raw, nullptr);
             qDebug() << "Waku start called with event_handler and userData.";
         } else {
             qDebug() << "Context is not initialized in start.";
@@ -48,7 +56,7 @@ public:
 
     Q_INVOKABLE void stop() {
         if (ctx) {
-            logosdelivery_stop_node(ctx, event_handler, nullptr);
+            logosdelivery_stop_node(ctx, event_handler_raw, nullptr);
             qDebug() << "Waku stop called with event_handler and userData.";
         } else {
             qDebug() << "Context is not initialized in stop.";

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -1,6 +1,6 @@
-use std::cell::OnceCell;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::{slice, thread, time};
 
 // These declarations are hand-written rather than generated from
@@ -93,6 +93,21 @@ where
     create_trampoline::<C>
 }
 
+/// The library answers on its own thread, so every call below has to wait for
+/// its reply before reading the result.
+fn wait_reply(rx: &Receiver<(i32, String)>, what: &str) -> String {
+    match rx.recv_timeout(time::Duration::from_secs(15)) {
+        Ok((_ret, data)) => data,
+        Err(err) => panic!("no reply from {what}: {err}"),
+    }
+}
+
+fn reply_sender(tx: Sender<(i32, String)>) -> impl FnMut(i32, &str) {
+    move |ret: i32, data: &str| {
+        let _ = tx.send((ret, data.to_string()));
+    }
+}
+
 fn main() {
     let config_json = "\
     { \
@@ -107,47 +122,47 @@ fn main() {
 
     unsafe {
         // Create the waku node
-        let closure = |ret: i32, data: &str| {
-            println!("Ret {ret}. logosdelivery_create_node closure called {data}");
-        };
+        let (tx, rx) = channel::<(i32, String)>();
+        let mut closure = reply_sender(tx);
         let cb = get_create_trampoline(&closure);
         let config_json_str = CString::new(config_json).unwrap();
         let req = LogosdeliveryCreateNodeCtorReq {
             config_json: config_json_str.as_ptr(),
         };
-        let ctx = logosdelivery_create_node(&req, cb, &closure as *const _ as *const c_void);
+        let ctx = logosdelivery_create_node(&req, cb, &mut closure as *mut _ as *const c_void);
+        println!(
+            "logosdelivery_create_node: {}",
+            wait_reply(&rx, "logosdelivery_create_node")
+        );
 
         // Extracting the current waku version
-        let version: OnceCell<String> = OnceCell::new();
-        let closure = |ret: i32, data: &str| {
-            println!("version_closure. Ret: {ret}. Data: {data}");
-            let _ = version.set(data.to_string());
-        };
+        let (tx, rx) = channel::<(i32, String)>();
+        let mut closure = reply_sender(tx);
         let cb = get_trampoline(&closure);
         // `ctx` is already the context pointer; taking its address passed a
         // pointer to the local instead, which the library rejected.
-        let _ret = waku_version(ctx, cb, &closure as *const _ as *const c_void);
+        let _ret = waku_version(ctx, cb, &mut closure as *mut _ as *const c_void);
+        let version = wait_reply(&rx, "waku_version");
 
         // Extracting the default pubsub topic
-        let default_pubsub_topic: OnceCell<String> = OnceCell::new();
-        let closure = |_ret: i32, data: &str| {
-            let _ = default_pubsub_topic.set(data.to_string());
-        };
+        let (tx, rx) = channel::<(i32, String)>();
+        let mut closure = reply_sender(tx);
         let cb = get_trampoline(&closure);
-        let _ret = waku_default_pubsub_topic(ctx, cb, &closure as *const _ as *const c_void);
+        let _ret = waku_default_pubsub_topic(ctx, cb, &mut closure as *mut _ as *const c_void);
+        let default_pubsub_topic = wait_reply(&rx, "waku_default_pubsub_topic");
 
-        println!("Version: {}", version.get_or_init(|| unreachable!()));
-        println!(
-            "Default pubsubTopic: {}",
-            default_pubsub_topic.get_or_init(|| unreachable!())
-        );
+        println!("Version: {version}");
+        println!("Default pubsubTopic: {default_pubsub_topic}");
 
         // Start the Waku node
-        let closure = |ret: i32, data: &str| {
-            println!("Ret {ret}. logosdelivery_start_node closure called {data}");
-        };
+        let (tx, rx) = channel::<(i32, String)>();
+        let mut closure = reply_sender(tx);
         let cb = get_trampoline(&closure);
-        let _ret = logosdelivery_start_node(ctx, cb, &closure as *const _ as *const c_void);
+        let _ret = logosdelivery_start_node(ctx, cb, &mut closure as *mut _ as *const c_void);
+        println!(
+            "logosdelivery_start_node: {}",
+            wait_reply(&rx, "logosdelivery_start_node")
+        );
     }
 
     loop {

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -3,29 +3,49 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 use std::{slice, thread, time};
 
-pub type FFICallBack = unsafe extern "C" fn(c_int, *const c_char, usize, *const c_void);
+// These declarations are hand-written rather than generated from
+// library/generated/logosdelivery.h, so nothing checks them against it: a stale
+// one compiles and links cleanly and only misbehaves at run time. Keep them in
+// step with the header by hand.
+
+/// LogosDeliveryScalarRawFn: `msg` is a byte run of `len` bytes.
+pub type ScalarRawFn = unsafe extern "C" fn(c_int, *mut c_char, usize, *const c_void);
+
+/// LogosDeliveryCreateRawFn: carries the context address, and the failure text
+/// in its own argument rather than in the payload.
+pub type CreateRawFn =
+    unsafe extern "C" fn(c_int, *const c_char, *const c_char, *const c_void);
+
+#[repr(C)]
+pub struct LogosdeliveryCreateNodeCtorReq {
+    pub config_json: *const c_char,
+}
 
 extern "C" {
     pub fn logosdelivery_create_node(
-        config_json: *const u8,
-        cb: FFICallBack,
+        req: *const LogosdeliveryCreateNodeCtorReq,
+        on_created: CreateRawFn,
         user_data: *const c_void,
     ) -> *mut c_void;
 
-    pub fn waku_version(ctx: *const c_void, cb: FFICallBack, user_data: *const c_void) -> c_int;
+    pub fn waku_version(ctx: *const c_void, cb: ScalarRawFn, user_data: *const c_void) -> c_int;
 
-    pub fn logosdelivery_start_node(ctx: *const c_void, cb: FFICallBack, user_data: *const c_void) -> c_int;
+    pub fn logosdelivery_start_node(
+        ctx: *const c_void,
+        cb: ScalarRawFn,
+        user_data: *const c_void,
+    ) -> c_int;
 
     pub fn waku_default_pubsub_topic(
         ctx: *mut c_void,
-        cb: FFICallBack,
+        cb: ScalarRawFn,
         user_data: *const c_void,
-    ) -> *mut c_void;
+    ) -> c_int;
 }
 
 pub unsafe extern "C" fn trampoline<C>(
     return_val: c_int,
-    buffer: *const c_char,
+    buffer: *mut c_char,
     buffer_len: usize,
     data: *const c_void,
 ) where
@@ -40,11 +60,37 @@ pub unsafe extern "C" fn trampoline<C>(
     closure(return_val, &buffer_utf8);
 }
 
-pub fn get_trampoline<C>(_closure: &C) -> FFICallBack
+pub fn get_trampoline<C>(_closure: &C) -> ScalarRawFn
 where
     C: FnMut(i32, &str),
 {
     trampoline::<C>
+}
+
+/// The create/reply shape has no length, so the payload is read as a C string.
+pub unsafe extern "C" fn create_trampoline<C>(
+    return_val: c_int,
+    reply: *const c_char,
+    err_msg: *const c_char,
+    data: *const c_void,
+) where
+    C: FnMut(i32, &str),
+{
+    let closure = &mut *(data as *mut C);
+    let text = if !reply.is_null() { reply } else { err_msg };
+    let owned = if text.is_null() {
+        String::new()
+    } else {
+        std::ffi::CStr::from_ptr(text).to_string_lossy().into_owned()
+    };
+    closure(return_val, &owned);
+}
+
+pub fn get_create_trampoline<C>(_closure: &C) -> CreateRawFn
+where
+    C: FnMut(i32, &str),
+{
+    create_trampoline::<C>
 }
 
 fn main() {
@@ -64,13 +110,12 @@ fn main() {
         let closure = |ret: i32, data: &str| {
             println!("Ret {ret}. logosdelivery_create_node closure called {data}");
         };
-        let cb = get_trampoline(&closure);
+        let cb = get_create_trampoline(&closure);
         let config_json_str = CString::new(config_json).unwrap();
-        let ctx = logosdelivery_create_node(
-            config_json_str.as_ptr() as *const u8,
-            cb,
-            &closure as *const _ as *const c_void,
-        );
+        let req = LogosdeliveryCreateNodeCtorReq {
+            config_json: config_json_str.as_ptr(),
+        };
+        let ctx = logosdelivery_create_node(&req, cb, &closure as *const _ as *const c_void);
 
         // Extracting the current waku version
         let version: OnceCell<String> = OnceCell::new();

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -124,11 +124,9 @@ fn main() {
             let _ = version.set(data.to_string());
         };
         let cb = get_trampoline(&closure);
-        let _ret = waku_version(
-            &ctx as *const _ as *const c_void,
-            cb,
-            &closure as *const _ as *const c_void,
-        );
+        // `ctx` is already the context pointer; taking its address passed a
+        // pointer to the local instead, which the library rejected.
+        let _ret = waku_version(ctx, cb, &closure as *const _ as *const c_void);
 
         // Extracting the default pubsub topic
         let default_pubsub_topic: OnceCell<String> = OnceCell::new();

--- a/library/examples/logosdelivery_example.c
+++ b/library/examples/logosdelivery_example.c
@@ -155,7 +155,7 @@ int main() {
     "}";
 
     printf("1. Creating node...\n");
-    CreateNodeCtorReq createReq = { .configJson = config };
+    LogosdeliveryCreateNodeCtorReq createReq = { .configJson = config };
     void *ctx = logosdelivery_create_node(&createReq, on_created, NULL);
     if (ctx == NULL) {
         printf("Failed to create node\n");
@@ -185,7 +185,7 @@ int main() {
 
     printf("\n4. Subscribing to content topic...\n");
     const char *contentTopic = "/example/1/chat/proto";
-    SubscribeReq subscribeReq = { .contentTopicStr = contentTopic };
+    LogosdeliverySubscribeReq subscribeReq = { .contentTopicStr = contentTopic };
     logosdelivery_subscribe(ctx, on_reply, (void *)"subscribe", &subscribeReq);
 
     // Wait for subscription
@@ -195,13 +195,13 @@ int main() {
     logosdelivery_get_available_node_info_ids(ctx, on_scalar, (void *)"get_available_node_info_ids");
 
     printf("\nRetrieving node info for a specific invalid ID...\n");
-    GetNodeInfoReq nodeInfoReq = { .nodeInfoId = "WrongNodeInfoId" };
+    LogosdeliveryGetNodeInfoReq nodeInfoReq = { .nodeInfoId = "WrongNodeInfoId" };
     logosdelivery_get_node_info(ctx, on_reply, (void *)"get_node_info", &nodeInfoReq);
 
     printf("\nRetrieving several node info for specific correct IDs...\n");
     const char *nodeInfoIds[] = {"Version", "MyMultiaddresses", "MyENR", "MyPeerId"};
     for (size_t i = 0; i < sizeof(nodeInfoIds) / sizeof(nodeInfoIds[0]); i++) {
-        GetNodeInfoReq req = { .nodeInfoId = nodeInfoIds[i] };
+        LogosdeliveryGetNodeInfoReq req = { .nodeInfoId = nodeInfoIds[i] };
         logosdelivery_get_node_info(ctx, on_reply, (void *)"get_node_info", &req);
     }
 
@@ -216,7 +216,7 @@ int main() {
         "\"payload\": \"SGVsbG8sIExvZ29zIE1lc3NhZ2luZyE=\","
         "\"ephemeral\": false"
     "}";
-    SendReq sendReq = { .messageJson = message };
+    LogosdeliverySendReq sendReq = { .messageJson = message };
     logosdelivery_send(ctx, on_reply, (void *)"send", &sendReq);
 
     // Poll for terminal message events (sent, error, or received) with timeout
@@ -233,7 +233,7 @@ int main() {
     }
 
     printf("\n7. Unsubscribing from content topic...\n");
-    UnsubscribeReq unsubscribeReq = { .contentTopicStr = contentTopic };
+    LogosdeliveryUnsubscribeReq unsubscribeReq = { .contentTopicStr = contentTopic };
     logosdelivery_unsubscribe(ctx, on_reply, (void *)"unsubscribe", &unsubscribeReq);
 
     sleep(1);


### PR DESCRIPTION
## Description

None of the FFI examples compiled. The generated surface moved to request
structs and split its callback into three shapes, and **nothing ever built any
of them**, so all ten drifted. CI's `examples` target only ever covered the Nim
examples (`example2 chat2 chat2bridge`).

Beyond not building, the C example passed a `(int, const char*, size_t, void*)`
handler into slots now typed `(int, const char*, const char*, void*)`, so
failure text was landing in the `len` argument. Splitting the handlers is what
makes errors reportable again, not just what silences the compiler.

Split out of #4200, which needs a buildable C example to demo segmented sends.

## Changes

| example | was | verified by |
|---|---|---|
| `examples/cbindings` | 11 errors | `make ffi-examples` |
| `examples/cpp` | 12 errors | `make ffi-examples` |
| `library/examples` | 12 errors | `make ffi-examples` |
| `examples/golang` | 26 errors | `go build` |
| `examples/nodejs` | 8 errors | `cc` against real `node_api.h` |
| `examples/mobile/android` | 8 errors | `cc` against real `jni.h` |
| `examples/ios` | 30 errors | `swiftc -typecheck` |
| `examples/rust` | compiled, wrong | `cargo build` |
| `examples/python` | n/a | inspection |
| `examples/qt` | referenced a deleted type | inspection (no Qt available) |

Recurring shapes: `event_handler` keeps the raw-scalar form; a new reply handler
serves the request-struct entry points; `create_node` gets its own, and takes
its request first. `logosdelivery_destroy` no longer takes a callback.

Two needed more than substitution. **Swift** bridges a String into a C parameter
but not into a struct field, so each request-struct site nests `withCString`.
**Qt** referenced `WakuCallBack`, a type the library no longer defines at all.

## The two nothing can guard

`examples/python` (ctypes) and `examples/rust` (hand-written `extern "C"`) bind
by name or re-declare, so a stale signature runs and only misbehaves when
called — Rust's linked cleanly against a header it disagreed with. Python's
`CFUNCTYPE` was missing `user_data` outright. Both now carry a comment saying
they are unguarded; only a runtime smoke test would catch the next drift.

## CI

New `ffi-examples` target, built by the existing `build` job on ubuntu-22.04 and
macos-15. That job already produces liblogosdelivery, so the cost is three
compiler invocations. Go/Node/Qt/iOS/Android would each need their own SDK; not
added here.

## Issue

closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)