### PR TITLE
fix(build): make portable builds the default

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -8,7 +8,7 @@ on:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
+  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
   NIM_VERSION: '2.2.6'
 
 jobs:

--- a/.github/workflows/ci-rln-simulator.yml
+++ b/.github/workflows/ci-rln-simulator.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Build wakunode2
         run: |
           make -j${NPROC} V=1 POSTGRES=1 \
-            NIMFLAGS="-d:disableMarchNative -d:chronicles_colors:none" \
+            NIMFLAGS="-d:chronicles_colors:none" \
             wakunode2
 
       - name: Audit installed deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none -d:disableMarchNative"
+  NIMFLAGS: "--parallelBuild:${NPROC} --colors:off -d:chronicles_colors:none"
   NIM_VERSION: '2.2.6'
 
 jobs:
@@ -114,6 +114,38 @@ jobs:
           name: liblogosdelivery
           path: build/liblogosdelivery.so
           retention-days: 1
+
+  # Runs `make liblogosdelivery` with the default flags to test compile and link.
+  liblogosdelivery-default:
+    needs: changes
+    if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    env:
+      NIMFLAGS: ""
+
+    name: liblogosdelivery default build - ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nim ${{ env.NIM_VERSION }}
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install nimble deps
+        uses: ./.github/actions/nimble-deps
+        with:
+          nim-version: ${{ env.NIM_VERSION }}
+
+      - name: make liblogosdelivery
+        run: make V=1 -j1 liblogosdelivery
 
   build-windows:
     needs: changes
@@ -262,7 +294,7 @@ jobs:
           fi
 
           export MAKEFLAGS="-j1"
-          export NIMFLAGS="--colors:off -d:chronicles_colors:none -d:disableMarchNative"
+          export NIMFLAGS="--colors:off -d:chronicles_colors:none"
           export USE_LIBBACKTRACE=0
 
           make V=1 POSTGRES=$postgres_enabled test

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -14,7 +14,7 @@ on:
 env:
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "--parallelBuild:${NPROC} -d:disableMarchNative -d:chronicles_colors:none"
+  NIMFLAGS: "--parallelBuild:${NPROC} -d:chronicles_colors:none"
   NIM_VERSION: '2.2.6'
 
 # This workflow should not run for outside contributors

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ env:
 
   NPROC: 2
   MAKEFLAGS: "-j${NPROC}"
-  NIMFLAGS: "-d:disableMarchNative"
+  NIMFLAGS: ""
   NIM_VERSION: '2.2.6'
 
 jobs:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   NPROC: 2
-  NIMFLAGS: "-d:disableMarchNative"
+  NIMFLAGS: ""
   NIM_VERSION: '2.2.6'
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,7 @@ RUN if [ "$HEAPTRACK_BUILD" = "1" ]; then \
     fi
 
 # Build the final node binary
-# -d:disableMarchNative is appended here, not left to the caller. Without it
-# config.nims adds -march=native, and the image may then require CPU features
-# unavailable on the runtime host. NIMFLAGS is applied last, so a caller can
-# still add to it.
-RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET NIMFLAGS="${NIMFLAGS} -d:disableMarchNative" POSTGRES=${POSTGRES} DEBUG=${DEBUG} LOG_LEVEL=${LOG_LEVEL} HEAPTRACKER=${HEAPTRACK_BUILD}
+RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET NIMFLAGS="${NIMFLAGS}" POSTGRES=${POSTGRES} DEBUG=${DEBUG} LOG_LEVEL=${LOG_LEVEL} HEAPTRACKER=${HEAPTRACK_BUILD}
 
 
 # PRODUCTION IMAGE -------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,15 @@ NIM_PARAMS := $(NIM_PARAMS) -d:heaptracker
 endif
 endif
 
+# TODO: native builds are unsupported until nim-leopard builds Leopard-RS through
+# Nim; its cmake step ignores Nim's flags and the native .so does not link.
+# CPU baseline. The default is the portable build (see config.nims).
+#
+# MARCH_NATIVE ?= 0
+# ifeq ($(MARCH_NATIVE), 1)
+# NIM_PARAMS := $(NIM_PARAMS) -d:marchNative
+# endif
+
 # Debug/Release mode
 ifeq ($(DEBUG), 0)
 NIM_PARAMS := $(NIM_PARAMS) -d:release -d:lto_incremental -d:strip

--- a/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
+++ b/apps/liteprotocoltester/Dockerfile.liteprotocoltester.compile
@@ -22,9 +22,7 @@ RUN git submodule update --init --recursive
 RUN make -j$(nproc) deps QUICK_AND_DIRTY_COMPILER=1 ${NIM_COMMIT}
 
 # Build the final node binary
