### PR TITLE
feat(examples): demo a segmented send from the C example

### DIFF
--- a/examples/cbindings/README.md
+++ b/examples/cbindings/README.md
@@ -12,7 +12,40 @@ This will create liblogosdelivery.so and cwaku_example binary within the build f
 1. Open terminal
 2. cd to nwaku root folder
 3. export LD_LIBRARY_PATH=build
-4. `./build/cwaku_example --host=0.0.0.0 --port=60001`
+4. `./build/cwaku_example -h 0.0.0.0 -p 60001`
 
-Use `./build/cwaku_example --help` to see some other options.
+Options are short flags: `-h <host> -p <tcp-port> -k <key> -r <relay> -a <peers>`.
+The discv5 UDP port is derived as `-p` + 1, so two local instances do not clash.
 
+## Menu option 4: a segmented send
+
+Option 4 sends a payload one byte past three whole segments over a reliable
+channel, so the segmentation layer has to split it into four.
+
+### Confirming the split
+
+Run one node, pick option 4, and count the distinct messages it put on the
+channel's content topic:
+
+```
+./build/cwaku_example -h 127.0.0.1 -p 60000 > run.log 2>&1
+# pick option 4, then:
+grep large-message run.log | grep -oE '0x[0-9a-f]{64}' | sort -u | wc -l
+```
+
+One send must yield `CHANNEL_DATA_SEGMENTS` (4) hashes. That is the whole point
+of the option: fewer means the payload was not split.
+
+### Two instances
+
+Start a second node on another port, then on the sender use option 2 with the
+receiver's `/ip4/.../tcp/<port>/p2p/<peer-id>` (printed at startup) before
+option 4. Each instance derives its own channel sender id from its TCP port,
+because SDS ignores messages whose sender id matches its own participant id.
+
+Observed so far: the four segments do reach the peer, which reports four
+`message_received` events carrying the `RELIABLE-CHANNEL-API/1` marker on the
+channel's content topic. Reassembly into a single `onChannelMessageReceived`
+has **not** been observed on the receiver in a local two-node run, with no
+error event and no output from the segmentation layer, so treat the receive
+half as unverified.

--- a/examples/cbindings/README.md
+++ b/examples/cbindings/README.md
@@ -36,16 +36,29 @@ grep large-message run.log | grep -oE '0x[0-9a-f]{64}' | sort -u | wc -l
 One send must yield `CHANNEL_DATA_SEGMENTS` (4) hashes. That is the whole point
 of the option: fewer means the payload was not split.
 
-### Two instances
+### Confirming the reassembly
 
-Start a second node on another port, then on the sender use option 2 with the
-receiver's `/ip4/.../tcp/<port>/p2p/<peer-id>` (printed at startup) before
-option 4. Each instance derives its own channel sender id from its TCP port,
-because SDS ignores messages whose sender id matches its own participant id.
+This needs two nodes, and each must run **from its own directory**:
 
-Observed so far: the four segments do reach the peer, which reports four
-`message_received` events carrying the `RELIABLE-CHANNEL-API/1` marker on the
-channel's content topic. Reassembly into a single `onChannelMessageReceived`
-has **not** been observed on the receiver in a local two-node run, with no
-error event and no output from the segmentation layer, so treat the receive
-half as unverified.
+```
+mkdir -p /tmp/nodeA /tmp/nodeB
+(cd /tmp/nodeB && <repo>/build/cwaku_example -h 127.0.0.1 -p 60141)
+(cd /tmp/nodeA && <repo>/build/cwaku_example -h 127.0.0.1 -p 60142)
+```
+
+On the sender, use option 2 with the receiver's
+`/ip4/.../tcp/<port>/p2p/<peer-id>` (printed at startup), then option 4. The
+receiver reports a single `onChannelMessageReceived` carrying the whole
+payload, not one event per segment.
+
+The separate directories matter. A node persists its SDS state in
+`store.sqlite3` in the working directory, and that state includes the message
+ids it has already seen. Two nodes started from the same directory share one
+store, so the receiver treats the sender's segments as duplicates it has
+already handled and drops all of them: four segments arrive, nothing is
+reassembled, and nothing is logged, because a duplicate is a silent outcome by
+design.
+
+For the same reason each send seeds its payload from the clock. An identical
+payload produces identical SDS message ids, so a receiver that saw the previous
+run would discard the next one as a replay.

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -211,6 +211,74 @@ void publish_message(const char *msg)
   WAKU_CALL(waku_relay_publish(ctx, reply_handler, userData, &publishReq));
 }
 
