### PR TITLE
chore: bump version to 0.39.0

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -4,7 +4,7 @@ import os
 mode = ScriptMode.Verbose
 
 ### Package
-version = "0.38.1"
+version = "0.39.0"
 author = "Status Research & Development GmbH"
 description = "Logos-delivery, Private P2P Messaging for Resource-Restricted Devices"
 license = "MIT or Apache License 2.0"


### PR DESCRIPTION
Iterates #4211

# Description

1. Bumped `logos_delivery.nimble` to `0.39.0`, the version `v0.39.0-rc.1` already claims. Until this lands, `nimble-not-behind-tag` fails on every branch rebased past that tag, and `release-assets` will refuse the final `v0.39.0`.

<details>
<summary>AI-made decisions</summary>

- Bump the file rather than relax the check (#4211): an rc tag on a commit whose nimble says `0.38.1` makes the Nix and lgpm builds report `0.38.1-<sha>` for a 0.39.0 candidate.
- rc.1 is left in place; tag `v0.39.0-rc.2` on this commit once merged.
- Not bumping master to `0.40.0` here. That belongs with the final tag.

</details>
