### PR TITLE
refactor(rln): configure the RLN plugin over FFI instead of the CLI

### DIFF
--- a/library/liblogosdelivery_rln.h
+++ b/library/liblogosdelivery_rln.h
@@ -6,70 +6,50 @@
 extern "C" {
 #endif
 
-/* One typed callback per RLN function. Each dispatches and returns immediately;
-   the call completes later via logosdelivery_rln_response with the same req_id.
-   Scalar args are passed directly; complex args (config, options, proof) and
-   every result are JSON strings. All strings are borrowed for the duration of
-   the call — copy before returning.
+/* One typed callback per RLN operation the node performs. Each dispatches and
+   returns immediately; the call completes later via logosdelivery_rln_response
+   with the same req_id. Scalar args are passed directly; complex args (proof)
+   and every result are JSON strings. All strings are borrowed for the duration
+   of the call — copy before returning.
 
-   req_id is supplied by the library calling the callbacks. It needs to be 
-   unique among the requests currently in flight, that lets concurrent calls 
-   (including calls made from different threads) be told apart and matched to
-   their responses.
+   The plugin is implementation-agnostic: the library never names a membership,
+   a registry or an epoch size, and never starts or configures the backend. The
+   host owns all of that and supplies whatever its implementation needs when it
+   forwards a call.
 
-   Arg shapes and result_json follow the RLN module's own wire dialect
-   (logos-rln-modules, liblogos_rln_module.lidl / docs/wire-binding.md) — the
-   host forwards both directions verbatim:
-   - start/stop/generate_proof/validate_proof/get_epoch_quota results are the
-     module's LogosResult envelope {"success":bool,"value":…,"error":…} where
-     a failure's error is the JSON-encoded typed object
-     {"class":…,"kind":…,"message":…} (class: not_ready | transient |
-     budget_exhausted | permanent).
-   - register_membership/get_membership_state results are the module's compact
-     JSON reply; failures are the in-band envelope {"error":{"class":…,…}}. */
+   result_json follows the RLN module API's own wire dialect (logos-rln-modules,
+   liblogos_rln_module.lidl / docs/wire-binding.md), forwarded verbatim:
+   - get_epoch_quota/generate_proof/validate_proof results are the LogosResult
+     envelope {"success":bool,"value":…,"error":…} where a failure's error is
+     the JSON-encoded typed object {"class":…,"kind":…,"message":…}
+     (class: not_ready | transient | budget_exhausted | permanent).
+   - get_membership_state results are the compact JSON reply; failures are the
+     in-band envelope {"error":{"class":…,…}}. */
 
-typedef void (*LogosDeliveryRlnStartFn)(uint64_t req_id, const char* config_json,
-                                        void* user_data);
+typedef void (*LogosDeliveryRlnGetMembershipStateFn)(uint64_t req_id, void* user_data);
 
-typedef void (*LogosDeliveryRlnStopFn)(uint64_t req_id, void* user_data);
+typedef void (*LogosDeliveryRlnGetEpochQuotaFn)(uint64_t req_id, uint64_t timestamp,
+                                                void* user_data);
 