+// A reliable channel splits anything larger than one segment and reassembles
+// it on the far side. `segmentationSegmentSizeBytes` defaults to 102400 and the
+// wire header takes up to 128 of those, leaving 102272 bytes of payload per
+// segment once rounded down to the 64-byte alignment Reed-Solomon needs.
+#define CHANNEL_SEGMENT_PAYLOAD 102272
+#define CHANNEL_DATA_SEGMENTS 4
+
+static const char *kChannelId = "c-example-large";
+// A real node validates this: /<application>/<version>/<topic-name>/<encoding>.
+static const char *kChannelTopic = "/c-example/1/large-message/proto";
+
+void send_large_channel_message()
+{
+  LogosdeliveryChannelCreateReq createReq = {
+      .channelIdStr = kChannelId,
+      .contentTopicStr = kChannelTopic,
+      .senderIdStr = "c-example-sender"};
+  // Creating an existing channel fails, so only the first send sets it up.
+  static int channelReady = 0;
+  if (!channelReady)
+  {
+    WAKU_CALL(logosdelivery_channel_create(ctx, reply_handler, userData, &createReq));
+    channelReady = 1;
+  }
+
+  // One byte past three whole segments, so the payload needs a fourth.
+  const size_t payloadLen = (CHANNEL_DATA_SEGMENTS - 1) * CHANNEL_SEGMENT_PAYLOAD + 1;
+  unsigned char *payload = malloc(payloadLen);
+  if (payload == NULL)
+  {
+    printf("Could not allocate the payload\n");
+    return;
+  }
+  // A non-repeating pattern, so a mis-ordered reassembly cannot look correct.
+  for (size_t i = 0; i < payloadLen; i++)
+  {
+    payload[i] = (unsigned char)(i * 31 + (i / 251) * 7);
+  }
+
+  char *payloadB64 = b64_encode(payload, payloadLen);
+  free(payload);
+  if (payloadB64 == NULL)
+  {
+    printf("Could not base64-encode the payload\n");
+    return;
+  }
+
+  const size_t jsonLen = strlen(payloadB64) + 64;
+  char *messageJson = malloc(jsonLen);
+  if (messageJson == NULL)
+  {
+    free(payloadB64);
+    printf("Could not allocate the message\n");
+    return;
+  }
+  snprintf(messageJson, jsonLen, "{\"payload\":\"%s\",\"ephemeral\":false}", payloadB64);
+  free(payloadB64);
+
+  printf("Sending %zu bytes over channel '%s': expect %d segments on the wire,\n"
+         "and a single onChannelMessageReceived on any peer that reassembles it.\n",
+         payloadLen, kChannelId, CHANNEL_DATA_SEGMENTS);
+
+  LogosdeliveryChannelSendReq sendReq = {.channelIdStr = kChannelId,
+                                         .messageJson = messageJson};
+  WAKU_CALL(logosdelivery_channel_send(ctx, reply_handler, userData, &sendReq));
+  free(messageJson);
+}
+
 void show_help_and_exit()
 {
   printf("Wrong parameters\n");
@@ -236,7 +304,8 @@ enum PROGRAM_STATE
   MAIN_MENU,
   SUBSCRIBE_TOPIC_MENU,
   CONNECT_TO_OTHER_NODE_MENU,
-  PUBLISH_MESSAGE_MENU
+  PUBLISH_MESSAGE_MENU,
+  SEND_LARGE_CHANNEL_MESSAGE_MENU
 };
 
 enum PROGRAM_STATE current_state = MAIN_MENU;
@@ -247,6 +316,7 @@ void show_main_menu()
   printf("\t1.) Subscribe to topic\n");
   printf("\t2.) Connect to other node\n");
   printf("\t3.) Publish a message\n");
+  printf("\t4.) Send a large message over a reliable channel (segmented)\n");
 }
 
 void handle_user_input()
@@ -292,6 +362,13 @@ void handle_user_input()
 
     publish_message(msg);
 
+    show_main_menu();
+  }
+  break;
+
+  case SEND_LARGE_CHANNEL_MESSAGE_MENU:
+  {
+    send_large_channel_message();
     show_main_menu();
   }
   break;
@@ -347,7 +424,7 @@ int main(int argc, char **argv)
       "onConnectionStatusChange", "onTopicHealthChange",
       "onConnectionChange",       "onReceivedMessage",
       "onChannelMessageReceived", "onChannelMessageSent",
