### PR TITLE
test: resolve the relay tests (migration 4)

### DIFF
--- a/tests-e2e/tests/rest/relay/test_multiple_nodes.py
+++ b/tests-e2e/tests/rest/relay/test_multiple_nodes.py
@@ -7,3 +7,17 @@ class TestRelayMultipleNodes(StepsRelay):
     @pytest.mark.smoke
     def test_first_node_to_start_publishes(self, subscribe_optional_relay_nodes, relay_warm_up):
         self.check_published_message_reaches_relay_peer()
+
+    def test_last_node_to_start_publishes(self, subscribe_optional_relay_nodes, relay_warm_up):
+        self.check_published_message_reaches_relay_peer(sender=self.optional_nodes[-1])
+
+    def test_relay_get_message_while_one_peer_is_paused(self, subscribe_optional_relay_nodes, relay_warm_up):
+        self.check_published_message_reaches_relay_peer()
+        relay_message1 = self.create_message(contentTopic=self.test_content_topic)
+        relay_message2 = self.create_message(contentTopic=self.test_content_topic)
+        self.node2.pause()
+        self.node1.send_relay_message(relay_message1, self.test_pubsub_topic)
+        self.node2.unpause()
+        self.node1.send_relay_message(relay_message2, self.test_pubsub_topic)
+        messages = self.node2.get_relay_messages(self.test_pubsub_topic)
+        assert len(messages) == 2, "Both messages should've been returned"

--- a/tests-e2e/tests/rest/relay/test_publish.py
+++ b/tests-e2e/tests/rest/relay/test_publish.py
@@ -1,0 +1,29 @@
+import pytest
+from time import time
+from src.libs.common import delay, to_base64
+from src.steps.relay import StepsRelay
+
+
+@pytest.mark.usefixtures("setup_main_relay_nodes", "subscribe_main_relay_nodes", "relay_warm_up")
+class TestRelayPublish(StepsRelay):
+    def test_publish_after_node2_restarts(self):
+        self.check_published_message_reaches_relay_peer()
+        self.node2.restart()
+        self.node2.ensure_ready()
+        self.ensure_relay_subscriptions_on_nodes(self.main_nodes, [self.test_pubsub_topic])
+        self.wait_for_published_message_to_reach_relay_peer()
+
+    def test_publish_and_retrieve_100_messages(self):
+        num_messages = 100  # if increase this number make sure to also increase rest-relay-cache-capacity flag
+        for index in range(num_messages):
+            message = self.create_message(payload=to_base64(f"M_{index}"))
+            self.node1.send_relay_message(message, self.test_pubsub_topic)
+        messages = []
+        deadline = time() + 10
+        while len(messages) < num_messages and time() < deadline:
+            messages.extend(self.node2.get_relay_messages(self.test_pubsub_topic))
+            delay(0.1)
+        assert len(messages) == num_messages
+        received_payloads = {message["payload"] for message in messages}
+        expected_payloads = {to_base64(f"M_{index}") for index in range(num_messages)}
+        assert received_payloads == expected_payloads

--- a/tests/testlib/rest_requests.nim
+++ b/tests/testlib/rest_requests.nim
@@ -1,0 +1,54 @@
+import stew/byteutils, presto, presto/client as presto_client
+import logos_delivery/waku/rest_api/endpoint/server
+
+type TestResponseTuple* = tuple[status: int, data: string, headers: HttpTable]
+
+proc fetchWithHeader*(
+    request: HttpClientRequestRef
+): Future[TestResponseTuple] {.async: (raises: [CancelledError, HttpError]).} =
+  var response: HttpClientResponseRef
+  try:
+    response = await request.send()
+    let buffer = await response.getBodyBytes()
+    let status = response.status
+    let headers = response.headers
+    await response.closeWait()
+    response = nil
+    return (status, buffer.bytesToString(), headers)
+  except HttpError as exc:
+    if not (isNil(response)):
+      await response.closeWait()
+    assert false
+  except CancelledError as exc:
+    if not (isNil(response)):
+      await response.closeWait()
+    assert false
+
+proc getAddress*(restServer: WakuRestServerRef, path: string): HttpAddress =
+  getAddress(restServer.localAddress(), HttpClientScheme.NonSecure, path)
+
+proc issueRequest*(
+    address: HttpAddress,
+    meth = MethodGet,
+    headers: seq[HttpHeaderTuple] = @[],
+    body = "",
+): Future[TestResponseTuple] {.async.} =
+  ## Sends the body as given, so an invalid one reaches the handler.
+  var
+    session = HttpSessionRef.new({HttpClientFlag.Http11Pipeline})
+    data: TestResponseTuple
+
+  var request = HttpClientRequestRef.new(
+    session,
+    address,
+    meth,
+    version = HttpVersion11,
+    headers = headers,
+    body = body.toBytes(),
+  )
+  try:
+    data = await request.fetchWithHeader()
+  finally:
+    await request.closeWait()
+    await session.closeWait()
+  return data

--- a/tests/testlib/testasync.nim
+++ b/tests/testlib/testasync.nim
@@ -1,5 +1,8 @@
-# Sourced from: vendor/nim-libp2p/tests/testutils.nim
+# Sourced from: nim-libp2p/tests/tools/unittest.nim
 # Adds the ability for asyncSetup and asyncTeardown to be used in unittest2
+
+import std/macros
+import chronos, testutils/unittests
 
 template asyncTeardown*(body: untyped): untyped =
   teardown:
@@ -18,3 +21,55 @@ template asyncSetup*(body: untyped): untyped =
           body
       )()
     )
