### PR TITLE
fix(ci): do not treat a release candidate as a released version

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -32,10 +32,11 @@ jobs:
           # the moving `nightly` tag (auto-updated by the daily CI to point at
           # master HEAD), which would otherwise be picked as the nearest tag
           # and break the version-sort comparison below.
-          BASE_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          # `--exclude '*-rc*'` skips release candidates: v0.39.0-rc.1 precedes
+          # the 0.39.0 release, so it must not demand that version be in
+          # logos_delivery.nimble yet.
+          BASE_TAG=$(git describe --tags --abbrev=0 --match 'v*' --exclude '*-rc*' 2>/dev/null || echo "")
           BASE_TAG=${BASE_TAG#v}
-          # Compare on the base version, ignoring any -rc.N prerelease suffix.
-          BASE_TAG=${BASE_TAG%%-*}
           echo "logos_delivery.nimble version: ${NIMBLE_VERSION}"
           echo "ancestor git tag:    ${BASE_TAG:-<none>}"
           if [ -z "${BASE_TAG}" ]; then


### PR DESCRIPTION
## Description

`nimble-not-behind-tag` currently fails on every branch cut after `v0.39.0-rc.1`
— master included:

```
logos_delivery.nimble version: 0.38.1
ancestor git tag:    0.39.0
::error::logos_delivery.nimble version (0.38.1) is behind its ancestor git tag (v0.39.0).
```

There is no `v0.39.0` tag. `git describe` finds `v0.39.0-rc.1`, and the check
then stripped the prerelease suffix (`BASE_TAG=${BASE_TAG%%-*}`) and compared
against `0.39.0`. A release candidate *precedes* that release, so this demanded
a version bump that has not happened yet.

## Changes

Skip rc tags when looking for the ancestor tag, rather than flattening them onto
the release they lead up to:

```diff
-BASE_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+BASE_TAG=$(git describe --tags --abbrev=0 --match 'v*' --exclude '*-rc*' 2>/dev/null || echo "")
 BASE_TAG=${BASE_TAG#v}
-# Compare on the base version, ignoring any -rc.N prerelease suffix.
-BASE_TAG=${BASE_TAG%%-*}
```

The stripping line goes with it, since nothing reaches it any more.

Verified against the current tags:

| | result |
|---|---|
| `describe --match 'v*'` | `v0.39.0-rc.1` → compares as `0.39.0` → **fails** |
| `describe --match 'v*' --exclude '*-rc*'` | `v0.38.1` → matches `.nimble` → **passes** |

The exact `tag == nimble` guarantee at release time is unaffected; it lives in
`release-assets.yml`.

Found while it blocked #4210.

## Issue

closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)