-typedef void (*LogosDeliveryRlnRegisterFn)(uint64_t req_id, const char* registry_id,
-                                           const char* rln_identifier,
-                                           const char* options_json, void* user_data);
-
-typedef void (*LogosDeliveryRlnGetMembershipStateFn)(uint64_t req_id,
-                                                     const char* registry_id,
-                                                     const char* rln_identifier,
-                                                     void* user_data);
-
-typedef void (*LogosDeliveryRlnGetEpochQuotaFn)(uint64_t req_id, const char* registry_id,
-                                                const char* rln_identifier,
+typedef void (*LogosDeliveryRlnGenerateProofFn)(uint64_t req_id, const char* signal_hex,
                                                 uint64_t timestamp, void* user_data);
 
-typedef void (*LogosDeliveryRlnGenerateProofFn)(uint64_t req_id, const char* registry_id,
-                                                const char* rln_identifier,
-                                                const char* signal_hex,
-                                                uint64_t timestamp, void* user_data);
-
-typedef void (*LogosDeliveryRlnValidateProofFn)(uint64_t req_id, const char* registry_id,
-                                                const char* rln_identifier,
-                                                const char* signal_hex, uint64_t timestamp,
+typedef void (*LogosDeliveryRlnValidateProofFn)(uint64_t req_id, const char* signal_hex,
+                                                uint64_t timestamp,
                                                 const char* proof_json, void* user_data);
 
 typedef struct {
-  LogosDeliveryRlnStartFn start;
-  LogosDeliveryRlnStopFn stop;
-  LogosDeliveryRlnRegisterFn register_membership;
   LogosDeliveryRlnGetMembershipStateFn get_membership_state;
   LogosDeliveryRlnGetEpochQuotaFn get_epoch_quota;
   LogosDeliveryRlnGenerateProofFn generate_proof;
   LogosDeliveryRlnValidateProofFn validate_proof;
-} LogosDeliveryRlnCallbacks;
+} LogosDeliveryRlnPlugin;
 
-/* The host application registers callbacks once, before node start. NULL clears and fails
-   all in-flight requests. Returns 0 on success. */
-int logosdelivery_rln_set_callbacks(const LogosDeliveryRlnCallbacks* cbs,
-                                    void* user_data);
+/* The host application installs the plugin once, before node creation: an
+   installed plugin is what enables RLN over it. NULL clears the plugin and
+   fails all in-flight requests. Returns 0 on success. */
+int logosdelivery_rln_set_plugin(const LogosDeliveryRlnPlugin* plugin,
+                                 void* user_data);
 
 /* The host application sends the response on completion of an outbound call, same req_id. Thread-safe;
    result_json is copied before return. */

--- a/library/liblogosdelivery_rln.h
+++ b/library/liblogosdelivery_rln.h
@@ -6,11 +6,14 @@
 extern "C" {
 #endif
 
-/* One typed callback per RLN operation the node performs. Each dispatches and
-   returns immediately; the plugin replies to logosdelivery later via logosdelivery_rln_response
-   with the same req_id. Scalar args are passed directly; complex args (proof)
-   and every result are JSON strings. All strings are borrowed for the duration
-   of the call — copy before returning.
+/* "Host" below is the application embedding this library over its C ABI and
+   installing the plugin — logos-delivery-module in a Logos Core deployment.
+
+   One typed callback per RLN operation the node performs. Each dispatches and
+   returns immediately; the plugin replies to logosdelivery later via
+   logosdelivery_rln_response with the same req_id. Scalar args are passed
+   directly; complex args (proof) and every result are JSON strings. All strings
+   are borrowed for the duration of the call — copy before returning.
 
    The plugin is implementation-agnostic: the library never names a membership,
    a registry or an epoch size, and never starts or configures the backend. The

--- a/library/liblogosdelivery_rln.h
+++ b/library/liblogosdelivery_rln.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 /* One typed callback per RLN operation the node performs. Each dispatches and
-   returns immediately; the call completes later via logosdelivery_rln_response
+   returns immediately; the plugin replies to logosdelivery later via logosdelivery_rln_response
    with the same req_id. Scalar args are passed directly; complex args (proof)
    and every result are JSON strings. All strings are borrowed for the duration
    of the call — copy before returning.

--- a/library/logos_delivery_api/node_api.nim
+++ b/library/logos_delivery_api/node_api.nim
@@ -197,8 +197,7 @@ proc logosdelivery_create_node(
     await lib.teardownFFIEventScope()
     return err(error)
 
-  let lez = lib.waku.conf.rlnLezConf.isSome()
-  registerRlnModuleProviders(lib.waku.brokerCtx, lez).isOkOr:
+  registerRlnModuleProviders(lib.waku.brokerCtx, rlnPluginRegistered()).isOkOr:
     await lib.teardownFFIEventScope()
     return err(error)
 

--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -35,16 +35,6 @@ type MessagingClientConf* = object
     ## Chain id the RLN contract is deployed on.
   rlnEpochSizeSec* {.name: "rln-relay-epoch-sec".}: Opt[uint]
     ## RLN epoch size, in seconds.
-  rlnLez* {.name: "rln-lez".}: Opt[bool]
-    ## Outsource RLN to the external LEZ-registry RLN module; when set, RLN is enabled.
-  rlnRegistryId* {.name: "rln-registry-id".}: Opt[string]
-    ## CAIP-10 account identifier of the LEZ RLN registry deployment.
-  rlnIdentifier* {.name: "rln-identifier".}: Opt[string]
-    ## 32-byte hex per-application RLN identifier; must match on every node of a deployment.
-  rlnRegistryOptions* {.name: "rln-registry-options".}: Opt[string]
-    ## Flat JSON object of registry-specific registration options, passed verbatim
-    ## to the external RLN module's register().
-    ## e.g. "rate_limit":"10" (default is applied if not present)
   rlnUserMessageLimit* {.name: "rln-relay-user-message-limit".}: Opt[uint64]
     ## Per-epoch message limit requested for the RLN membership.
   reliabilityEnabled* {.name: "reliability".}: Opt[bool]
@@ -142,16 +132,6 @@ proc toWakuNodeConf*(
     conf.rlnRelayChainId = self.rlnChainId.get()
   if self.rlnEpochSizeSec.isSome():
     conf.rlnEpochSizeSec = Opt.some(self.rlnEpochSizeSec.get().uint64)
-  if self.rlnLez.isSome():
-    conf.rlnRelayLez = self.rlnLez
-    if self.rlnLez.get():
-      conf.rlnRelay = Opt.some(true)
-  if self.rlnRegistryId.isSome():
-    conf.rlnRelayRegistryId = self.rlnRegistryId.get()
-  if self.rlnIdentifier.isSome():
-    conf.rlnRelayIdentifier = self.rlnIdentifier.get()
-  if self.rlnRegistryOptions.isSome():
-    conf.rlnRelayRegistryOptions = self.rlnRegistryOptions.get()
   if self.rlnUserMessageLimit.isSome():
     conf.rlnRelayUserMessageLimit = self.rlnUserMessageLimit
   if self.anonymityLevel.get(AnonymityLevel.None) != AnonymityLevel.None:

--- a/logos_delivery/waku/api/publish.nim
+++ b/logos_delivery/waku/api/publish.nim
@@ -85,10 +85,7 @@ proc attachRlnProof*(
         return err("The node does not have a usable RLN membership: " & $status)
 
     let generated = (
-      await RequestGenerateRlnProof.request(
-        self.brokerCtx, message, rlnLez.scope.registryId, rlnLez.scope.rlnIdentifier,
-        timestamp,
-      )
+      await RequestGenerateRlnProof.request(self.brokerCtx, message, timestamp)
     ).valueOr:
       return err("Failed to attach RLN proof: " & error)
     var msgWithProof = message

--- a/logos_delivery/waku/factory/conf_builder/rln_relay_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/rln_relay_conf_builder.nim
@@ -23,10 +23,6 @@ type RlnConfBuilder* = object
   dynamic*: Opt[bool]
   epochSizeSec*: Opt[uint64]
   userMessageLimit*: Opt[uint64]
-  lez*: Opt[bool]
-  registryId*: Opt[string]
-  identifier*: Opt[string] ## 32-byte hex string, decoded and validated in build()
-  registryOptions*: Opt[string] ## flat JSON object, passed verbatim to register()
 
 proc init*(T: type RlnConfBuilder): RlnConfBuilder =
   RlnConfBuilder()
@@ -64,51 +60,15 @@ proc withEpochSizeSec*(b: var RlnConfBuilder, epochSizeSec: uint64) =
 proc withUserMessageLimit*(b: var RlnConfBuilder, userMessageLimit: uint64) =
   b.userMessageLimit = Opt.some(userMessageLimit)
 
-proc withLez*(b: var RlnConfBuilder, lez: bool) =
-  b.lez = Opt.some(lez)
-
-proc withRegistryId*(b: var RlnConfBuilder, registryId: string) =
-  b.registryId = Opt.some(registryId)
-
-proc withIdentifier*(b: var RlnConfBuilder, identifier: string) =
-  b.identifier = Opt.some(identifier)
-
-proc withRegistryOptions*(b: var RlnConfBuilder, registryOptions: string) =
-  b.registryOptions = Opt.some(registryOptions)
-
 type RlnConfs* = object
-  ## Built RLN configuration: at most one backend is set — `lez` when the
-  ## builder's lez switch is on, `evm` otherwise, neither when RLN is disabled.
+  ## Built RLN configuration: the embedded EVM backend, or nothing when RLN is
+  ## disabled. The RLN module backend is configured by the plugin the host
+  ## installs over FFI, not from here.
   evm*: Opt[RlnConf]
-  lez*: Opt[RlnLezConf]
 
 proc build*(b: RlnConfBuilder): Result[RlnConfs, string] =
   if not b.enabled.get(DefaultRlnRelayEnabled):
     return ok(RlnConfs())
-
-  if b.lez.get(false):
-    if b.registryId.get("") == "":
-      return err("rlnRelay.registryId is not specified")
-    if b.identifier.get("") == "":
-      return err("rlnRelay.identifier is not specified")
-    var identifier: array[32, byte]
-    try:
-      hexToByteArray(b.identifier.get(), identifier)
-    except ValueError:
-      return err("rlnRelay.identifier is not a 32-byte hex string")
-    return ok(
-      RlnConfs(
-        lez: Opt.some(
-          RlnLezConf(
-            registryId: b.registryId.get(),
-            identifier: identifier,
-            epochSizeSec: b.epochSizeSec.get(DefaultRlnRelayEpochSizeSec),
-            userMessageLimit: b.userMessageLimit.get(DefaultRlnRelayUserMessageLimit),
-            registryOptionsJson: b.registryOptions.get("{}"),
-          )
-        )
-      )
-    )
 
   let creds =
     if b.credPath.isSome() and b.credPassword.isSome():

--- a/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
+++ b/logos_delivery/waku/factory/conf_builder/waku_conf_builder.nim
@@ -808,7 +808,6 @@ proc build*(
     filterServiceConf: filterServiceConf,
     discv5Conf: discv5Conf,
     rlnEvmConf: rlnConfs.evm,
-    rlnLezConf: rlnConfs.lez,
     metricsServerConf: metricsServerConf,
     restServerConf: restServerConf,
     dnsDiscoveryConf: dnsDiscoveryConf,

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -26,6 +26,7 @@ import
   ../waku_core/codecs,
   ../rln,
   ../rln/rln_lez/rln_lez,
+  ../rln/rln_lez/transport,
   ../discovery/waku_dnsdisc,
   ../waku_archive/retention_policy as policy,
   ../waku_archive/retention_policy/builder as policy_builder,
@@ -331,26 +332,26 @@ proc setupProtocols(
   except CatchableError:
     return err("failed to mount libp2p ping protocol: " & getCurrentExceptionMsg())
 
-  if conf.rlnLezConf.isSome() or conf.rlnEvmConf.isSome():
+  # The RLN module backend is selected by the host installing an RLN plugin over
+  # FFI (`logosdelivery_rln_set_plugin`), not by configuration. The plugin is
+  # implementation-agnostic: the host owns its parameters and its lifecycle.
+  let rlnPlugin = rlnPluginRegistered()
+
+  if rlnPlugin and conf.rlnEvmConf.isSome():
+    return err(
+      "two RLN backends requested: an RLN plugin is installed and RLN relay is " &
+        "also configured for the embedded EVM backend"
+    )
+
+  if rlnPlugin or conf.rlnEvmConf.isSome():
     when defined(disable_rln):
       return
         err("the configuration enables RLN relay, but this build has -d:disable_rln")
 
-  if conf.rlnLezConf.isSome():
-    let rlnLezConf = conf.rlnLezConf.get()
-    # Module start happens in startNode, after the host installs its RLN callbacks.
-    node.rlnLez = RlnLez.init(
-      MembershipScope.init(rlnLezConf.registryId, rlnLezConf.identifier),
-      rlnLezConf.epochSizeSec,
-    )
-    let validatorConf = WakuRlnLezConfig(
-      registryId: rlnLezConf.registryId,
-      identifier: rlnLezConf.identifier,
-      userMessageLimit: rlnLezConf.userMessageLimit,
-      epochSizeSec: rlnLezConf.epochSizeSec,
-      registryOptionsJson: rlnLezConf.registryOptionsJson,
-      onFatalErrorAction: onFatalErrorAction,
-    )
+  if rlnPlugin:
+    info "Mounting RLN plugin backend"
+    node.rlnLez = RlnLez.init()
+    let validatorConf = WakuRlnLezConfig(onFatalErrorAction: onFatalErrorAction)
     try:
       await node.setRlnValidator(validatorConf)
     except CatchableError:
@@ -446,19 +447,6 @@ proc startNode*(
   ## keep-alive, if configured.
 
   info "Running nwaku node", version = git_version
-
-  # Start the external RLN module before the switch listens: the host installs
-  # its RLN callbacks between node creation and start, so this is the first
-  # point the module is reachable — and bringing it up first closes the window
-  # where inbound RLN traffic could only be Ignored. A node that cannot start
-  # its module silently stops relaying RLN traffic, so failure is fatal.
-  if not node.rlnLez.isNil():
-    try:
-      (await node.rlnLez.startModule()).isOkOr:
-        return err("failed to start RLN module: " & error)
-      info "RLN module started"
-    except CancelledError:
-      return err("cancelled while starting RLN module")
 
   try:
     await node.start()

--- a/logos_delivery/waku/factory/waku_conf.nim
+++ b/logos_delivery/waku/factory/waku_conf.nim
@@ -29,8 +29,7 @@ import
   ./conf_builder/kademlia_discovery_conf_builder
 
 export
-  RlnConf, RlnCreds, RlnLezConf, WakuRlnLezConfig, RestServerConf, Discv5Conf,
-  MetricsServerConf
+  RlnConf, RlnCreds, WakuRlnLezConfig, RestServerConf, Discv5Conf, MetricsServerConf
 # Export only the NatStrategy type and its parse and render procs.
 # The mapper machinery stays in net/nat_config.
 export nat_strategy
@@ -121,7 +120,6 @@ type WakuConf* {.requiresInit.} = ref object
   filterServiceConf*: Opt[FilterServiceConf]
   storeServiceConf*: Opt[StoreServiceConf]
   rlnEvmConf*: Opt[RlnConf]
-  rlnLezConf*: Opt[RlnLezConf]
   restServerConf*: Opt[RestServerConf]
   metricsServerConf*: Opt[MetricsServerConf]
   webSocketConf*: Opt[WebSocketConf]
@@ -168,7 +166,7 @@ type WakuConf* {.requiresInit.} = ref object
 proc logConf*(conf: WakuConf) =
   info "Configuration: Enabled protocols",
     relay = conf.relay,
-    rlnRelay = conf.rlnEvmConf.isSome() or conf.rlnLezConf.isSome(),
+    rlnRelay = conf.rlnEvmConf.isSome(),
     store = conf.storeServiceConf.isSome(),
     filter = conf.filterServiceConf.isSome(),
     lightPush = conf.lightPush,
@@ -184,15 +182,7 @@ proc logConf*(conf: WakuConf) =
     for i in conf.discv5Conf.get().bootstrapNodes:
       debug "Configuration. Bootstrap nodes", node = i.string
 
-  if conf.rlnLezConf.isSome():
-    let rlnLezConf = conf.rlnLezConf.get()
-    info "Configuration. Validation",
-      mechanism = "lez rln",
-      registryId = rlnLezConf.registryId,
-      maxMessageSize = conf.maxMessageSizeBytes,
-      rlnEpochSizeSec = rlnLezConf.epochSizeSec,
-      rlnRelayUserMessageLimit = rlnLezConf.userMessageLimit
-  elif conf.rlnEvmConf.isSome() and conf.rlnEvmConf.get().dynamic:
+  if conf.rlnEvmConf.isSome() and conf.rlnEvmConf.get().dynamic:
     let rlnEvmConf = conf.rlnEvmConf.get()
     info "Configuration. Validation",
       mechanism = "onchain rln",
@@ -239,10 +229,6 @@ proc validateNoEmptyStrings(wakuConf: WakuConf): Result[void, string] =
     return err("dns-discovery-url is an empty string")
 
   # TODO: rln relay config should validate itself
-  if wakuConf.rlnLezConf.isSome():
-    if isEmptyOrWhiteSpace(wakuConf.rlnLezConf.get().registryId):
-      return err("rln-registry-id is an empty string")
-
   if wakuConf.rlnEvmConf.isSome():
     let rlnEvmConf = wakuConf.rlnEvmConf.get()
 

--- a/logos_delivery/waku/node/waku_node/relay.nim
+++ b/logos_delivery/waku/node/waku_node/relay.nim
@@ -199,10 +199,6 @@ proc setRlnValidator*(
       info "WakuRelay not mounted; RLN validator not set"
       return
 
-    let
-      registryId = rlnConf.registryId
-      rlnIdentifier = rlnConf.identifier
-
     # Maps the module's verdict (RequestValidateRlnProof) to pubsub.ValidationResult.
     proc validator(
         topic: string, message: WakuMessage
@@ -218,9 +214,7 @@ proc setRlnValidator*(
       let timestamp = uint64(message.timestamp div 1_000_000_000)
 
       let res = (
-        await RequestValidateRlnProof.request(
-          node.brokerCtx, message, registryId, rlnIdentifier, timestamp
-        )
+        await RequestValidateRlnProof.request(node.brokerCtx, message, timestamp)
       ).valueOr:
         # no verdict from the module — don't score the peer down for our own failure
         trace "rln-lez validator ignore", error = error

--- a/logos_delivery/waku/requests/rln_requests.nim
+++ b/logos_delivery/waku/requests/rln_requests.nim
@@ -9,10 +9,7 @@ RequestBroker:
     proof*: seq[byte]
 
   proc signature(
-    message: WakuMessage,
-    registryId: RegistryId,
-    rlnIdentifier: RlnIdentifier,
-    timestamp: uint64,
+    message: WakuMessage, timestamp: uint64
   ): Future[Result[RequestGenerateRlnProof, string]] {.async.}
 
 RequestBroker:
@@ -20,34 +17,11 @@ RequestBroker:
     validation*: ValidationResult
 
   proc signature(
-    message: WakuMessage,
-    registryId: RegistryId,
-    rlnIdentifier: RlnIdentifier,
-    timestamp: uint64,
+    message: WakuMessage, timestamp: uint64
   ): Future[Result[RequestValidateRlnProof, string]] {.async.}
-
-## configJson: the module's start() config — at minimum {"epoch_size_sec":N},
-## plus "registries" to warm.
-RequestBroker:
-  type RequestStartRlnModule* = object
-    response*: string
-
-  proc signature(
-    configJson: string
-  ): Future[Result[RequestStartRlnModule, string]] {.async.}
-
-RequestBroker:
-  type RequestRegisterRlnMembership* = object
-    response*: string
-
-  proc signature(
-    registryId: RegistryId, rlnIdentifier: RlnIdentifier, options: RegistryOptions
-  ): Future[Result[RequestRegisterRlnMembership, string]] {.async.}
 
 RequestBroker:
   type RequestGetRlnMembershipState* = object
     state*: MembershipState
 
-  proc signature(
-    registryId: RegistryId, rlnIdentifier: RlnIdentifier
-  ): Future[Result[RequestGetRlnMembershipState, string]] {.async.}
+  proc signature(): Future[Result[RequestGetRlnMembershipState, string]] {.async.}

--- a/logos_delivery/waku/rln/rln_api.nim
+++ b/logos_delivery/waku/rln/rln_api.nim
@@ -11,31 +11,21 @@ export chronos, types
 ## vocabulary — logos-lips `docs/anoncomms/raw/rln-api.md` — mirrored in
 ## `./rln_lez/types`, not defined by this repo.
 ##
+## The surface is implementation-agnostic: no membership, registry or epoch
+## size appears in it. Starting, configuring and registering the backend belong
+## to whoever installs it.
+##
 ## Implementation contract:
 ## - calls made before the implementation can serve fail with `NotReady`;
 ##   unsupported optional extensions fail with `Permanent`
 ## - only `validateProof` writes the nullifier log
-## - `registerMembership` is idempotent while the scope's membership is
-##   `Pending`/`Active`/`GracePeriod` and returns `Pending` on submission —
-##   confirmation is observed via `getMembershipState`
 
 type RlnInterface* = concept m
-  start(m, config = string) is Future[Result[void, RlnError]]
-  stop(m) is Future[Result[void, RlnError]]
-  registerMembership(m, scope = MembershipScope, options = RegistryOptions) is
-    Future[Result[MembershipState, RlnError]]
-  getMembershipState(m, scope = MembershipScope) is
-    Future[Result[MembershipState, RlnError]]
-  getEpochQuota(m, scope = MembershipScope, timestamp = uint64) is
-    Future[Result[EpochQuota, RlnError]]
-  generateProof(m, scope = MembershipScope, signal = seq[byte], timestamp = uint64) is
+  getMembershipState(m) is Future[Result[MembershipState, RlnError]]
+  getEpochQuota(m, timestamp = uint64) is Future[Result[EpochQuota, RlnError]]
+  generateProof(m, signal = seq[byte], timestamp = uint64) is
     Future[Result[RateLimitProof, RlnError]]
-  validateProof(
-    m,
-    scope = MembershipScope,
-    signal = seq[byte],
-    timestamp = uint64,
-    proof = RateLimitProof,
-  ) is Future[Result[ValidationResult, RlnError]]
+  validateProof(m, signal = seq[byte], timestamp = uint64, proof = RateLimitProof) is
+    Future[Result[ValidationResult, RlnError]]
 
 {.pop.}

--- a/logos_delivery/waku/rln/rln_evm/rln_evm.nim
+++ b/logos_delivery/waku/rln/rln_evm/rln_evm.nim
@@ -229,13 +229,8 @@ proc mount(
   RequestGenerateRlnProof.setProvider(
     rlnEvm.brokerCtx,
     proc(
-        message: WakuMessage,
-        registryId: rln_api_types.RegistryId,
-        rlnIdentifier: rln_api_types.RlnIdentifier,
-        timestamp: uint64,
+        message: WakuMessage, timestamp: uint64
     ): Future[Result[RequestGenerateRlnProof, string]] {.async.} =
-      # The legacy zerokit path keeps its registry/identifier in the group
-      # manager, so only the signal and the sender epoch time are used here.
       let proofBytes = (
         await rlnEvm.generateRLNProofWithRootRefresh(
           message.toRLNSignal(), float64(timestamp)

--- a/logos_delivery/waku/rln/rln_lez/config.nim
+++ b/logos_delivery/waku/rln/rln_lez/config.nim
@@ -1,8 +1,10 @@
 {.push raises: [].}
 
-## The RLN plugin carries no configuration: the host owns the backend's
-## parameters and never hands them to the library. Only the node-local fatal
-## error handler remains, which is not RLN configuration.
+## The RLN plugin carries no configuration: the host — the application
+## embedding this library over its C ABI and installing the plugin, i.e.
+## logos-delivery-module — owns the backend's parameters and never hands them
+## to the library. Only the node-local fatal error handler remains, which is
+## not RLN configuration.
 
 import logos_delivery/waku/common/error_handling
 

--- a/logos_delivery/waku/rln/rln_lez/config.nim
+++ b/logos_delivery/waku/rln/rln_lez/config.nim
@@ -1,22 +1,12 @@
 {.push raises: [].}
 
-## RLN-LEZ backend configuration: membership scope and epoch parameters only.
-## The external module owns keystore, credentials, and registry connectivity.
+## The RLN plugin carries no configuration: the host owns the backend's
+## parameters and never hands them to the library. Only the node-local fatal
+## error handler remains, which is not RLN configuration.
 
 import logos_delivery/waku/common/error_handling
 
-type RlnLezConf* = object of RootObj
-  registryId*: string ## CAIP-10 account identifier selecting the registry deployment.
-  identifier*: array[32, byte]
-    ## Per-application RLN identifier, mixed into the external nullifier.
-  epochSizeSec*: uint64
-  userMessageLimit*: uint64
-  registryOptionsJson*: string
-    ## Flat JSON object of registry-specific registration options passed
-    ## verbatim to the external RLN module's register() (e.g. funding or
-    ## delegation options for the logos namespace). "{}" when unset.
-
-type WakuRlnLezConfig* = object of RlnLezConf
+type WakuRlnLezConfig* = object
   onFatalErrorAction*: OnFatalErrorHandler
 
 {.pop.}

--- a/logos_delivery/waku/rln/rln_lez/rln_lez.nim
+++ b/logos_delivery/waku/rln/rln_lez/rln_lez.nim
@@ -1,9 +1,11 @@
 {.push raises: [].}
 
-## `RlnInterface` backend over the external RLN module FFI (`./transport`).
-## The instance is created at mount (local wiring only); the module itself is
-## started from `startNode`, once the host has installed its RLN callbacks
-## (`logosdelivery_rln_set_callbacks`) — before that every call fails NotReady.
+## `RlnInterface` backend over the external RLN plugin (`./transport`).
+## Implementation-agnostic: the library never names a membership or a registry,
+## never configures the backend and never starts it — the host owns all of that
+## and supplies whatever its implementation needs when it forwards a call.
+## Calls fail NotReady until the host has installed its plugin
+## (`logosdelivery_rln_set_plugin`).
 
 import std/json
 import chronos, chronicles, results
@@ -17,17 +19,15 @@ logScope:
   topics = "waku rln lez"
 
 type RlnLez* = ref object
-  scope*: MembershipScope
-  epochSizeSec*: uint64
+  ## The typed calls below are the RlnInterface backend proper. The single
+  ## field is the node's cached view of whether it may send: the host's
+  ## implementation knows which membership that refers to.
   membershipVerified*: bool
-    ## Set once a membership check passes; `attachRlnProof` then skips the
-    ## registry read. Never set on failure, so the next send retries.
+    ## The membership check has passed once; `attachRlnProof` skips the
+    ## registry read on later sends.
 
 proc init*(T: type RlnLez): T =
   RlnLez()
-
-proc init*(T: type RlnLez, scope: MembershipScope, epochSizeSec: uint64): T =
-  RlnLez(scope: scope, epochSizeSec: epochSizeSec)
 
 proc toRlnError(transportErr: string): RlnError =
   ## Transport-level failures never carry a wire error object: no callbacks
@@ -38,62 +38,24 @@ proc toRlnError(transportErr: string): RlnError =
   else:
     RlnError.transient(transportErr)
 
-proc start*(
-    m: RlnLez, config: string
-): Future[Result[void, RlnError]] {.async: (raises: [CancelledError]).} =
-  ## `config` is the module's start config JSON (the node_factory shape:
-  ## epoch_size_sec, registries).
-  let response = (await rlnStart(config)).valueOr:
-    return err(toRlnError(error))
-  discard ?parseRlnResultEnvelope(response)
-  return ok()
-
-proc stop*(
-    m: RlnLez
-): Future[Result[void, RlnError]] {.async: (raises: [CancelledError]).} =
-  let response = (await rlnStop()).valueOr:
-    return err(toRlnError(error))
-  discard ?parseRlnResultEnvelope(response)
-  return ok()
-
-proc registerMembership*(
-    m: RlnLez, scope: MembershipScope, options: RegistryOptions
-): Future[Result[MembershipState, RlnError]] {.async: (raises: [CancelledError]).} =
-  var optionsJson = newJArray()
-  for opt in options:
-    optionsJson.add(%*{"key": opt.key, "value": opt.value})
-  let response = (
-    await rlnRegister(scope.registryId, scope.rlnIdentifier.toHex(), $optionsJson)
-  ).valueOr:
-    return err(toRlnError(error))
-  return parseRlnMembershipState(response)
-
 proc getMembershipState*(
-    m: RlnLez, scope: MembershipScope
+    m: RlnLez
 ): Future[Result[MembershipState, RlnError]] {.async: (raises: [CancelledError]).} =
-  let response = (
-    await rlnGetMembershipState(scope.registryId, scope.rlnIdentifier.toHex())
-  ).valueOr:
+  let response = (await rlnGetMembershipState()).valueOr:
     return err(toRlnError(error))
   return parseRlnMembershipState(response)
 
 proc getEpochQuota*(
-    m: RlnLez, scope: MembershipScope, timestamp: uint64
+    m: RlnLez, timestamp: uint64
 ): Future[Result[EpochQuota, RlnError]] {.async: (raises: [CancelledError]).} =
-  let response = (
-    await rlnGetEpochQuota(scope.registryId, scope.rlnIdentifier.toHex(), timestamp)
-  ).valueOr:
+  let response = (await rlnGetEpochQuota(timestamp)).valueOr:
     return err(toRlnError(error))
   return parseRlnEpochQuota(response)
 
 proc generateProof*(
-    m: RlnLez, scope: MembershipScope, signal: seq[byte], timestamp: uint64
+    m: RlnLez, signal: seq[byte], timestamp: uint64
 ): Future[Result[RateLimitProof, RlnError]] {.async: (raises: [CancelledError]).} =
-  let response = (
-    await rlnGenerateProof(
-      scope.registryId, scope.rlnIdentifier.toHex(), signal.toHex(), timestamp
-    )
-  ).valueOr:
+  let response = (await rlnGenerateProof(signal.toHex(), timestamp)).valueOr:
     return err(toRlnError(error))
   let blob = ?parseRlnGeneratedProof(response)
   if blob.len != RlnProofSize:
@@ -109,59 +71,22 @@ proc generateProof*(
   return ok(proof)
 
 proc validateProof*(
-    m: RlnLez,
-    scope: MembershipScope,
-    signal: seq[byte],
-    timestamp: uint64,
-    proof: RateLimitProof,
+    m: RlnLez, signal: seq[byte], timestamp: uint64, proof: RateLimitProof
 ): Future[Result[ValidationResult, RlnError]] {.async: (raises: [CancelledError]).} =
   let proofJson = $(%*{"proof": proof.proof.toHex()})
-  let response = (
-    await rlnValidateProof(
-      scope.registryId,
-      scope.rlnIdentifier.toHex(),
-      signal.toHex(),
-      timestamp,
-      proofJson,
-    )
-  ).valueOr:
+  let response = (await rlnValidateProof(signal.toHex(), timestamp, proofJson)).valueOr:
     return err(toRlnError(error))
   return parseRlnValidationResult(response)
 
 static:
   doAssert RlnLez is RlnInterface
 
-const
-  RlnStartAttempts = 3
-  RlnStartRetryDelay = 2.seconds
-
-proc startModule*(
-    w: RlnLez
-): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-  ## Starts the external RLN module. epoch_size_sec must equal this node's epoch
-  ## size so proof generators and validators derive the same epoch.
-  w.membershipVerified = false
-  let config =
-    $(%*{"epoch_size_sec": w.epochSizeSec, "registries": [w.scope.registryId]})
-  var lastErr: RlnError
-  for attempt in 1 .. RlnStartAttempts:
-    let res = await w.start(config)
-    if res.isOk():
-      return ok()
-    lastErr = res.error
-    if lastErr.kind notin {RlnErrorKind.NotReady, RlnErrorKind.Transient}:
-      break
-    if attempt < RlnStartAttempts:
-      debug "RLN module start not ready, retrying", attempt = attempt, error = $lastErr
-      await sleepAsync(RlnStartRetryDelay)
-  return err($lastErr)
-
 proc verifyMembership*(
     w: RlnLez
 ): Future[Result[MembershipStatus, string]] {.async: (raises: [CancelledError]).} =
-  ## Reads the scope's membership state; a usable result (Active/GracePeriod)
-  ## sets `membershipVerified`.
-  let state = (await w.getMembershipState(w.scope)).valueOr:
+  ## Reads the membership state from the host's implementation; a usable
+  ## result (Active/GracePeriod) sets `membershipVerified`.
+  let state = (await w.getMembershipState()).valueOr:
     return err($error)
   if state.status.isUsable():
     w.membershipVerified = true

--- a/logos_delivery/waku/rln/rln_lez/transport.nim
+++ b/logos_delivery/waku/rln/rln_lez/transport.nim
@@ -221,7 +221,7 @@ proc rlnPluginRegistered*(): bool =
   ## Whether the host has installed an RLN plugin. This is what enables RLN
   ## over it: there is no separate configuration switch.
   withLock gLock:
-    result = gRegistered
+    return gRegistered
 
 proc logosdelivery_rln_response*(
     reqId: uint64, resultJson: cstring

--- a/logos_delivery/waku/rln/rln_lez/transport.nim
+++ b/logos_delivery/waku/rln/rln_lez/transport.nim
@@ -20,50 +20,26 @@ from logos_delivery/waku/rln/rln_evm/proof import toRLNSignal
 export types
 
 type
-  LogosDeliveryRlnStartFn* = proc(reqId: uint64, configJson: cstring, userData: pointer) {.
-    cdecl, gcsafe, raises: []
-  .}
-
-  LogosDeliveryRlnStopFn* =
+  LogosDeliveryRlnGetMembershipStateFn* =
     proc(reqId: uint64, userData: pointer) {.cdecl, gcsafe, raises: [].}
 
-  LogosDeliveryRlnRegisterFn* = proc(
-    reqId: uint64,
-    registryId, rlnIdentifier: cstring,
-    optionsJson: cstring,
-    userData: pointer,
-  ) {.cdecl, gcsafe, raises: [].}
-
-  LogosDeliveryRlnGetMembershipStateFn* = proc(
-    reqId: uint64, registryId, rlnIdentifier: cstring, userData: pointer
-  ) {.cdecl, gcsafe, raises: [].}
-
   LogosDeliveryRlnGetEpochQuotaFn* = proc(
-    reqId: uint64,
-    registryId, rlnIdentifier: cstring,
-    timestamp: uint64,
-    userData: pointer,
+    reqId: uint64, timestamp: uint64, userData: pointer
   ) {.cdecl, gcsafe, raises: [].}
 
   LogosDeliveryRlnGenerateProofFn* = proc(
-    reqId: uint64,
-    registryId, rlnIdentifier, signalHex: cstring,
-    timestamp: uint64,
-    userData: pointer,
+    reqId: uint64, signalHex: cstring, timestamp: uint64, userData: pointer
   ) {.cdecl, gcsafe, raises: [].}
 
   LogosDeliveryRlnValidateProofFn* = proc(
     reqId: uint64,
-    registryId, rlnIdentifier, signalHex: cstring,
+    signalHex: cstring,
     timestamp: uint64,
     proofJson: cstring,
     userData: pointer,
   ) {.cdecl, gcsafe, raises: [].}
 
-  LogosDeliveryRlnCallbacks* = object
-    start*: LogosDeliveryRlnStartFn
-    stop*: LogosDeliveryRlnStopFn
-    register_membership*: LogosDeliveryRlnRegisterFn
+  LogosDeliveryRlnPlugin* = object
     get_membership_state*: LogosDeliveryRlnGetMembershipStateFn
     get_epoch_quota*: LogosDeliveryRlnGetEpochQuotaFn
     generate_proof*: LogosDeliveryRlnGenerateProofFn
@@ -78,10 +54,11 @@ type
 
 var
   gLock: Lock
-  gCallbacks: LogosDeliveryRlnCallbacks # all-nil struct = "not registered"
+  gPlugin: LogosDeliveryRlnPlugin # all-nil struct = "no plugin installed"
   gUserData: pointer
   gPending: ptr Pending # head of the in-flight request list
   gNextReqId: uint64
+  gRegistered: bool # a plugin has been installed
 
 initLock(gLock)
 
@@ -117,7 +94,6 @@ const
   # Per-call response budgets. Add 10s to each request's documented worst case.
   RlnLocalTimeout = 10.seconds
   RlnRegistryReadTimeout = 80.seconds
-  RlnRegisterTimeout = 200.seconds
 
 proc awaitResult(
     p: ptr Pending, timeout: Duration
@@ -143,33 +119,16 @@ proc awaitResult(
 # the lock, fire the callback (outside the lock, so a synchronous host response
 # can't deadlock), then await the JSON result.
 
-proc rlnStart*(
-    configJson: string
-): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
+proc rlnGetMembershipState*(): Future[Result[string, string]] {.
+    async: (raises: [CancelledError])
+.} =
+  var cb: LogosDeliveryRlnGetMembershipStateFn
+  var ud: pointer
   let pending = newPending()
   if pending.isNil:
-    return err("signal alloc failed")
-  var cb: LogosDeliveryRlnStartFn
-  var ud: pointer
+    return err("failed to allocate RLN request")
   withLock gLock:
-    cb = gCallbacks.start
-    if cb.isNil:
-      discard pending.signal.close()
-      deallocShared(pending)
-      return err("RLN module not registered")
-    ud = gUserData
-    linkPending(pending)
-  cb(pending.reqId, configJson.cstring, ud)
-  return await awaitResult(pending, RlnLocalTimeout)
-
-proc rlnStop*(): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
-  let pending = newPending()
-  if pending.isNil:
-    return err("signal alloc failed")
-  var cb: LogosDeliveryRlnStopFn
-  var ud: pointer
-  withLock gLock:
-    cb = gCallbacks.stop
+    cb = gPlugin.get_membership_state
     if cb.isNil:
       discard pending.signal.close()
       deallocShared(pending)
@@ -177,128 +136,92 @@ proc rlnStop*(): Future[Result[string, string]] {.async: (raises: [CancelledErro
     ud = gUserData
     linkPending(pending)
   cb(pending.reqId, ud)
-  return await awaitResult(pending, RlnLocalTimeout)
-
-proc rlnRegister*(
-    registryId, rlnIdentifier: string, optionsJson: string
-): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
-  let pending = newPending()
-  if pending.isNil:
-    return err("signal alloc failed")
-  var cb: LogosDeliveryRlnRegisterFn
-  var ud: pointer
-  withLock gLock:
-    cb = gCallbacks.register_membership
-    if cb.isNil:
-      discard pending.signal.close()
-      deallocShared(pending)
-      return err("RLN module not registered")
-    ud = gUserData
-    linkPending(pending)
-  cb(pending.reqId, registryId.cstring, rlnIdentifier.cstring, optionsJson.cstring, ud)
-  return await awaitResult(pending, RlnRegisterTimeout)
-
-proc rlnGetMembershipState*(
-    registryId, rlnIdentifier: string
-): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
-  let pending = newPending()
-  if pending.isNil:
-    return err("signal alloc failed")
-  var cb: LogosDeliveryRlnGetMembershipStateFn
-  var ud: pointer
-  withLock gLock:
-    cb = gCallbacks.get_membership_state
-    if cb.isNil:
-      discard pending.signal.close()
-      deallocShared(pending)
-      return err("RLN module not registered")
-    ud = gUserData
-    linkPending(pending)
-  cb(pending.reqId, registryId.cstring, rlnIdentifier.cstring, ud)
   return await awaitResult(pending, RlnRegistryReadTimeout)
 
 proc rlnGetEpochQuota*(
-    registryId, rlnIdentifier: string, timestamp: uint64
+    timestamp: uint64
 ): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
-  let pending = newPending()
-  if pending.isNil:
-    return err("signal alloc failed")
   var cb: LogosDeliveryRlnGetEpochQuotaFn
   var ud: pointer
+  let pending = newPending()
+  if pending.isNil:
+    return err("failed to allocate RLN request")
   withLock gLock:
-    cb = gCallbacks.get_epoch_quota
+    cb = gPlugin.get_epoch_quota
     if cb.isNil:
       discard pending.signal.close()
       deallocShared(pending)
       return err("RLN module not registered")
     ud = gUserData
     linkPending(pending)
-  cb(pending.reqId, registryId.cstring, rlnIdentifier.cstring, timestamp, ud)
+  cb(pending.reqId, timestamp, ud)
   return await awaitResult(pending, RlnLocalTimeout)
 
 proc rlnGenerateProof*(
-    registryId, rlnIdentifier, signalHex: string, timestamp: uint64
+    signalHex: string, timestamp: uint64
 ): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
-  let pending = newPending()
-  if pending.isNil:
-    return err("signal alloc failed")
   var cb: LogosDeliveryRlnGenerateProofFn
   var ud: pointer
+  let pending = newPending()
+  if pending.isNil:
+    return err("failed to allocate RLN request")
   withLock gLock:
-    cb = gCallbacks.generate_proof
+    cb = gPlugin.generate_proof
     if cb.isNil:
       discard pending.signal.close()
       deallocShared(pending)
       return err("RLN module not registered")
     ud = gUserData
     linkPending(pending)
-  cb(
-    pending.reqId, registryId.cstring, rlnIdentifier.cstring, signalHex.cstring,
-    timestamp, ud,
-  )
+  cb(pending.reqId, signalHex.cstring, timestamp, ud)
   return await awaitResult(pending, RlnRegistryReadTimeout)
 
 proc rlnValidateProof*(
-    registryId, rlnIdentifier, signalHex: string, timestamp: uint64, proofJson: string
+    signalHex: string, timestamp: uint64, proofJson: string
 ): Future[Result[string, string]] {.async: (raises: [CancelledError]).} =
-  let pending = newPending()
-  if pending.isNil:
-    return err("signal alloc failed")
   var cb: LogosDeliveryRlnValidateProofFn
   var ud: pointer
+  let pending = newPending()
+  if pending.isNil:
+    return err("failed to allocate RLN request")
   withLock gLock:
-    cb = gCallbacks.validate_proof
+    cb = gPlugin.validate_proof
     if cb.isNil:
       discard pending.signal.close()
       deallocShared(pending)
       return err("RLN module not registered")
     ud = gUserData
     linkPending(pending)
-  cb(
-    pending.reqId, registryId.cstring, rlnIdentifier.cstring, signalHex.cstring,
-    timestamp, proofJson.cstring, ud,
-  )
+  cb(pending.reqId, signalHex.cstring, timestamp, proofJson.cstring, ud)
   return await awaitResult(pending, RlnLocalTimeout)
 
 # --- C entry points -----------------------------------------------------------
 
-proc logosdelivery_rln_set_callbacks*(
-    cbs: ptr LogosDeliveryRlnCallbacks, userData: pointer
+proc logosdelivery_rln_set_plugin*(
+    plugin: ptr LogosDeliveryRlnPlugin, userData: pointer
 ): cint {.exportc, cdecl, dynlib.} =
-  # copy struct (or clear on nil), stash userData; nil fails all pending
+  # copy the struct (or clear on nil), stash userData; nil fails all pending
   withLock gLock:
-    if cbs.isNil:
-      gCallbacks = LogosDeliveryRlnCallbacks()
+    if plugin.isNil:
+      gPlugin = LogosDeliveryRlnPlugin()
       gUserData = nil
+      gRegistered = false
       var p = gPending
       while not p.isNil:
         p.completed = false # signals "module cleared", not a real completion
         discard p.signal.fireSync()
         p = p.next
     else:
-      gCallbacks = cbs[]
+      gPlugin = plugin[]
       gUserData = userData
+      gRegistered = true
     return 0
+
+proc rlnPluginRegistered*(): bool =
+  ## Whether the host has installed an RLN plugin. This is what enables RLN
+  ## over it: there is no separate configuration switch.
+  withLock gLock:
+    result = gRegistered
 
 proc logosdelivery_rln_response*(
     reqId: uint64, resultJson: cstring
@@ -489,41 +412,16 @@ proc parseRlnMembershipState*(resultJson: string): Result[MembershipState, RlnEr
 
 # --- broker providers ---------------------------------------------------------
 
-proc registerRlnModuleProviders*(ctx: BrokerContext, lez: bool): Result[void, string] =
-  ## Bridges the waku layer's RLN module requests onto the FFI callback
-  ## surface. Providers are registered at create time; the underlying calls
-  ## only succeed once the host has installed its RLN callbacks.
-  RequestStartRlnModule.setProvider(
-    ctx,
-    proc(configJson: string): Future[Result[RequestStartRlnModule, string]] {.async.} =
-      let response = ?await rlnStart(configJson)
-      discard parseRlnResultEnvelope(response).valueOr:
-        return err($error)
-      return ok(RequestStartRlnModule(response: response)),
-  ).isOkOr:
-    return err("Failed to set RequestStartRlnModule provider: " & error)
-
-  RequestRegisterRlnMembership.setProvider(
-    ctx,
-    proc(
-        registryId: RegistryId, rlnIdentifier: RlnIdentifier, options: RegistryOptions
-    ): Future[Result[RequestRegisterRlnMembership, string]] {.async.} =
-      var optionsJson = newJArray()
-      for opt in options:
-        optionsJson.add(%*{"key": opt.key, "value": opt.value})
-      let response = ?await rlnRegister(registryId, rlnIdentifier.toHex(), $optionsJson)
-      discard parseRlnTstrReply(response).valueOr:
-        return err($error)
-      return ok(RequestRegisterRlnMembership(response: response)),
-  ).isOkOr:
-    return err("Failed to set RequestRegisterRlnMembership provider: " & error)
-
+proc registerRlnModuleProviders*(
+    ctx: BrokerContext, plugin: bool
+): Result[void, string] =
+  ## Bridges the waku layer's RLN requests onto the FFI plugin surface.
+  ## Providers are registered at create time; the underlying calls only succeed
+  ## once the host has installed its plugin.
   RequestGetRlnMembershipState.setProvider(
     ctx,
-    proc(
-        registryId: RegistryId, rlnIdentifier: RlnIdentifier
-    ): Future[Result[RequestGetRlnMembershipState, string]] {.async.} =
-      let response = ?await rlnGetMembershipState(registryId, rlnIdentifier.toHex())
+    proc(): Future[Result[RequestGetRlnMembershipState, string]] {.async.} =
+      let response = ?await rlnGetMembershipState()
       let state = parseRlnMembershipState(response).valueOr:
         return err($error)
       return ok(RequestGetRlnMembershipState(state: state)),
@@ -533,40 +431,31 @@ proc registerRlnModuleProviders*(ctx: BrokerContext, lez: bool): Result[void, st
   RequestValidateRlnProof.setProvider(
     ctx,
     proc(
-        message: WakuMessage,
-        registryId: RegistryId,
-        rlnIdentifier: RlnIdentifier,
-        timestamp: uint64,
+        message: WakuMessage, timestamp: uint64
     ): Future[Result[RequestValidateRlnProof, string]] {.async.} =
       let signalHex = message.toRLNSignal().toHex()
       let proofJson = $(%*{"proof": message.proof.toHex()})
-      let response = ?await rlnValidateProof(
-        registryId, rlnIdentifier.toHex(), signalHex, timestamp, proofJson
-      )
+      let response = ?await rlnValidateProof(signalHex, timestamp, proofJson)
       let validation = parseRlnValidationResult(response).valueOr:
         return err($error)
       return ok(RequestValidateRlnProof(validation: validation)),
   ).isOkOr:
     return err("Failed to set RequestValidateRlnProof provider: " & error)
 
-  # lez-gated: the legacy zerokit path registers its own provider for this request type
-  if lez:
+  # plugin-gated: the legacy zerokit path registers its own provider for this
+  # request type
+  if plugin:
     RequestGenerateRlnProof.setProvider(
       ctx,
       proc(
-          message: WakuMessage,
-          registryId: RegistryId,
-          rlnIdentifier: RlnIdentifier,
-          timestamp: uint64,
+          message: WakuMessage, timestamp: uint64
       ): Future[Result[RequestGenerateRlnProof, string]] {.async.} =
         let signalHex = message.toRLNSignal().toHex()
-        let response = ?await rlnGenerateProof(
-          registryId, rlnIdentifier.toHex(), signalHex, timestamp
-        )
-        let proofBytes = parseRlnGeneratedProof(response).valueOr:
+        let response = ?await rlnGenerateProof(signalHex, timestamp)
+        let blob = parseRlnGeneratedProof(response).valueOr:
           return err($error)
-        return ok(RequestGenerateRlnProof(proof: proofBytes)),
+        return ok(RequestGenerateRlnProof(proof: blob)),
     ).isOkOr:
-      return err("failed to set RequestGenerateRlnProof provider: " & error)
+      return err("Failed to set RequestGenerateRlnProof provider: " & error)
 
-  ok()
+  return ok()

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -277,36 +277,11 @@ suite "parseLogosDeliveryConf - JSON parsing":
       raiseAssert error
     check WakuNodeConf(lc.kernelConf).ethClientUrls.len == 1
 
-  test "flat blob carries the LEZ RLN fields into the kernel conf":
-    let lc = parseLogosDeliveryConf(
-      """{"mode": "Core", "rln-relay": true, "rln-lez": true, "rln-registry-id": "logos:testnet:00aa", "rln-identifier": "1220000000000000000000000000000000000000000000000000000000000000", "rln-relay-epoch-sec": 600, "rln-relay-user-message-limit": 100}"""
-    ).valueOr:
-      raiseAssert error
-    let kc = WakuNodeConf(lc.kernelConf)
-    check:
-      kc.rlnRelay == Opt.some(true)
-      kc.rlnRelayLez == Opt.some(true)
-      kc.rlnRelayRegistryId == "logos:testnet:00aa"
-      kc.rlnRelayIdentifier ==
-        "1220000000000000000000000000000000000000000000000000000000000000"
-      kc.rlnEpochSizeSec == Opt.some(600'u64)
-      kc.rlnRelayUserMessageLimit == Opt.some(100'u64)
-
-  test "messagingOverrides carry the LEZ RLN fields; lez implies rln-relay":
-    let lc = parseLogosDeliveryConf(
-      """{"messagingOverrides": {"rln-lez": true, "rln-registry-id": "logos:testnet:00aa", "rln-identifier": "1220000000000000000000000000000000000000000000000000000000000000", "rln-relay-epoch-sec": 600, "rln-relay-user-message-limit": 100, "rln-registry-options": "{\"funding_holding_account_id\":\"acc1\"}"}}"""
-    ).valueOr:
-      raiseAssert error
-    let kc = WakuNodeConf(lc.kernelConf)
-    check:
-      kc.rlnRelay == Opt.some(true) # lifted by rln-lez, no explicit rln-relay key
-      kc.rlnRelayLez == Opt.some(true)
-      kc.rlnRelayRegistryId == "logos:testnet:00aa"
-      kc.rlnRelayIdentifier ==
-        "1220000000000000000000000000000000000000000000000000000000000000"
-      kc.rlnRelayRegistryOptions == """{"funding_holding_account_id":"acc1"}"""
-      kc.rlnEpochSizeSec == Opt.some(600'u64)
-      kc.rlnRelayUserMessageLimit == Opt.some(100'u64)
+  test "the LEZ RLN options are not accepted from configuration":
+    # The RLN plugin is installed over FFI and carries its own configuration.
+    for key in ["rln-lez", "rln-registry-id", "rln-identifier", "rln-registry-options"]:
+      check parseLogosDeliveryConf("{\"messagingOverrides\": {\"" & key & "\": \"x\"}}")
+        .isErr()
 
   test "store backend fields fold into the kernel conf":
     let lc = parseLogosDeliveryConf(

--- a/tests/api/test_node_conf.nim
+++ b/tests/api/test_node_conf.nim
@@ -72,7 +72,7 @@ suite "WakuNodeConf - preset integration":
       wakuConf.clusterId == 16
       wakuConf.shardingConf.kind == AutoSharding
       wakuConf.shardingConf.numShardsInCluster == 1
-      wakuConf.rlnEvmConf.isNone() and wakuConf.rlnLezConf.isNone()
+      wakuConf.rlnEvmConf.isNone()
 
   test "Invalid preset returns error":
     ## Given
@@ -91,7 +91,7 @@ suite "WakuNodeConf - preset integration":
       wakuConf.clusterId == 16
       wakuConf.shardingConf.kind == AutoSharding
       wakuConf.shardingConf.numShardsInCluster == 1
-      wakuConf.rlnEvmConf.isNone() and wakuConf.rlnLezConf.isNone()
+      wakuConf.rlnEvmConf.isNone()
 
   test "Invalid preset returns error":
     ## Given

--- a/tests/factory/test_waku_conf.nim
+++ b/tests/factory/test_waku_conf.nim
@@ -103,7 +103,7 @@ suite "Waku Conf - build with cluster conf":
       uint64(parseCorrectMsgSize(networkPresetConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkPresetConf.discv5BootstrapNodes
 
-    assert conf.rlnEvmConf.isNone and conf.rlnLezConf.isNone
+    assert conf.rlnEvmConf.isNone
 
   test "Cluster Conf is passed, but rln relay is disabled":
     ## Setup
@@ -134,7 +134,7 @@ suite "Waku Conf - build with cluster conf":
     check conf.maxMessageSizeBytes ==
       uint64(parseCorrectMsgSize(networkPresetConf.maxMessageSize))
     check conf.discv5Conf.get().bootstrapNodes == networkPresetConf.discv5BootstrapNodes
-    assert conf.rlnEvmConf.isNone and conf.rlnLezConf.isNone
+    assert conf.rlnEvmConf.isNone
 
   test "Cluster Conf is passed and valid shards are specified":
     ## Setup
@@ -405,49 +405,3 @@ suite "Waku Conf Builder - rate limits":
 
     ## Then
     assert res.isOk(), $res.error
-
-suite "Rln Conf Builder - LEZ":
-  const LezIdentifierHex =
-    "1220000000000000000000000000000000000000000000000000000000000000"
-
-  test "LEZ conf builds with registry id and decoded identifier":
-    ## Given
-    var builder = RlnConfBuilder.init()
-    builder.withEnabled(true)
-    builder.withLez(true)
-    builder.withRegistryId("logos:testnet:00aa")
-    builder.withIdentifier(LezIdentifierHex)
-    builder.withEpochSizeSec(600)
-    builder.withUserMessageLimit(100)
-
-    ## When
-    let res = builder.build()
-
-    ## Then
-    assert res.isOk(), $res.error
-    check res.get().evm.isNone()
-    require res.get().lez.isSome()
-    let conf = res.get().lez.get()
-    var expectedIdentifier: array[32, byte]
-    hexToByteArray(LezIdentifierHex, expectedIdentifier)
-    check:
-      conf.registryId == "logos:testnet:00aa"
-      conf.identifier == expectedIdentifier
-      conf.epochSizeSec == 600
-      conf.userMessageLimit == 100
-      conf.registryOptionsJson == "{}" # default when unset
-
-  test "a malformed identifier fails the build":
-    var builder = RlnConfBuilder.init()
-    builder.withEnabled(true)
-    builder.withLez(true)
-    builder.withRegistryId("logos:testnet:00aa")
-    builder.withIdentifier("not-hex")
-    check builder.build().isErr()
-
-  test "a missing registry id fails the build":
-    var builder = RlnConfBuilder.init()
-    builder.withEnabled(true)
-    builder.withLez(true)
-    builder.withIdentifier(LezIdentifierHex)
-    check builder.build().isErr()

--- a/tests/waku_rln_relay/test_rln_interface.nim
+++ b/tests/waku_rln_relay/test_rln_interface.nim
@@ -7,23 +7,8 @@ import logos_delivery/waku/rln/rln_api
 type StubRlnModule = ref object
   quota: EpochQuota
 
-proc start(
-    m: StubRlnModule, config: string
-): Future[Result[void, RlnError]] {.async: (raises: [CancelledError]).} =
-  return ok()
-
-proc stop(
-    m: StubRlnModule
-): Future[Result[void, RlnError]] {.async: (raises: [CancelledError]).} =
-  return ok()
-
-proc registerMembership(
-    m: StubRlnModule, scope: MembershipScope, options: RegistryOptions
-): Future[Result[MembershipState, RlnError]] {.async: (raises: [CancelledError]).} =
-  return ok(MembershipState(status: MembershipStatus.Pending))
-
 proc getMembershipState(
-    m: StubRlnModule, scope: MembershipScope
+    m: StubRlnModule
 ): Future[Result[MembershipState, RlnError]] {.async: (raises: [CancelledError]).} =
   return ok(
     MembershipState(
@@ -33,21 +18,17 @@ proc getMembershipState(
   )
 
 proc getEpochQuota(
-    m: StubRlnModule, scope: MembershipScope, timestamp: uint64
+    m: StubRlnModule, timestamp: uint64
 ): Future[Result[EpochQuota, RlnError]] {.async: (raises: [CancelledError]).} =
   return ok(m.quota)
 
 proc generateProof(
-    m: StubRlnModule, scope: MembershipScope, signal: seq[byte], timestamp: uint64
+    m: StubRlnModule, signal: seq[byte], timestamp: uint64
 ): Future[Result[RateLimitProof, RlnError]] {.async: (raises: [CancelledError]).} =
   return ok(RateLimitProof())
 
 proc validateProof(
-    m: StubRlnModule,
-    scope: MembershipScope,
-    signal: seq[byte],
-    timestamp: uint64,
-    proof: RateLimitProof,
+    m: StubRlnModule, signal: seq[byte], timestamp: uint64, proof: RateLimitProof
 ): Future[Result[ValidationResult, RlnError]] {.async: (raises: [CancelledError]).} =
   return ok(ValidationResult(verdict: ProofVerdict.Valid))
 
@@ -87,22 +68,18 @@ suite "RLN interface - types":
 
     let m =
       StubRlnModule(quota: EpochQuota(epochIndex: 42, rateLimit: 100, remaining: 99))
-    var rlnId: RlnIdentifier
-    let scope = MembershipScope.init("logos:testnet:00", rlnId)
     let timestamp = 1_700_000_000'u64
 
-    let quota = (waitFor m.getEpochQuota(scope, timestamp)).valueOr:
+    let quota = (waitFor m.getEpochQuota(timestamp)).valueOr:
       raiseAssert $error
     let validation = (
-      waitFor m.validateProof(scope, @[1'u8, 2, 3], timestamp, RateLimitProof())
+      waitFor m.validateProof(@[1'u8, 2, 3], timestamp, RateLimitProof())
     ).valueOr:
       raiseAssert $error
-    let state = (waitFor m.getMembershipState(scope)).valueOr:
+    let state = (waitFor m.getMembershipState()).valueOr:
       raiseAssert $error
 
     check:
-      (waitFor m.start("{}")).isOk()
       quota.remaining == 99
       validation.verdict == ProofVerdict.Valid
       state.membership.isSome()
-      (waitFor m.stop()).isOk()

--- a/tests/waku_rln_relay/test_rln_lez.nim
+++ b/tests/waku_rln_relay/test_rln_lez.nim
@@ -1,9 +1,9 @@
 {.used.}
 
-## Drives `RlnLez` (the RlnInterface backend over the module-API FFI
-## crossing) against a fake host: real C entry points, canned wire replies
-## answered synchronously through `logosdelivery_rln_response`. Covers both
-## wire dialects, both error paths (transport-level and module-level), and the
+## Drives `RlnLez` (the RlnInterface backend over the RLN plugin FFI crossing)
+## against a fake host: real C entry points, canned wire replies answered
+## synchronously through `logosdelivery_rln_response`. Covers both wire
+## dialects, both error paths (transport-level and module-level), and the
 ## canonical-proof round trip.
 
 import std/strutils
@@ -13,13 +13,11 @@ import logos_delivery/waku/rln/rln_lez/rln_lez
 import logos_delivery/waku/rln/rln_lez/transport
 
 const
-  OkEnvelope = """{"error":null,"success":true,"value":{"started":true}}"""
   QuotaReply =
     """{"error":null,"success":true,"value":{"epoch_index":42,"rate_limit":100,"remaining":99}}"""
   StateReply =
     """{"state":"active","membership_hash":"""" & repeat("aa", 32) &
     """","rate_limit":100,"leaf_index":7}"""
-  RegisterReply = """{"state":"pending"}"""
   NotReadyEnvelope =
     """{"success":false,"error":"{\"class\":\"not_ready\",\"kind\":\"module_stopped\",\"message\":\"not started\"}"}"""
 
@@ -34,58 +32,30 @@ let
 
 # The fake host: each callback answers its canned reply immediately, on the
 # caller's thread (the crossing explicitly supports a synchronous response).
+# No callback carries a registry, a membership or any configuration.
 var
-  gStartReply = OkEnvelope
+  gQuotaReply = QuotaReply
   gValidateReply = ViolationReply
-  gLastRegistryId = ""
 
-proc fakeStart(
-    reqId: uint64, configJson: cstring, userData: pointer
-) {.cdecl, gcsafe, raises: [].} =
-  {.cast(gcsafe), cast(raises: []).}:
-    discard logosdelivery_rln_response(reqId, gStartReply.cstring)
-
-proc fakeStop(reqId: uint64, userData: pointer) {.cdecl, gcsafe, raises: [].} =
-  {.cast(gcsafe), cast(raises: []).}:
-    discard logosdelivery_rln_response(reqId, OkEnvelope.cstring)
-
-proc fakeRegister(
-    reqId: uint64,
-    registryId, rlnIdentifier: cstring,
-    optionsJson: cstring,
-    userData: pointer,
-) {.cdecl, gcsafe, raises: [].} =
-  {.cast(gcsafe), cast(raises: []).}:
-    gLastRegistryId = $registryId
-    discard logosdelivery_rln_response(reqId, RegisterReply.cstring)
-
-proc fakeGetState(
-    reqId: uint64, registryId, rlnIdentifier: cstring, userData: pointer
-) {.cdecl, gcsafe, raises: [].} =
+proc fakeGetState(reqId: uint64, userData: pointer) {.cdecl, gcsafe, raises: [].} =
   {.cast(gcsafe), cast(raises: []).}:
     discard logosdelivery_rln_response(reqId, StateReply.cstring)
 
 proc fakeGetQuota(
-    reqId: uint64,
-    registryId, rlnIdentifier: cstring,
-    timestamp: uint64,
-    userData: pointer,
+    reqId: uint64, timestamp: uint64, userData: pointer
 ) {.cdecl, gcsafe, raises: [].} =
   {.cast(gcsafe), cast(raises: []).}:
-    discard logosdelivery_rln_response(reqId, QuotaReply.cstring)
+    discard logosdelivery_rln_response(reqId, gQuotaReply.cstring)
 
 proc fakeGenerate(
-    reqId: uint64,
-    registryId, rlnIdentifier, signalHex: cstring,
-    timestamp: uint64,
-    userData: pointer,
+    reqId: uint64, signalHex: cstring, timestamp: uint64, userData: pointer
 ) {.cdecl, gcsafe, raises: [].} =
   {.cast(gcsafe), cast(raises: []).}:
     discard logosdelivery_rln_response(reqId, GenerateReply.cstring)
 
 proc fakeValidate(
     reqId: uint64,
-    registryId, rlnIdentifier, signalHex: cstring,
+    signalHex: cstring,
     timestamp: uint64,
     proofJson: cstring,
     userData: pointer,
@@ -93,57 +63,42 @@ proc fakeValidate(
   {.cast(gcsafe), cast(raises: []).}:
     discard logosdelivery_rln_response(reqId, gValidateReply.cstring)
 
-var gCallbacks = LogosDeliveryRlnCallbacks(
-  start: fakeStart,
-  stop: fakeStop,
-  register_membership: fakeRegister,
+var gPlugin = LogosDeliveryRlnPlugin(
   get_membership_state: fakeGetState,
   get_epoch_quota: fakeGetQuota,
   generate_proof: fakeGenerate,
   validate_proof: fakeValidate,
 )
 
-suite "RlnLez - RlnInterface over the module FFI crossing":
-  var rlnId: RlnIdentifier
-  rlnId[0] = 1'u8
+suite "RlnLez - RlnInterface over the RLN plugin FFI crossing":
   let
-    scope = MembershipScope.init("logos:testnet:0", rlnId)
     timestamp = 1_700_000_000'u64
-    configJson = """{"epoch_size_sec":120,"registries":["logos:testnet:0"]}"""
     rlnLez = RlnLez.init()
 
-  test "unregistered host fails NotReady":
-    let res = waitFor rlnLez.start(configJson)
+  test "no plugin installed fails NotReady":
+    check logosdelivery_rln_set_plugin(nil, nil) == 0
+    check not rlnPluginRegistered()
+    let res = waitFor rlnLez.getEpochQuota(timestamp)
     check:
       res.isErr()
       res.error.kind == RlnErrorKind.NotReady
 
-  test "start and stop round-trip the result envelope":
-    check logosdelivery_rln_set_callbacks(addr gCallbacks, nil) == 0
-    check:
-      (waitFor rlnLez.start(configJson)).isOk()
-      (waitFor rlnLez.stop()).isOk()
+  test "installing the plugin enables the backend":
+    check logosdelivery_rln_set_plugin(addr gPlugin, nil) == 0
+    check rlnPluginRegistered()
 
   test "module-level failure decodes into the typed error":
-    gStartReply = NotReadyEnvelope
+    gQuotaReply = NotReadyEnvelope
     defer:
-      gStartReply = OkEnvelope
-    let res = waitFor rlnLez.start(configJson)
+      gQuotaReply = QuotaReply
+    let res = waitFor rlnLez.getEpochQuota(timestamp)
     check:
       res.isErr()
       res.error.kind == RlnErrorKind.NotReady
       "module_stopped" in res.error.message
 
-  test "registerMembership submits and reports the pending state":
-    let options = @[RegistryOption(key: "rate_limit", value: "100")]
-    let state = (waitFor rlnLez.registerMembership(scope, options)).valueOr:
-      raiseAssert $error
-    check:
-      state.status == MembershipStatus.Pending
-      gLastRegistryId == scope.registryId
-
   test "getMembershipState decodes the tstr reply":
-    let state = (waitFor rlnLez.getMembershipState(scope)).valueOr:
+    let state = (waitFor rlnLez.getMembershipState()).valueOr:
       raiseAssert $error
     check:
       state.status == MembershipStatus.Active
@@ -151,8 +106,17 @@ suite "RlnLez - RlnInterface over the module FFI crossing":
       state.membership.get().rateLimit == 100
       state.membership.get().leafIndex == 7
 
+  test "verifyMembership caches a usable membership":
+    let rln = RlnLez.init()
+    check not rln.membershipVerified
+    let status = (waitFor rln.verifyMembership()).valueOr:
+      raiseAssert $error
+    check:
+      status == MembershipStatus.Active
+      rln.membershipVerified
+
   test "getEpochQuota decodes the envelope value":
-    let quota = (waitFor rlnLez.getEpochQuota(scope, timestamp)).valueOr:
+    let quota = (waitFor rlnLez.getEpochQuota(timestamp)).valueOr:
       raiseAssert $error
     check:
       quota.epochIndex == 42
@@ -160,18 +124,16 @@ suite "RlnLez - RlnInterface over the module FFI crossing":
       quota.remaining == 99
 
   test "generateProof carries the canonical blob":
-    let proof = (waitFor rlnLez.generateProof(scope, @[1'u8, 2, 3], timestamp)).valueOr:
+    let proof = (waitFor rlnLez.generateProof(@[1'u8, 2, 3], timestamp)).valueOr:
       raiseAssert $error
     check:
       proof.proof[0] == 0xab'u8
       proof.proof[RlnProofSize - 1] == 0xab'u8
 
   test "validateProof decodes verdict and recovered secret":
-    let generated = (waitFor rlnLez.generateProof(scope, @[1'u8, 2, 3], timestamp)).valueOr:
+    let generated = (waitFor rlnLez.generateProof(@[1'u8, 2, 3], timestamp)).valueOr:
       raiseAssert $error
-    let validation = (
-      waitFor rlnLez.validateProof(scope, @[1'u8, 2, 3], timestamp, generated)
-    ).valueOr:
+    let validation = (waitFor rlnLez.validateProof(@[1'u8, 2, 3], timestamp, generated)).valueOr:
       raiseAssert $error
     check:
       validation.verdict == ProofVerdict.RateLimitViolation
@@ -179,17 +141,15 @@ suite "RlnLez - RlnInterface over the module FFI crossing":
       validation.recoveredSecret.get()[0] == 0xcd'u8
 
     gValidateReply = """{"error":null,"success":true,"value":{"verdict":"valid"}}"""
-    let valid = (
-      waitFor rlnLez.validateProof(scope, @[1'u8, 2, 3], timestamp, generated)
-    ).valueOr:
+    let valid = (waitFor rlnLez.validateProof(@[1'u8, 2, 3], timestamp, generated)).valueOr:
       raiseAssert $error
     check:
       valid.verdict == ProofVerdict.Valid
       valid.recoveredSecret.isNone()
 
-  test "clearing the host callbacks returns the backend to NotReady":
-    check logosdelivery_rln_set_callbacks(nil, nil) == 0
-    let res = waitFor rlnLez.getEpochQuota(scope, timestamp)
+  test "clearing the plugin returns the backend to NotReady":
+    check logosdelivery_rln_set_plugin(nil, nil) == 0
+    let res = waitFor rlnLez.getEpochQuota(timestamp)
     check:
       res.isErr()
       res.error.kind == RlnErrorKind.NotReady

--- a/tests/waku_rln_relay/test_wakunode_rln_relay.nim
+++ b/tests/waku_rln_relay/test_wakunode_rln_relay.nim
@@ -794,14 +794,8 @@ procSuite "WakuNode - RLN relay":
       rlnManager.merkleProofCache = newSeq[byte](goodCache.len)
 
       let msg = fakeWakuMessage()
-      const testRegistryId =
-        "logos:selftest:0000000000000000000000000000000000000000000000000000000000000000"
       let proofResult = await RequestGenerateRlnProof.request(
-        node.rln.brokerCtx,
-        msg,
-        testRegistryId,
-        default(rln_api_types.RlnIdentifier),
-        uint64(epochTime()),
+        node.rln.brokerCtx, msg, uint64(epochTime())
       )
 
       check proofResult.isOk()

--- a/tools/confutils/cli_args.nim
+++ b/tools/confutils/cli_args.nim
@@ -115,35 +115,6 @@ type WakuNodeConf* = object
     name: "rln-relay-cred-password"
   .}: string
 
-  # Opt-typed; desc states the default since the CLI can't auto-show it for Opt.none().
-  rlnRelayLez* {.
-    desc:
-      "Use the LEZ registry backed RLN module instead of on-chain group management: true|false. Default is false.",
-    defaultValue: Opt.none(bool),
-    name: "rln-lez"
-  .}: Opt[bool]
-
-  rlnRelayRegistryId* {.
-    desc:
-      "CAIP-10 account identifier of the LEZ RLN registry deployment, e.g. logos:<network>:<64-hex>",
-    defaultValue: "",
-    name: "rln-registry-id"
-  .}: string
-
-  rlnRelayIdentifier* {.
-    desc: "32-byte hex per-application RLN identifier for the LEZ registry",
-    defaultValue: "",
-    name: "rln-identifier"
-  .}: string
-
-  rlnRelayRegistryOptions* {.
-    desc:
-      "Flat JSON object of registry-specific registration options passed verbatim " &
-      "to the external RLN module's register(), e.g. funding or delegation options",
-    defaultValue: "",
-    name: "rln-registry-options"
-  .}: string
-
   rlnRelayEthPrivateKey* {.
     desc: "Private key for broadcasting transactions",
     defaultValue: "",
@@ -1076,14 +1047,6 @@ proc toWakuConf*(n: WakuNodeConf): ConfResult[WakuConf] =
     b.rlnRelayConf.withCredIndex(n.rlnRelayCredIndex.get())
   if n.rlnRelayDynamic.isSome():
     b.rlnRelayConf.withDynamic(n.rlnRelayDynamic.get())
-  if n.rlnRelayLez.isSome():
-    b.rlnRelayConf.withLez(n.rlnRelayLez.get())
-  if n.rlnRelayRegistryId != "":
-    b.rlnRelayConf.withRegistryId(n.rlnRelayRegistryId)
-  if n.rlnRelayIdentifier != "":
-    b.rlnRelayConf.withIdentifier(n.rlnRelayIdentifier)
-  if n.rlnRelayRegistryOptions != "":
-    b.rlnRelayConf.withRegistryOptions(n.rlnRelayRegistryOptions)
 
   if n.maxMessageSize != "":
     b.withMaxMessageSize(n.maxMessageSize)


### PR DESCRIPTION
Iterates #4160

Addresses https://github.com/logos-messaging/logos-delivery/pull/4160/changes#r3960997861 — an RLN plugin is installed over FFI, so its configuration should arrive with it rather than through the CLI.

# Description

1. Replaced `logosdelivery_rln_set_callbacks` with `logosdelivery_rln_set_plugin`. The plugin is four callbacks — membership state, epoch quota, proof generation, proof validation — none carrying a registry, an identifier or any configuration. It must be installed before `logosdelivery_create_node`.
2. Dropped `start`, `stop` and `register_membership` from the surface, and the module start from `startNode`: the host starts its own backend.
3. Dropped `--rln-lez`, `--rln-registry-id`, `--rln-identifier`, `--rln-registry-options` and their `MessagingClientConf` counterparts. An installed plugin is now what enables RLN over it. A standalone binary cannot install one, so these were unreachable in the only context that reads CLI args.
4. Removed `RlnLezConf` from `WakuConf` and the LEZ arm of the RLN conf builder; the node mounts on plugin presence alone.
5. `setupProtocols` now fails when a plugin is installed and the embedded EVM backend is configured too.
6. Narrowed `RlnInterface` and the `RequestGenerateRlnProof` / `RequestValidateRlnProof` / `RequestGetRlnMembershipState` signatures to match — the EVM provider already ignored the scope arguments it was handed.

<details>
<summary>AI-made decisions</summary>

- `getMembershipState` and `getEpochQuota` stay on the surface, scope-free: the node itself asks whether it may send and how much budget is left, and the host's implementation knows which membership that means. Only registration, configuration and lifecycle left.
- `--rln-relay-epoch-sec` and `--rln-relay-user-message-limit` stay, since both are the EVM backend's. Nothing in the plugin path reads an epoch size any more — the host derives the epoch, the library only forwards a Unix timestamp.
- `logConf` no longer reports the plugin backend under "Enabled protocols"; `node_factory` logs it at mount instead, which keeps `waku_conf` from depending on the FFI transport.
- `rln_lez` / `RlnLez` keep their names even though they now describe an implementation-agnostic plugin. Renaming them touches every file #4160 owns and would bury this diff; worth doing separately.
- The builder tests for LEZ config are gone rather than moved: there is no configuration left to validate.

</details>