+
+const
+  timeoutDefault: Duration = 10.seconds
+  sleepIntervalDefault: Duration = 100.milliseconds
+
+proc buildAndExpr(n: NimNode): NimNode =
+  # Helper proc to recursively build a combined boolean expression
+
+  if n.kind == nnkStmtList and n.len > 0:
+    var combinedExpr = n[0] # Start with the first expression
+    for i in 1 ..< n.len:
+      # Combine the current expression with the next using 'and'
+      combinedExpr = newCall("and", combinedExpr, n[i])
+    return combinedExpr
+  else:
+    return n
+
+macro checkUntilTimeoutCustom*(
+    timeout: Duration, sleepInterval: Duration, code: untyped
+): untyped =
+  ## Periodically checks a given condition until it is true or a timeout occurs.
+  ##
+  ## `code`: untyped - A condition expression that should eventually evaluate to true.
+  ## `timeout`: Duration - The maximum duration to wait for the condition to be true.
+
+  # Build the combined expression
+  let combinedBoolExpr = buildAndExpr(code)
+
+  quote:
+    proc checkExpiringInternal(): Future[void] {.gensym, async.} =
+      let start = Moment.now()
+      while true:
+        if Moment.now() > (start + `timeout`):
+          checkpoint(
+            "[TIMEOUT] Timeout was reached and the conditions were not true. Check if the code is working as " &
+              "expected or consider increasing the timeout param."
+          )
+          check `code`
+          return
+        else:
+          if `combinedBoolExpr`:
+            return
+          else:
+            await sleepAsync(`sleepInterval`)
+
+    await checkExpiringInternal()
+
+macro checkUntilTimeout*(code: untyped): untyped =
+  ## Same as `checkUntilTimeoutCustom` but with a default timeout of 10s with 100ms
+  ## interval.
+  quote:
+    checkUntilTimeoutCustom(timeoutDefault, sleepIntervalDefault, `code`)

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -1235,6 +1235,55 @@ suite "Waku Relay":
       # Finally stop the other node
       await allFutures(otherSwitch.stop(), otherNode.stop())
 
+    asyncTest "Publishing the same message twice delivers it to the peer once":
+      # Given a second node connected to the first one
+      let
+        otherSwitch = newTestSwitch()
+        otherNode = await newTestWakuRelay(otherSwitch)
+
+      await allFutures(otherSwitch.start(), otherNode.start())
+      defer:
+        await allFutures(otherSwitch.stop(), otherNode.stop())
+      let otherRemotePeerInfo = otherSwitch.peerInfo.toRemotePeerInfo()
+      check await peerManager.connectPeer(otherRemotePeerInfo)
+
+      # Given both are subscribed to the same pubsub topic
+      var otherHandlerFuture = newPushHandlerFuture()
+      var otherMessageSeq: seq[(PubsubTopic, WakuMessage)] = @[]
+      proc otherSimpleFutureHandler(
+          topic: PubsubTopic, message: WakuMessage
+      ) {.async, gcsafe.} =
+        otherMessageSeq.add((topic, message))
+        otherHandlerFuture.complete((topic, message))
+
+      node.subscribe(pubsubTopic, simpleFutureHandler)
+      otherNode.subscribe(pubsubTopic, otherSimpleFutureHandler)
+      check:
+        node.subscribedTopics == pubsubTopicSeq
+        otherNode.subscribedTopics == pubsubTopicSeq
+      await sleepAsync(500.millis)
+
+      # When the same message is published twice
+      let msg = fakeWakuMessage("msg", pubsubTopic)
+      let firstPublish = await node.publish(pubsubTopic, msg)
+      check:
+        firstPublish.isOk()
+        await handlerFuture.withTimeout(FUTURE_TIMEOUT)
+        await otherHandlerFuture.withTimeout(FUTURE_TIMEOUT)
+
+      handlerFuture = newPushHandlerFuture()
+      otherHandlerFuture = newPushHandlerFuture()
+      let secondPublish = await node.publish(pubsubTopic, msg)
+
+      # Then the second publish fails with NoPeersToPublish, the publishing
+      # node's handler still runs and the peer receives a single copy
+      check:
+        secondPublish.isErr() and secondPublish.error == PublishOutcome.NoPeersToPublish
+        await handlerFuture.withTimeout(FUTURE_TIMEOUT)
+        not (await otherHandlerFuture.withTimeout(FUTURE_TIMEOUT))
+        messageSeq == @[(pubsubTopic, msg), (pubsubTopic, msg)]
+        otherMessageSeq == @[(pubsubTopic, msg)]
+
   suite "Security and Privacy":
     asyncTest "Relay can't receive messages after subscribing and stopping without unsubscribing":
       # Given a second node connected to the first one

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -27,15 +27,10 @@ proc hasMeshPeer(relay: WakuRelay, topic: PubsubTopic, peer: PeerId): bool =
       return true
   false
 
-proc waitForMeshPeer(
-    relay: WakuRelay, topic: PubsubTopic, peer: PeerId, timeout = 10.seconds
-): Future[bool] {.async.} =
-  ## Wait until `relay`'s gossipsub mesh for `topic` has GRAFTed `peer`.
-  let deadline = Moment.now() + timeout
-  while Moment.now() < deadline:
-    if relay.hasMeshPeer(topic, peer):
+proc hasGossipsubPeer(relay: WakuRelay, topic: PubsubTopic, peer: PeerId): bool =
+  for p in relay.gossipsub.getOrDefault(topic):
+    if p.peerId == peer:
       return true
-    await sleepAsync(50.milliseconds)
   false
 
 suite "Waku Relay":
@@ -138,7 +133,8 @@ suite "Waku Relay":
         otherNode.isSubscribed(pubsubTopic)
         otherNode.subscribedTopics == pubsubTopicSeq
 
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasGossipsubPeer(pubsubTopic, otherRemotePeerInfo.peerId)
 
       # When publishing a message in the subscribed node
       let fromOtherWakuMessage = fakeWakuMessage("fromOther")
@@ -200,7 +196,9 @@ suite "Waku Relay":
         otherNode.isSubscribed(pubsubTopic)
         otherNode.subscribedTopics == pubsubTopicSeq
 
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # When publishing a message in node
       let fromOtherWakuMessage = fakeWakuMessage("fromOther")
@@ -310,14 +308,17 @@ suite "Waku Relay":
 
       otherNode.addValidator(len4Validator)
       otherNode.subscribe(pubsubTopic, otherSimpleFutureHandler)
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasGossipsubPeer(pubsubTopic, otherRemotePeerInfo.peerId)
       check:
         otherNode.isSubscribed(pubsubTopic)
 
       # Given a subscribed node with a validator
       node.addValidator(len4Validator)
       node.subscribe(pubsubTopic, simpleFutureHandler)
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
       check:
         node.isSubscribed(pubsubTopic)
         node.subscribedTopics == pubsubTopicSeq
@@ -406,7 +407,9 @@ suite "Waku Relay":
         otherNode.isSubscribed(pubsubTopic)
         otherNode.subscribedTopics == pubsubTopicSeq
 
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # Given some crypto info
       var key = "My fancy key"
