### PR TITLE
ci(release): attach release-assets packages to the GitHub release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -173,6 +173,12 @@ jobs:
           pattern: wakutools-*
           path: wakutools
           merge-multiple: true
+      - name: download packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: liblogosdelivery-*
+          path: packages
+          merge-multiple: true
 
       - name: prep variables
         id: vars
@@ -276,4 +282,4 @@ jobs:
 
           gh release create "$TAG" --prerelease ${TARGET} \
             --title "$TAG" --notes-file release_notes.md \
-            wakunode2/* wakutools/*
+            wakunode2/* wakutools/* packages/*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -274,12 +274,6 @@ jobs:
 
           TARGET=$([[ "$TAG" == "nightly" ]] && echo "--target ${{steps.vars.outputs.ref}}" || echo "")
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            # release-assets.yml created it first; add our files to it.
-            gh release edit "$TAG" --prerelease --title "$TAG" --notes-file release_notes.md
-            gh release upload "$TAG" wakunode2/* wakutools/* --clobber
-          else
-            gh release create "$TAG" --prerelease ${TARGET} \
-              --title "$TAG" --notes-file release_notes.md \
-              wakunode2/* wakutools/*
-          fi
+          gh release create "$TAG" --prerelease ${TARGET} \
+            --title "$TAG" --notes-file release_notes.md \
+            wakunode2/* wakutools/*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -274,6 +274,12 @@ jobs:
 
           TARGET=$([[ "$TAG" == "nightly" ]] && echo "--target ${{steps.vars.outputs.ref}}" || echo "")
 
-          gh release create "$TAG" --prerelease ${TARGET} \
-            --title "$TAG" --notes-file release_notes.md \
-            wakunode2/* wakutools/*
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            # release-assets.yml created it first; add our files to it.
+            gh release edit "$TAG" --prerelease --title "$TAG" --notes-file release_notes.md
+            gh release upload "$TAG" wakunode2/* wakutools/* --clobber
+          else
+            gh release create "$TAG" --prerelease ${TARGET} \
+              --title "$TAG" --notes-file release_notes.md \
+              wakunode2/* wakutools/*
+          fi

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           VERSION=${{ steps.version.outputs.version }}
 
-          NWAKU_ARTIFACT_NAME=$(echo "waku-${{matrix.arch}}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
+          NWAKU_ARTIFACT_NAME=$(echo "waku-${VERSION}-${{matrix.arch}}-${{runner.os}}.tar.gz" | tr "[:upper:]" "[:lower:]")
           echo "waku=${NWAKU_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
           if [[ "${{ runner.os }}" == "Linux" ]]; then
@@ -178,3 +178,51 @@ jobs:
           name: liblogosdelivery-${{ steps.version.outputs.version }}-${{ matrix.arch }}-${{ runner.os }}
           path: ${{ steps.vars.outputs.liblogosdelivery }}
           if-no-files-found: error
+
+  # Attach the built packages to the GitHub release for the tag. pre-release.yml
+  # creates the release for rc tags; for a final tag this job creates a draft so
+  # the release owner only has to add notes and publish.
+  attach-to-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-and-upload
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create the release if none exists yet
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release $TAG exists"
+            exit 0
+          fi
+          if [[ "$TAG" == *-* ]]; then
+            # pre-release.yml creates the rc release; wait for it rather than race.
+            for _ in $(seq 1 30); do
+              sleep 60
+              gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && exit 0
+            done
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --prerelease \
+              --title "$TAG" --notes "Release notes pending."
+          else
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --draft \
+              --title "$TAG" --notes "Release notes pending."
+          fi
+
+      - name: Upload packages to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ls -l dist
+          gh release upload "$TAG" dist/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -5,6 +5,14 @@ on:
     tags:
     - 'v*' # "e.g. v0.4"
 
+  # pre-release.yml calls this for rc tags and nightly, and attaches the
+  # packages to the release it creates.
+  workflow_call:
+    inputs:
+      called:
+        type: boolean
+        default: false
+
   workflow_dispatch:
 
 env:
@@ -18,6 +26,8 @@ jobs:
   # CI cannot reject/remove a tag, so we gate artifact build & upload on
   # this instead: a mismatched tag yields no released artifacts.
   verify-version:
+    # rc tags are built through pre-release.yml, see workflow_call above.
+    if: inputs.called || github.event_name != 'push' || !contains(github.ref_name, '-')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -179,11 +189,10 @@ jobs:
           path: ${{ steps.vars.outputs.liblogosdelivery }}
           if-no-files-found: error
 
-  # Attach the built packages to the GitHub release for the tag. pre-release.yml
-  # creates the rc release from the same push; a final release is created with
-  # `gh release create vX.Y.Z`, which pushes the tag and so exists before this runs.
+  # A final release is created with `gh release create vX.Y.Z`, which pushes
+  # the tag, so the release exists before this job runs.
   attach-to-release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ !inputs.called && startsWith(github.ref, 'refs/tags/') }}
     needs: build-and-upload
     runs-on: ubuntu-22.04
     permissions:
@@ -197,16 +206,6 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-
-      - name: Wait for the release
-        run: |
-          set -euo pipefail
-          for _ in $(seq 1 15); do
-            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && exit 0
-            sleep 60
-          done
-          echo "::error::No GitHub release for $TAG. Create it (gh release create $TAG) and re-run this workflow."
-          exit 1
 
       - name: Upload packages to the release
         run: |

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -180,14 +180,17 @@ jobs:
           if-no-files-found: error
 
   # Attach the built packages to the GitHub release for the tag. pre-release.yml
-  # creates the release for rc tags; for a final tag this job creates a draft so
-  # the release owner only has to add notes and publish.
+  # creates the rc release from the same push; a final release is created with
+  # `gh release create vX.Y.Z`, which pushes the tag and so exists before this runs.
   attach-to-release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build-and-upload
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Download packages
         uses: actions/download-artifact@v4
@@ -195,33 +198,17 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Create the release if none exists yet
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+      - name: Wait for the release
         run: |
           set -euo pipefail
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "release $TAG exists"
-            exit 0
-          fi
-          if [[ "$TAG" == *-* ]]; then
-            # pre-release.yml creates the rc release; wait for it rather than race.
-            for _ in $(seq 1 30); do
-              sleep 60
-              gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && exit 0
-            done
-            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --prerelease \
-              --title "$TAG" --notes "Release notes pending."
-          else
-            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --draft \
-              --title "$TAG" --notes "Release notes pending."
-          fi
+          for _ in $(seq 1 15); do
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && exit 0
+            sleep 60
+          done
+          echo "::error::No GitHub release for $TAG. Create it (gh release create $TAG) and re-run this workflow."
+          exit 1
 
       - name: Upload packages to the release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           ls -l dist


### PR DESCRIPTION
# Description

1. `release-assets.yml` attaches the packages it builds to the GitHub release for the tag. Until now they stayed as run artifacts, so every 2026 release shipped without binaries unless someone re-uploaded them by hand.
2. Made `release-assets.yml` reusable and called it from `pre-release.yml` for rc tags and nightly. The release job `needs` that call, so the rc release is created once with node tarballs and liblogosdelivery packages together. The push trigger skips rc tags.
3. A final tag runs `release-assets.yml` on its own and uploads to the existing release. Create it with `gh release create vX.Y.Z`, which pushes the tag.
4. Node tarball name now carries the tag, like the liblogosdelivery packages.

<details>
<summary>AI-made decisions</summary>

- First two commits created the release when missing, then polled for it. Both replaced by the `workflow_call` dependency; squash on merge.
- Nightly now builds liblogosdelivery too. Its deb version is `0.0.0~master` and the artifact name says `master`, not `nightly`; left as is.
- rc and nightly get only `liblogosdelivery-*`. The node tarball from `release-assets.yml` duplicates the one `pre-release.yml` builds, so it stays on final releases only.
- `prepare_release.md` still says tag first, then create the release. Should say `gh release create vX.Y.Z`; follow-up.

</details>