-# -d:disableMarchNative is appended here. Without it config.nims adds
-# -march=native and the image may require CPU features the runtime host lacks.
-RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS} -d:disableMarchNative"
+RUN make -j$(nproc) ${NIM_COMMIT} $MAKE_TARGET LOG_LEVEL=${LOG_LEVEL} NIMFLAGS="${NIMFLAGS}"
 
 
 # REFERENCE IMAGE as BASE for specialized PRODUCTION IMAGES----------------------------------------

--- a/ci/Jenkinsfile.lpt
+++ b/ci/Jenkinsfile.lpt
@@ -47,7 +47,6 @@ pipeline {
       description: 'Flags for Nim compilation.',
       defaultValue: params.NIMFLAGS ?: [
         '--colors:off',
-        '-d:disableMarchNative',
         '-d:chronicles_colors:none',
         '-d:insecure',
       ].join(' ')

--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -12,7 +12,6 @@ pipeline {
       defaultValue: params.NIMFLAGS ?: [
         '--colors:off',
         '-d:insecure',
-        '-d:disableMarchNative',
         '--parallelBuild:6',
         '-d:postgres',
       ].join(' ')

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -57,7 +57,6 @@ pipeline {
       description: 'Flags for Nim compilation.',
       defaultValue: params.NIMFLAGS ?: [
         '--colors:off',
-        '-d:disableMarchNative',
         '-d:chronicles_colors:none',
         '-d:insecure',
       ].join(' ')

--- a/config.nims
+++ b/config.nims
@@ -21,6 +21,10 @@ if defined(windows):
     # set the IMAGE_FILE_LARGE_ADDRESS_AWARE flag so we can use PAE, if enabled, and access more than 2 GiB of RAM
     switch("passL", "-Wl,--large-address-aware")
 
+# CPU baseline. The default build is portable. -d:marchNative selects the native flags.
+# -d:disableMarchNative, the former name of the portable build, still works and wins.
+const portableBuild = not defined(marchNative) or defined(disableMarchNative)
+
 # Leopard-RS is built by nim-leopard, which shells out to cmake from a `static:`
 # block outside Nim's flag plumbing: nothing passed with --passC/--cpu/--os
 # reaches Leopard-RS' compiler, so every knob it has -- all strdefines -- has to
@@ -59,7 +63,7 @@ if defined(android):
   # dlopen on the device.
   switch("passL", "-lc++_static")
   switch("passL", "-lc++abi")
-elif defined(disableMarchNative):
+elif portableBuild:
   # Leopard-RS' CMakeLists adds -march=native whenever the compiler accepts it.
   # Seed the cache variable guarding that probe so a portable build stays
   # portable -- and hand leopard the same x86 baseline this file gives the C
@@ -95,13 +99,12 @@ elif defined(disableMarchNative):
       " -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCOMPILER_SUPPORTS_MARCH_NATIVE=FALSE" &
       leopardCxxFlags,
   )
-
-# https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#ssse3-supplemental-sse3
-# suggests that SHA256 hashing with SSSE3 is 20% faster than without SSSE3, so
-# given its near-ubiquity in the x86 installed base, it renders a distribution
-# build more viable on an overall broader range of hardware.
-#
-if defined(disableMarchNative):
+if portableBuild:
+  switch("define", "disableMarchNative")
+  # https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#ssse3-supplemental-sse3
+  # suggests that SHA256 hashing with SSSE3 is 20% faster than without SSSE3, so
+  # given its near-ubiquity in the x86 installed base, it renders a distribution
+  # build more viable on an overall broader range of hardware.
   if defined(i386) or defined(amd64):
     if defined(macosx):
       # macOS Catalina is EOL as of 2022-09

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,10 +23,6 @@ let
 
   nimDefineArgs = pkgs.lib.concatStringsSep " \\\n      " (
        [ "--define:disable_libbacktrace"
-         # nix's cc-wrapper drops -march=native (NIX_ENFORCE_NO_NATIVE), so the
-         # build must not depend on it. This also hands nim-leopard's own cmake
-         # an explicit ISA baseline; see config.nims.
-         "--define:disableMarchNative"
          "--define:libp2p_mix_experimental_exit_is_dest"
          "--define:libp2p_quic_support"
          "--define:git_version=${gitVersion}" ]


### PR DESCRIPTION
## Description

This PR makes portable builds the default, fixing the Linux `make liblogosdelivery` link failure introduced by nim-segmentation's nim-leopard dependency in #4200. The portable settings enable position-independent code (PIC) for Leopard's static library, allowing it to link into `liblogosdelivery.so`.

This PR also adds a commented-out `MARCH_NATIVE` switch to the Makefile, which can be enabled when native builds can be shown to work again.

## Changes

* Make portable builds the default in `config.nims`
* Add CI test for `make liblogosdelivery` (Ubuntu, macOS)
* Add draft `MARCH_NATIVE` code to Makefile
* Misc cleanups

## Issue

Maintenance Y2026H2 #4043