@@ -514,7 +517,11 @@ suite "Waku Relay":
       otherNode.subscribe(pubsubTopicC, otherSimpleFutureHandler2)
       anotherNode.subscribe(pubsubTopicB, anotherSimpleFutureHandler1)
       anotherNode.subscribe(pubsubTopicC, anotherSimpleFutureHandler2)
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherPeerId)
+        node.hasMeshPeer(pubsubTopicB, anotherPeerId)
+        node.hasGossipsubPeer(pubsubTopicC, otherPeerId)
+        node.hasGossipsubPeer(pubsubTopicC, anotherPeerId)
 
       # When publishing a message in node for each of the pubsub topics
       let
@@ -695,9 +702,9 @@ suite "Waku Relay":
         otherPeerManager.switch.isConnected(anotherPeerId)
 
       # Wait for the mesh to re-form before publishing (else it races the 1s FUTURE_TIMEOUT).
-      check:
-        await otherNode.waitForMeshPeer(pubsubTopicC, anotherPeerId)
-        await anotherNode.waitForMeshPeer(pubsubTopicC, otherPeerId)
+      checkUntilTimeout:
+        otherNode.hasMeshPeer(pubsubTopicC, anotherPeerId)
+        anotherNode.hasMeshPeer(pubsubTopicC, otherPeerId)
 
       # When publishing a message in anotherNode for each of the pubsub topics
       handlerFuture = newPushHandlerFuture()
@@ -881,7 +888,9 @@ suite "Waku Relay":
         node.subscribedTopics == pubsubTopicSeq
         otherNode.subscribedTopics == pubsubTopicSeq
 
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # Given some payloads
       let
@@ -1047,7 +1056,9 @@ suite "Waku Relay":
         node.subscribedTopics == pubsubTopicSeq
         otherNode.subscribedTopics == pubsubTopicSeq
 
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # Given some valid payloads
       let
@@ -1188,7 +1199,9 @@ suite "Waku Relay":
       check:
         node.subscribedTopics == pubsubTopicSeq
         otherNode.subscribedTopics == pubsubTopicSeq
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # When sending multiple messages from node
       let
@@ -1261,7 +1274,9 @@ suite "Waku Relay":
       check:
         node.subscribedTopics == pubsubTopicSeq
         otherNode.subscribedTopics == pubsubTopicSeq
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherRemotePeerInfo.peerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # When the same message is published twice
       let msg = fakeWakuMessage("msg", pubsubTopic)
@@ -1312,7 +1327,9 @@ suite "Waku Relay":
         node.subscribedTopics == pubsubTopicSeq
         otherNode.subscribedTopics == pubsubTopicSeq
 
-      await sleepAsync(500.millis)
+      checkUntilTimeout:
+        node.hasMeshPeer(pubsubTopic, otherPeerId)
+        otherNode.hasMeshPeer(pubsubTopic, peerId)
 
       # Given other node is stopped without unsubscribing
       await allFutures(otherSwitch.stop(), otherNode.stop())

--- a/tests/wakunode_rest/test_rest_cors.nim
+++ b/tests/wakunode_rest/test_rest_cors.nim
@@ -15,61 +15,20 @@ import
     rest_api/endpoint/server,
     rest_api/endpoint/debug/handlers as debug_rest_interface,
   ],
-  ../testlib/common,
   ../testlib/wakucore,
-  ../testlib/wakunode
+  ../testlib/wakunode,
+  ../testlib/rest_requests
 
-type TestResponseTuple = tuple[status: int, data: string, headers: HttpTable]
+const OriginHeader = "Origin"
 
 proc testWakuNode(): WakuNode =
   let
-    privkey = crypto.PrivateKey.random(Secp256k1, rng).tryGet()
+    privkey = generateSecp256k1Key()
     bindIp = parseIpAddress("0.0.0.0")
     extIp = parseIpAddress("127.0.0.1")
     port = Port(0)
 
   newTestWakuNode(privkey, bindIp, port, Opt.some(extIp), Opt.some(port))