-      "onChannelMessageError"};
+      "onChannelMessageError",     "onChannelMessageLost"};
   for (size_t i = 0; i < sizeof(kEventNames) / sizeof(kEventNames[0]); i++)
     logosdelivery_add_event_listener(ctx, kEventNames[i], on_event_received, userData);
 

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -215,6 +215,18 @@ void publish_message(const char *msg)
 // it on the far side. `segmentationSegmentSizeBytes` defaults to 102400 and the
 // wire header takes up to 128 of those, leaving 102272 bytes of payload per
 // segment once rounded down to the 64-byte alignment Reed-Solomon needs.
+//
+// To check the split really happens, count the distinct messages this node put
+// on the channel's content topic; one send must produce CHANNEL_DATA_SEGMENTS
+// of them:
+//
+//   ./build/cwaku_example -h 127.0.0.1 -p 60000 2>&1 | tee run.log
+//   # pick option 4, then:
+//   grep large-message run.log | grep -oE '0x[0-9a-f]{64}' | sort -u | wc -l
+//
+// To check reassembly, run a second instance on another port, connect the two
+// (option 2) and send from one: the receiver reports a single
+// onChannelMessageReceived carrying the whole payload, not one per segment.
 #define CHANNEL_SEGMENT_PAYLOAD 102272
 #define CHANNEL_DATA_SEGMENTS 4
 

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdint.h>
+#include <time.h>
 #include <pthread.h>
 
 #include <sys/types.h>
@@ -252,9 +253,12 @@ void send_large_channel_message()
     return;
   }
   // A non-repeating pattern, so a mis-ordered reassembly cannot look correct.
+  // Seeded per send: an identical payload yields identical SDS message ids,
+  // which a peer that already saw them discards as duplicates.
+  const unsigned char seed = (unsigned char)time(NULL);
   for (size_t i = 0; i < payloadLen; i++)
   {
-    payload[i] = (unsigned char)(i * 31 + (i / 251) * 7);
+    payload[i] = (unsigned char)(i * 31 + (i / 251) * 7 + seed);
   }
 
   char *payloadB64 = b64_encode(payload, payloadLen);

--- a/examples/cbindings/waku_example.c
+++ b/examples/cbindings/waku_example.c
@@ -215,18 +215,7 @@ void publish_message(const char *msg)
 // it on the far side. `segmentationSegmentSizeBytes` defaults to 102400 and the
 // wire header takes up to 128 of those, leaving 102272 bytes of payload per
 // segment once rounded down to the 64-byte alignment Reed-Solomon needs.
-//
-// To check the split really happens, count the distinct messages this node put
-// on the channel's content topic; one send must produce CHANNEL_DATA_SEGMENTS
-// of them:
-//
-//   ./build/cwaku_example -h 127.0.0.1 -p 60000 2>&1 | tee run.log
-//   # pick option 4, then:
-//   grep large-message run.log | grep -oE '0x[0-9a-f]{64}' | sort -u | wc -l
-//
-// To check reassembly, run a second instance on another port, connect the two
-// (option 2) and send from one: the receiver reports a single
-// onChannelMessageReceived carrying the whole payload, not one per segment.
+// See README.md for how to confirm the split and the reassembly.
 #define CHANNEL_SEGMENT_PAYLOAD 102272
 #define CHANNEL_DATA_SEGMENTS 4
 
@@ -234,19 +223,25 @@ static const char *kChannelId = "c-example-large";
 // A real node validates this: /<application>/<version>/<topic-name>/<encoding>.
 static const char *kChannelTopic = "/c-example/1/large-message/proto";
 
