### PR TITLE
fix(ci): run the liblogosdelivery default build again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   # Runs `make liblogosdelivery` with the default flags to test compile and link.
   liblogosdelivery-default:
     needs: changes
-    if: ${{ needs.changes.outputs.v2 == 'true' || needs.changes.outputs.common == 'true' }}
+    if: ${{ needs.changes.outputs.code == 'true' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

CI skips the `liblogosdelivery default build` job on every PR, master included. The job's condition reads `needs.changes.outputs.v2` and `needs.changes.outputs.common`. These outputs do not exist since #4225 replaced them with `code`.

## Changes

* run `liblogosdelivery-default` when `needs.changes.outputs.code` is true

## Issue

Maintenance Y2026H2 #4043