-
-proc fetchWithHeader(
-    request: HttpClientRequestRef
-): Future[TestResponseTuple] {.async: (raises: [CancelledError, HttpError]).} =
-  var response: HttpClientResponseRef
-  try:
-    response = await request.send()
-    let buffer = await response.getBodyBytes()
-    let status = response.status
-    let headers = response.headers
-    await response.closeWait()
-    response = nil
-    return (status, buffer.bytesToString(), headers)
-  except HttpError as exc:
-    if not (isNil(response)):
-      await response.closeWait()
-    assert false
-  except CancelledError as exc:
-    if not (isNil(response)):
-      await response.closeWait()
-    assert false
-
-proc issueRequest(
-    address: HttpAddress, reqOrigin: Opt[string] = Opt.none(string)
-): Future[TestResponseTuple] {.async.} =
-  var
-    session = HttpSessionRef.new({HttpClientFlag.Http11Pipeline})
-    data: TestResponseTuple
-
-  var originHeader: seq[HttpHeaderTuple]
-  if reqOrigin.isSome():
-    originHeader.insert(("Origin", reqOrigin.get()))
-
-  var request = HttpClientRequestRef.new(
-    session, address, version = HttpVersion11, headers = originHeader
-  )
-  try:
-    data = await request.fetchWithHeader()
-  finally:
-    await request.closeWait()
-  return data
 
 proc checkResponse(
     response: TestResponseTuple, expectedStatus: int, expectedOrigin: Opt[string]
@@ -125,28 +84,36 @@ suite "Waku v2 REST API CORS Handling":
     let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
 
     # When
-    var response = await issueRequest(ha, Opt.some("http://test.net:1234"))
+    var response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://test.net:1234")])
     check checkResponse(response, 200, Opt.some("http://test.net:1234"))
 
-    response = await issueRequest(ha, Opt.some("https://test.net:1234"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://test.net:1234")])
     check checkResponse(response, 200, Opt.some("https://test.net:1234"))
 
-    response = await issueRequest(ha, Opt.some("https://localhost:8080"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://localhost:8080")])
     check checkResponse(response, 200, Opt.some("https://localhost:8080"))
 
-    response = await issueRequest(ha, Opt.some("https://localhost:80"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://localhost:80")])
     check checkResponse(response, 200, Opt.some("https://localhost:80"))
 
-    response = await issueRequest(ha, Opt.some("http://127.0.0.1:78"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://127.0.0.1:78")])
     check checkResponse(response, 200, Opt.some("http://127.0.0.1:78"))
 
-    response = await issueRequest(ha, Opt.some("http://wakuTHE.net:8078"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://wakuTHE.net:8078")])
     check checkResponse(response, 200, Opt.some("http://wakuTHE.net:8078"))
 
-    response = await issueRequest(ha, Opt.some("http://nwaku.main.net:1980"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://nwaku.main.net:1980")])
     check checkResponse(response, 200, Opt.some("http://nwaku.main.net:1980"))
 
-    response = await issueRequest(ha, Opt.some("http://nwaku.main.net:80"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://nwaku.main.net:80")])
     check checkResponse(response, 200, Opt.some("http://nwaku.main.net:80"))
 
     await restServer.stop()
@@ -180,31 +147,40 @@ suite "Waku v2 REST API CORS Handling":
     let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
 
     # When
-    var response = await issueRequest(ha, Opt.some("http://test.net:12334"))
+    var response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://test.net:12334")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("http://test.net:12345"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://test.net:12345")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("xhttp://test.net:1234"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "xhttp://test.net:1234")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("https://xtest.net:1234"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://xtest.net:1234")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("http://localhost:8080"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://localhost:8080")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("https://127.0.0.1:78"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://127.0.0.1:78")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("http://127.0.0.1:89"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://127.0.0.1:89")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("http://the.waku.net:8078"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://the.waku.net:8078")])
     check checkResponse(response, 403, Opt.none(string))
 
-    response = await issueRequest(ha, Opt.some("http://nwaku.main.net:1900"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://nwaku.main.net:1900")])
     check checkResponse(response, 403, Opt.none(string))
 
     await restServer.stop()
@@ -232,28 +208,36 @@ suite "Waku v2 REST API CORS Handling":
     let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
 
     # When
-    var response = await issueRequest(ha, Opt.some("http://test.net:1234"))
+    var response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://test.net:1234")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("https://test.net:1234"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://test.net:1234")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("https://localhost:8080"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://localhost:8080")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("https://localhost:80"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "https://localhost:80")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("http://127.0.0.1:78"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://127.0.0.1:78")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("http://wakuTHE.net:8078"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://wakuTHE.net:8078")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("http://nwaku.main.net:1980"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://nwaku.main.net:1980")])
     check checkResponse(response, 200, Opt.some("*"))
 
-    response = await issueRequest(ha, Opt.some("http://nwaku.main.net:80"))
+    response =
+      await issueRequest(ha, headers = @[(OriginHeader, "http://nwaku.main.net:80")])
     check checkResponse(response, 200, Opt.some("*"))
 
     await restServer.stop()
@@ -287,7 +271,7 @@ suite "Waku v2 REST API CORS Handling":
     let ha = getAddress(srvAddr, HttpClientScheme.NonSecure, "/debug/v1/info")
 
     # When
-    var response = await issueRequest(ha, Opt.none(string))
+    var response = await issueRequest(ha)
     check checkResponse(response, 200, Opt.none(string))
 
     await restServer.stop()

--- a/tests/wakunode_rest/test_rest_relay.nim
+++ b/tests/wakunode_rest/test_rest_relay.nim
@@ -2,7 +2,7 @@
 
 import
   results,
-  std/[sequtils, strformat, strutils, tempfiles, osproc],
+  std/[json, sequtils, sets, strformat, strutils, tempfiles, osproc, uri],
   stew/byteutils,
   testutils/unittests,
   presto,
@@ -26,6 +26,8 @@ import
   ],
   ../testlib/wakucore,
   ../testlib/wakunode,
+  ../testlib/futures,
+  ../testlib/rest_requests,
   ../resources/payloads,
   ../waku_rln_relay/[rln/waku_rln_relay_utils, utils_onchain]
 
@@ -37,6 +39,33 @@ proc testWakuNode(): WakuNode =
     port = Port(0)
 
   newTestWakuNode(privkey, bindIp, port, Opt.some(extIp), Opt.some(port))
+
+proc waitForTopicPeer(
+    node: WakuNode, topic: PubsubTopic, peer: PeerId, timeout = FUTURE_TIMEOUT_LONG
+) {.async.} =
+  ## Waits until node's gossipsub has learnt that peer subscribes to topic.
+  let deadline = Moment.now() + timeout
+  while Moment.now() < deadline:
+    for p in node.wakuRelay.gossipsub.getOrDefault(topic):
+      if p.peerId == peer:
+        return
+    await sleepAsync(10.milliseconds)
+  raiseAssert $peer & " never announced a subscription to " & topic
+
+proc waitForRelayMessages(
+    client: RestClientRef,
+    pubsubTopic: PubsubTopic,
+    count: int,
+    timeout = FUTURE_TIMEOUT_MEDIUM,
+): Future[seq[RelayWakuMessage]] {.async.} =
+  ## Each GET clears the cache, so the messages of every poll are collected.
+  var messages: seq[RelayWakuMessage]
+  let deadline = Moment.now() + timeout
+  while messages.len < count and Moment.now() < deadline:
+    let response = await client.relayGetMessagesV1(pubsubTopic)
+    messages.add(response.data)
+    await sleepAsync(50.milliseconds)
+  return messages
 
 suite "Waku v2 Rest API - Relay":
   var anvilProc {.threadVar.}: Process
@@ -1034,3 +1063,276 @@ suite "Waku v2 Rest API - Relay":
     await restServer.stop()
     await restServer.closeWait()
     await allFutures(node.stop(), meshNode.stop())
+
+  asyncTest "A message published on one node is read back on its relay peer - POST /relay/v1/messages/{topic}, GET /relay/v1/messages/{topic}":
+    # Given two relay nodes, each behind its own REST server
+    let publisher = testWakuNode()
+    (await publisher.mountRelay()).isOkOr:
+      assert false, "Failed to mount relay"
+    await publisher.start()
+    defer:
+      await publisher.stop()
+
+    var receiver: WakuNode
+    lockNewGlobalBrokerContext:
+      receiver = testWakuNode()
+      (await receiver.mountRelay()).isOkOr:
+        assert false, "Failed to mount relay"
+      await receiver.start()
+    defer:
+      await receiver.stop()
+
+    let restAddress = parseIpAddress("0.0.0.0")
+    let
+      publisherServer = WakuRestServerRef.init(restAddress, Port(0)).tryGet()
+      receiverServer = WakuRestServerRef.init(restAddress, Port(0)).tryGet()
+    installRelayApiHandlers(publisherServer.router, publisher, MessageCache.init())
+    installRelayApiHandlers(receiverServer.router, receiver, MessageCache.init())
+    publisherServer.start()
+    receiverServer.start()
+    defer:
+      await allFutures(publisherServer.stop(), receiverServer.stop())
+      await allFutures(publisherServer.closeWait(), receiverServer.closeWait())
+
+    let
+      publisherClient = newRestHttpClient(publisherServer.localAddress())
+      receiverClient = newRestHttpClient(receiverServer.localAddress())
+      otherTopic = $RelayShard(clusterId: DefaultClusterId, shardId: 1)
+
+    # Given both nodes subscribed over REST to two pubsub topics and connected
+    for client in [publisherClient, receiverClient]:
+      let response =
+        await client.relayPostSubscriptionsV1(@[DefaultPubsubTopic, otherTopic])
+      require response.status == 200
+    await publisher.connectToNodes(@[receiver.peerInfo.toRemotePeerInfo()])
+    await publisher.waitForTopicPeer(DefaultPubsubTopic, receiver.peerInfo.peerId)
+
+    # When a message with every optional field set is published on one node
+    let sent = RelayWakuMessage(
+      payload: base64.encode(EMOJI),
+      contentTopic: Opt.some(ContentTopic("/test/1/wäku-relay/proto")),
+      version: Opt.some(Natural(10)),
+      timestamp: Opt.some(now()),
+      meta: Opt.some(base64.encode("test-meta")),
+      ephemeral: Opt.some(true),
+    )
+    let postResponse =
+      await publisherClient.relayPostMessagesV1(DefaultPubsubTopic, sent)
+    check:
+      postResponse.status == 200
+      postResponse.data == "OK"
+
+    # Then the peer reads it back over REST with every field unchanged
+    let received = await receiverClient.waitForRelayMessages(DefaultPubsubTopic, 1)
+    check:
+      received.mapIt(it.payload) == @[sent.payload]
+      received.mapIt(it.contentTopic) == @[sent.contentTopic]
+      received.mapIt(it.version) == @[sent.version]
+      received.mapIt(it.timestamp) == @[sent.timestamp]
+      received.mapIt(it.meta) == @[sent.meta]
+      received.mapIt(it.ephemeral) == @[sent.ephemeral]
+
+    # Then nothing arrives on the other subscribed topic
+    let otherResponse = await receiverClient.relayGetMessagesV1(otherTopic)
+    check:
+      otherResponse.status == 200
+      otherResponse.data.len == 0
+
+    # When a message without a timestamp is published
+    let untimed = RelayWakuMessage(
+      payload: base64.encode("TEST-PAYLOAD"),
+      contentTopic: Opt.some(DefaultContentTopic),
+    )
+    let before = now()
+    let untimedResponse =
+      await publisherClient.relayPostMessagesV1(DefaultPubsubTopic, untimed)
+    check untimedResponse.status == 200
+
+    # Then the peer reads it back with a timestamp the publishing node assigned
+    let untimedReceived =
+      await receiverClient.waitForRelayMessages(DefaultPubsubTopic, 1)
+    check:
+      untimedReceived.mapIt(it.payload) == @[untimed.payload]
+      untimedReceived.mapIt(it.timestamp.get(0) >= before) == @[true]
+
+  asyncTest "Get messages of a not subscribed topic returns 404 - GET /relay/v1/messages/{topic}, GET /relay/v1/auto/messages/{topic}":
+    # Given
+    let node = testWakuNode()
+    (await node.mountRelay()).isOkOr:
+      assert false, "Failed to mount relay"
+    await node.start()
+    defer:
+      await node.stop()
+
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress, Port(0)).tryGet()
+    installRelayApiHandlers(restServer.router, node, MessageCache.init())
+    restServer.start()
+    defer:
+      await restServer.stop()
+      await restServer.closeWait()
+
+    # When getting messages of a pubsub topic
+    let staticResponse = await issueRequest(
+      restServer.getAddress("/relay/v1/messages/" & encodeUrl(DefaultPubsubTopic))
+    )
+
+    # Then the response has an empty body
+    check:
+      staticResponse.status == 404
+      staticResponse.data == ""
+
+    # When getting messages of a content topic
+    let autoResponse = await issueRequest(
+      restServer.getAddress("/relay/v1/auto/messages/" & encodeUrl(DefaultContentTopic))
+    )
+
+    # Then the response body is the content topic
+    check:
+      autoResponse.status == 404
+      autoResponse.data == DefaultContentTopic
+
+  asyncTest "Post a message with an invalid body - POST /relay/v1/messages/{topic}":
+    # Given a node subscribed to the topic, so only the body decides the response
+    let node = testWakuNode()
+    (await node.mountRelay()).isOkOr:
+      assert false, "Failed to mount relay"
+    await node.start()
+    defer:
+      await node.stop()
+
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress, Port(0)).tryGet()
+    installRelayApiHandlers(restServer.router, node, MessageCache.init())
+    restServer.start()
+    defer:
+      await restServer.stop()
+      await restServer.closeWait()
+
+    let client = newRestHttpClient(restServer.localAddress())
+    require (await client.relayPostSubscriptionsV1(@[DefaultPubsubTopic])).status == 200
+
+    let
+      path = "/relay/v1/messages/" & encodeUrl(DefaultPubsubTopic)
+      jsonHeader: seq[HttpHeaderTuple] = @[("Content-Type", "application/json")]
+      payload = string(base64.encode("TEST-PAYLOAD"))
+      validFields =
+        "\"payload\": \"" & payload & "\", \"contentTopic\": \"" & DefaultContentTopic &
+        "\""
+
+    # When the body does not decode into a message
+    let invalidBodies = [
+      $ %*{"contentTopic": DefaultContentTopic},
+      $ %*{"payload": "", "contentTopic": DefaultContentTopic},
+      $ %*{"payload": {"key": "YWFh"}, "contentTopic": DefaultContentTopic},
+      $ %*{"payload": 1234567890, "contentTopic": DefaultContentTopic},
+      $ %*{"payload": ["YWFh"], "contentTopic": DefaultContentTopic},
+      $ %*{"payload": true, "contentTopic": DefaultContentTopic},
+      "{" & validFields & ", \"payload\": \"" & payload & "\"}",
+      $ %*{"payload": payload},
+      $ %*{"payload": payload, "contentTopic": ""},
+      $ %*{"payload": payload, "contentTopic": 1234567890},
+      $ %*{
+        "payload": payload,
+        "contentTopic": DefaultContentTopic,
+        "timestamp": "1700000000000000000",
+      },
+      $ %*{"payload": payload, "contentTopic": DefaultContentTopic, "timestamp": 1.7e18},
+      $ %*{
+        "payload": payload,
+        "contentTopic": DefaultContentTopic,
+        "timestamp": [1700000000000000000],
+      },
+      $ %*{
+        "payload": payload,
+        "contentTopic": DefaultContentTopic,
+        "timestamp": {"time": 1700000000000000000},
+      },
+      "{" & validFields & ", \"timestamp\": null}",
+      "{" & validFields & ", \"timestamp\": 9223372036854775808}",
+      $ %*{"payload": payload, "contentTopic": DefaultContentTopic, "version": 2.1},
+      $ %*{
+        "payload": payload,
+        "contentTopic": DefaultContentTopic,
+        "extraField": "extraValue",
+      },
+    ]
+
+    # Then each is rejected as an invalid content body
+    for body in invalidBodies:
+      let response =
+        await issueRequest(restServer.getAddress(path), MethodPost, jsonHeader, body)
+      check:
+        response.status == 400
+        response.data.startsWith("Invalid content body, could not decode: ")
+
+    # When a field that must be base64 is not
+    let notBase64Bodies = [
+      $ %*{"payload": "Hello World!", "contentTopic": DefaultContentTopic},
+      $ %*{
+        "payload": payload, "contentTopic": DefaultContentTopic, "meta": "Hello World!"
+      },
+    ]
+
+    # Then it is rejected as an incorrect base64 string
+    for body in notBase64Bodies:
+      let response =
+        await issueRequest(restServer.getAddress(path), MethodPost, jsonHeader, body)
+      check:
+        response.status == 400
+        response.data == "Incorrect base64 string"
+
+  asyncTest "Subscribe and unsubscribe with an empty list, a repeated topic and an invalid topic - POST and DELETE /relay/v1/subscriptions":
+    # Given
+    let node = testWakuNode()
+    (await node.mountRelay()).isOkOr:
+      assert false, "Failed to mount relay"
+    await node.start()
+    defer:
+      await node.stop()
+
+    let restAddress = parseIpAddress("0.0.0.0")
+    let restServer = WakuRestServerRef.init(restAddress, Port(0)).tryGet()
+    let cache = MessageCache.init()
+    installRelayApiHandlers(restServer.router, node, cache)
+    restServer.start()
+    defer:
+      await restServer.stop()
+      await restServer.closeWait()
+
+    let client = newRestHttpClient(restServer.localAddress())
+    let noTopics = newSeq[PubsubTopic]()
+
+    # When subscribing and unsubscribing with an empty list
+    let emptyPost = await client.relayPostSubscriptionsV1(noTopics)
+    let emptyDelete = await client.relayDeleteSubscriptionsV1(noTopics)
+
+    # Then both succeed and nothing is subscribed
+    check:
+      emptyPost.status == 200
+      emptyDelete.status == 200
+      toSeq(node.wakuRelay.subscribedTopics).len == 0
+
+    # When subscribing to the same topic twice
+    let firstPost = await client.relayPostSubscriptionsV1(@[DefaultPubsubTopic])
+    let secondPost = await client.relayPostSubscriptionsV1(@[DefaultPubsubTopic])
+
+    # Then both succeed and the topic is subscribed once
+    check:
+      firstPost.status == 200
+      secondPost.status == 200
+      toSeq(node.wakuRelay.subscribedTopics) == @[DefaultPubsubTopic]
+
+    # When unsubscribing with an invalid topic in the list
+    let invalidTopic = "/test/2/this/is/a/content/topic/1"
+    let invalidDelete =
+      await client.relayDeleteSubscriptionsV1(@[DefaultPubsubTopic, invalidTopic])
+
+    # Then the request fails and the valid topic stays subscribed
+    check:
+      invalidDelete.status == 400
+      $invalidDelete.contentType == $MIMETYPE_TEXT
+      invalidDelete.data ==
+        "Invalid pubsub topic(s): @[\"/test/2/this/is/a/content/topic/1\"]"
+      node.wakuRelay.isSubscribed(DefaultPubsubTopic)
+      cache.isPubsubSubscribed(DefaultPubsubTopic)


### PR DESCRIPTION
## Description

67/424 (16%) of the interop tests are resolved: 11 ported, 13 rewritten in-process, 43 closed as already covered.

| Test | Verdict | Gate | Reason |
|---|---|---|---|
| [test last node to start publishes](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_multiple_nodes.py#L11) | migrate | PR gate | The last of five relay binaries to join, bootstrapped only through the first node's ENR, publishes, and every other container must receive it. No in-process test drives a mesh formed by discovery: the chains in tests/waku_relay/test_wakunode_relay.nim connect their peers by hand. |
| [test relay get message while one peer is paused](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_multiple_nodes.py#L22) | migrate | PR gate | One node is frozen with docker pause while a message is published, then a second follows after it resumes, and both must be in its relay cache. Only a real process can be frozen, and this test stands in for the three pause tests of the interop relay directory. |
| [test publish after node2 restarts](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L235) | migrate | PR gate | The non-bootstrap node restarts, re-bootstraps through discv5 and delivery must resume. In-process restart coverage in tests/node/test_wakunode_restart.nim checks the listener only. |
| [test publish and retrieve 100 messages](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L244) | migrate | PR gate | A burst of 100 messages must all be readable from the peer's relay cache, which needs the harness default --rest-relay-cache-capacity=100. Nothing in-process reads that flag, and this PR's CI run is the test's first green run since the skip. |
| [test optional nodes not subscribed to same pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_multiple_nodes.py#L14) | rewrite | none | Asserts only the 404 of a relay GET on a node that never subscribed. Now "Get messages of a not subscribed topic returns 404" in tests/wakunode_rest/test_rest_relay.nim, on the pubsub and content topic paths; the unsubscribed node receiving nothing is "Pubsub Topic Subscription (Network Size: 2, only one subscribed)" in tests/waku_relay/test_protocol.nim. |
| [test publish with valid payloads](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L16) | rewrite | none | Publishes 40 payload shapes over REST and reads each back on the peer. Now "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim, two nodes with every optional field set and read back field by field; payload shapes across a relay hop are "Valid Payload Types" in tests/waku_relay/test_protocol.nim. |
| [test publish with invalid payloads](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L28) | rewrite | none | Empty, unencoded and wrongly typed payloads must get 400. Now "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim, a table of twenty bodies over payload, content topic, timestamp, version, meta, a repeated field and an unknown field. |
| [test publish with no timestamp](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L153) | rewrite | none | A message without a timestamp is accepted and the peer reads it back with one the node assigned. The second message of "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish and retrieve duplicate message](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L200) | rewrite | none | Publishing an identical message twice must deliver once. Now "Publishing the same message twice delivers it to the peer once" in tests/waku_relay/test_protocol.nim, where the second publish fails with NoPeersToPublish and the peer's handler fires once. |
| [test relay subscribe with empty pubsub topic list](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L33) | rewrite | none | An empty topic list must be accepted. Now "Subscribe and unsubscribe with an empty list, a repeated topic and an invalid topic" in tests/wakunode_rest/test_rest_relay.nim, which also pins a repeated subscribe and an invalid topic on delete leaving the valid one subscribed. |
| [test relay get message after one peer was stopped](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_multiple_nodes.py#L33) | covered | none | A peer is stopped and the others must keep delivering. "How multiple interconnected nodes work" in tests/waku_relay/test_protocol.nim disconnects a peer mid-test and asserts delivery continues between the others. |
| [test publish with missing payload](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L40) | covered | none | A body without a payload must get 400. The first row of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish with payload less than 150 kb](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L49) | covered | none | A 100 KB payload reaches the peer. "Valid Payload Sizes" in tests/waku_relay/test_protocol.nim delivers 100 KiB and the exact maximum to the peer. |
| [test publish with payload equal or more 150 kb](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L55) | covered | none | Oversize payloads are refused. "Post a message larger than maximum size" in tests/wakunode_rest/test_rest_relay.nim asserts the 400 on both endpoints, and "Valid Payload Sizes" in tests/waku_relay/test_protocol.nim that an oversize message never reaches the peer. |
| [test publish with valid content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L66) | covered | none | Forty content topic strings must round-trip. The static endpoint does not parse the content topic, and "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim round-trips a non-ASCII one. |
| [test publish with invalid content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L78) | covered | none | An empty or wrongly typed content topic must get 400. Both are rows of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish with missing content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L90) | covered | none | A body without a content topic must get 400. A row of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish on multiple pubsub topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L99) | covered | none | Several shards are subscribed and each must deliver. "Unsubscribing from some pubsub topics keeps the others delivering" in tests/node/test_wakunode_sharding.nim asserts delivery on eight shards before unsubscribing, and the REST subscribe of a topic list is "Subscribe a node to an array of pubsub topics" in tests/wakunode_rest/test_rest_relay.nim. |
| [test message published on different pubsub topic is not retrieved](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L111) | covered | none | A message on one shard must not show up on another. "How multiple interconnected nodes work" in tests/waku_relay/test_protocol.nim asserts the per-topic delivery matrix, and "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim reads a second subscribed topic and gets nothing. |
| [test publish on non subscribed pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L118) | covered | none | Publishing on a topic the node has not subscribed must fail. "Post a message to a not subscribed pubsub topic" in tests/wakunode_rest/test_rest_relay.nim asserts the 400 and its text. |
| [test publish with valid timestamps](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L126) | covered | none | Seven timestamp values are accepted. Without RLN no validator reads the timestamp, so they prove only that an explicit int64 round-trips, which "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim asserts. |
| [test publish with invalid timestamps](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L139) | covered | none | String, float, list, object, null and out-of-range timestamps must get 400. All six are rows of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish with valid version](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L158) | covered | none | A version value round-trips. "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim sends version 10 and reads it back. |
| [test publish with invalid version](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L161) | covered | none | A fractional version must get 400. A row of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish with valid meta](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L168) | covered | none | A meta value round-trips. "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim sends it and reads it back. |
| [test publish with invalid meta](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L171) | covered | none | Meta that is not base64 must get 400. The base64 half of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test publish with ephemeral](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L179) | covered | none | The ephemeral flag round-trips. "A message published on one node is read back on its relay peer" in tests/wakunode_rest/test_rest_relay.nim sends it set and reads it back. |
| [test publish with extra field](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L190) | covered | none | An unknown field must get 400. The last row of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim pins that 400, which the reader produces by accident. |
| [test publish while peer is paused](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L209) | covered | none | A message published while the peer is frozen arrives after it resumes. test_relay_get_message_while_one_peer_is_paused in tests-e2e/tests/rest/relay/test_multiple_nodes.py publishes during the freeze and once more after it. |
| [test publish after node pauses and pauses](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_publish.py#L219) | covered | none | Delivery continues after each node was frozen and resumed. test_relay_get_message_while_one_peer_is_paused in tests-e2e/tests/rest/relay/test_multiple_nodes.py publishes after a resume, and freezing the publisher instead is not a different failure class. |
| [test valid payloads at slow rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L52) | covered | none | Class-skipped in interop. Registered members publishing under the limit with delivery across the mesh is "testing rln-relay with valid proof" in tests/waku_rln_relay/test_wakunode_rln_relay.nim, and over the REST publish path the propagation scenario of tests/simulator/rln-e2e-test.py in the rln-simulator job of ci-daily.yml. |
| [test valid payload at variable rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L101) | covered | none | Class-skipped in interop. Over-limit publishes fail with NonceLimitReached and the nonce resets after the epoch in tests/waku_rln_relay/test_rln_nonce_manager.nim; the REST 500 ceiling and the epoch reset are the rate-limit and epoch-reset scenarios of tests/simulator/rln-e2e-test.py. |
| [test valid payloads random epoch at slow rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L131) | covered | none | Class-skipped in interop. The epoch length reaching the node is proven by tests/simulator/rln-e2e-test.py at a 120 s epoch and a limit of 30 against defaults of 1 s and 1, and a random epoch between 2 and 5 s adds no failure class. |
| [test valid payloads random user message limit](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L151) | covered | none | Class-skipped in interop. N nonces accepted and the next refused is tests/waku_rln_relay/test_rln_nonce_manager.nim, and the limit reaching the node is proven by tests/simulator/rln-e2e-test.py at limit 30. |
| [test valid payloads dynamic at spam rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L171) | covered | none | Class-skipped in interop. The "dynamic" variant only adds the signing key to the node flags, both variants run the on-chain group manager and core has no other, and the over-limit 500 is the rate-limit scenario of tests/simulator/rln-e2e-test.py. |
| [test valid payloads dynamic at slow rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L206) | covered | none | Class-skipped in interop. Same reasoning on "dynamic", and under-limit delivery is "testing rln-relay with valid proof" in tests/waku_rln_relay/test_wakunode_rln_relay.nim and the propagation scenario of tests/simulator/rln-e2e-test.py. |
| [test valid payloads n1 with rln n2 without rln at spam rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L238) | covered | none | Class-skipped in interop. Despite the name its only assertion is the sender's 500 on over-limit, the rate-limit scenario of tests/simulator/rln-e2e-test.py, and nothing is asserted on the non-RLN peer. |
| [test valid payloads with optional nodes at slow rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L263) | covered | none | Class-skipped in interop. Five registered members publishing under the limit into a mesh is the three-node chain of tests/waku_rln_relay/test_wakunode_rln_relay.nim and the six-node propagation of tests/simulator/rln-e2e-test.py. |
| [test valid payloads with optional nodes at spam rate](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_rln.py#L289) | covered | none | Class-skipped in interop. The sender's 500 on over-limit is the rate-limit scenario of tests/simulator/rln-e2e-test.py, and the extra nodes receive nothing the test asserts. |
| [test relay subscribe to already existing pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L21) | covered | none | Re-subscribing keeps delivering. "Refreshing subscription" in tests/waku_relay/test_protocol.nim, and the repeated POST answering 200 in "Subscribe and unsubscribe with an empty list, a repeated topic and an invalid topic" in tests/wakunode_rest/test_rest_relay.nim. |
| [test relay subscribe with multiple overlapping pubsub topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L27) | covered | none | Overlapping subscribe lists deliver on every shard. "Refreshing subscription" in tests/waku_relay/test_protocol.nim and "Unsubscribing from some pubsub topics keeps the others delivering" in tests/node/test_wakunode_sharding.nim. |
| [test relay subscribe with invalid pubsub topic format](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L36) | covered | none | An invalid topic in the list must get 400, asserted by "Subscribe a node to an array of pubsub topics" in tests/wakunode_rest/test_rest_relay.nim. The interop test sends each topic as a bare JSON string, so its 400 comes from the body shape and never reaches topic validation. |
| [test relay unsubscribe from single pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L47) | covered | none | Unsubscribing silences the topic and publishing on it fails. "Unsubscribing from some pubsub topics keeps the others delivering" in tests/node/test_wakunode_sharding.nim and "Post a message to a not subscribed pubsub topic" in tests/wakunode_rest/test_rest_relay.nim. |
| [test relay unsubscribe from all pubsub topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L53) | covered | none | Unsubscribing everything stops all delivery. "Unsubscribing from all pubsub topics stops delivery" in tests/node/test_wakunode_sharding.nim and "Post a message to a not subscribed pubsub topic" in tests/wakunode_rest/test_rest_relay.nim. |
| [test relay unsubscribe from some pubsub topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L61) | covered | none | Unsubscribing some topics leaves the others delivering, which "Unsubscribing from some pubsub topics keeps the others delivering" in tests/node/test_wakunode_sharding.nim asserts. At the REST layer "Unsubscribe a node from an array of pubsub topics" in tests/wakunode_rest/test_rest_relay.nim deletes four of five and asserts the survivor. |
| [test relay unsubscribe from non existing pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L71) | covered | none | Unsubscribing a topic never subscribed is accepted. "Unsubscribe a node from an array of pubsub topics" in tests/wakunode_rest/test_rest_relay.nim deletes a shard never in the cache and gets 200, and "Unsubscribe / Without Subscription" in tests/waku_relay/test_protocol.nim proves the relay no-op. |
| [test relay unsubscribe with invalid pubsub topic format](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L84) | covered | none | An invalid topic on delete must get 400. The last part of "Subscribe and unsubscribe with an empty list, a repeated topic and an invalid topic" in tests/wakunode_rest/test_rest_relay.nim; the interop test has the same bare-string body as its subscribe twin. |
| [test relay resubscribe to unsubscribed pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/relay/test_subscribe.py#L95) | covered | none | Resubscribing after an unsubscribe restores delivery. "Resubscribing after unsubscribing from all content topics restores delivery" in tests/node/test_wakunode_sharding.nim, and content and pubsub subscriptions resolve to the same subscribeShard call. |

## Changes

- Port `test_last_node_to_start_publishes` and `test_relay_get_message_while_one_peer_is_paused` into `tests-e2e/tests/rest/relay/test_multiple_nodes.py`, and `test_publish_after_node2_restarts` and `test_publish_and_retrieve_100_messages` into a new `tests-e2e/tests/rest/relay/test_publish.py`. The 100-message test drops its stale skip and flaky markers, asserts the set of payloads instead of their order, and polls the peer's cache instead of sleeping once.
- Add four tests to `tests/wakunode_rest/test_rest_relay.nim`: a two-node publish-and-read-back over REST, 404 on both get-messages paths, a table of invalid message bodies, and the subscription request shapes. Every teardown sits in a `defer` registered where the resource starts.
- Add "Publishing the same message twice delivers it to the peer once" to `tests/waku_relay/test_protocol.nim`.
- Lift the raw-HTTP request helper of `tests/wakunode_rest/test_rest_cors.nim` into `tests/testlib/rest_requests.nim`, with method, headers and body parameters, and use it from both files. In the CORS test the repeated `Origin` header name becomes a const. Its node-key line had stopped compiling; it now calls `generateSecp256k1Key()` like every other REST test, so the file passes again.