+// Both ends need the channel: creating it subscribes to the content topic, so
+// a node that never calls this receives nothing. Done at startup rather than on
+// the first send, so an instance can be receive-only.
+void ensure_channel(const char *senderId)
+{
+  static int channelReady = 0;
+  if (channelReady)
+  {
+    return;
+  }
+  LogosdeliveryChannelCreateReq createReq = {.channelIdStr = kChannelId,
+                                             .contentTopicStr = kChannelTopic,
+                                             .senderIdStr = senderId};
+  WAKU_CALL(logosdelivery_channel_create(ctx, reply_handler, userData, &createReq));
+  channelReady = 1;
+}
+
 void send_large_channel_message()
 {
-  LogosdeliveryChannelCreateReq createReq = {
-      .channelIdStr = kChannelId,
-      .contentTopicStr = kChannelTopic,
-      .senderIdStr = "c-example-sender"};
-  // Creating an existing channel fails, so only the first send sets it up.
-  static int channelReady = 0;
-  if (!channelReady)
-  {
-    WAKU_CALL(logosdelivery_channel_create(ctx, reply_handler, userData, &createReq));
-    channelReady = 1;
-  }
 
   // One byte past three whole segments, so the payload needs a fourth.
   const size_t payloadLen = (CHANNEL_DATA_SEGMENTS - 1) * CHANNEL_SEGMENT_PAYLOAD + 1;
@@ -358,13 +353,19 @@ void handle_user_input()
   break;
 
   case CONNECT_TO_OTHER_NODE_MENU:
-    // printf("Connecting to a node. Please indicate the peer Multiaddress:\n");
-    // printf("e.g.: /ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmVFXtAfSj4EiR7mL2KvL4EE2wztuQgUSBoj2Jx2KeXFLN\n");
-    // char peerAddr[512];
-    // scanf("%511s", peerAddr);
-    // WAKU_CALL(waku_connect(ctx, peerAddr, 10000 /* timeoutMs */, event_handler, userData));
+  {
+    printf("Connecting to a node. Please indicate the peer Multiaddress:\n");
+    printf("e.g.: /ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmVFXtAfSj4EiR7mL2KvL4EE2wztuQgUSBoj2Jx2KeXFLN\n");
+    char peerAddr[512];
+    scanf("%511s", peerAddr);
+
+    WakuConnectReq connectReq = {.peerMultiAddr = peerAddr, .timeoutMs = 10000};
+    WAKU_CALL(waku_connect(ctx, reply_handler, userData, &connectReq));
+    printf("Connected\n");
+
     show_main_menu();
-    break;
+  }
+  break;
 
   case PUBLISH_MESSAGE_MENU:
   {
@@ -413,12 +414,15 @@ int main(int argc, char **argv)
                                         \"tcp-port\": %d,        \
                                         \"store\": %s,       \
                                         \"log-level\": \"DEBUG\", \
-                                        \"discv5-udp-port\": 9999 \
+                                        \"discv5-udp-port\": %d \
                                     } \
                                 }",
            cfgNode.host,
            cfgNode.port,
-           cfgNode.store ? "true" : "false");
+           cfgNode.store ? "true" : "false",
+           // Derived from the TCP port, so a second local instance does not
+           // fail to start with "Address already in use".
+           cfgNode.port + 1);
 
   LogosdeliveryCreateNodeCtorReq createReq = {.configJson = jsonConfig};
   ctx = logosdelivery_create_node(&createReq, create_handler, userData);
@@ -457,6 +461,12 @@ int main(int argc, char **argv)
   WAKU_CALL(waku_get_peerids_from_peerstore(ctx,
                                             event_handler,
                                             userData));
+
+  // Distinct per instance: SDS drops messages whose sender id matches its own
+  // participant id, so two local nodes sharing one id never see each other.
+  char senderId[64];
+  snprintf(senderId, sizeof(senderId), "c-example-%d", cfgNode.port);
+  ensure_channel(senderId);
 
   show_main_menu();
   while (1)


### PR DESCRIPTION
## Description

Adds a fourth menu option to `examples/cbindings` that sends a payload large
enough to force segmentation over a reliable channel, so the behaviour added in
#4200 can be observed end to end rather than only in unit tests.

Stacked on #4200: without real segmentation a large payload still goes out as a
single message, so the demo would prove nothing.

## Verified against a live node

The payload is one byte past three whole segments, so a fourth is required:

```
Sending 306817 bytes over channel 'c-example-large': expect 4 segments on the wire,
and a single onChannelMessageReceived on any peer that reassembles it.
```

Counting what actually reached the wire on the channel's content topic:

```
distinct message hashes for /c-example/1/large-message/proto: 4
```

Four segments, as predicted, each its own `WakuMessage`.

## Notes

- The content topic is `/c-example/1/large-message/proto`, not something
  shorter. A real node validates the structure and rejects anything that is not
  `/<application>/<version>/<topic-name>/<encoding>`. The channel unit tests
  never hit this because they install no `MessagingSubscribe` provider, so the
  subscription is deferred and never validated — worth knowing if you write
  another example.
- `CHANNEL_SEGMENT_PAYLOAD` (102272) is derived in a comment from the defaults:
  `segmentationSegmentSizeBytes` 102400, less the 128-byte wire header, rounded
  down to the 64-byte alignment Reed-Solomon needs. There is no FFI call to
  query it, so it is a constant; if the default segment size changes, this
  number moves with it.
- Registers `onChannelMessageLost` alongside the other channel events, so an
  inbound payload whose segment set expires or fails its integrity check is
  visible rather than silently absent.

## Issue

closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)