### PR TITLE
test: resolve the filter tests (migration 5)

### DIFF
--- a/tests-e2e/src/env_vars.py
+++ b/tests-e2e/src/env_vars.py
@@ -14,7 +14,7 @@ def get_env_var(var_name, default=None):
 
 
 # Configuration constants. Need to be upercase to appear in reports
-DEFAULT_NWAKU = get_env_var("DEFAULT_NWAKU", "wakuorg/nwaku:v0.38.1")
+DEFAULT_NWAKU = get_env_var("DEFAULT_NWAKU", "quay.io/wakuorg/nwaku-pr:nightly")
 STRESS_ENABLED = False
 USE_WRAPPERS = True
 NODE_1 = get_env_var("NODE_1", DEFAULT_NWAKU)

--- a/tests-e2e/src/libs/common.py
+++ b/tests-e2e/src/libs/common.py
@@ -5,6 +5,7 @@ from src.libs.custom_logger import get_custom_logger
 import os
 import base64
 import allure
+from tenacity import retry, stop_after_delay, wait_fixed
 
 logger = get_custom_logger(__name__)
 
@@ -46,6 +47,18 @@ def attach_allure_file(file):
 def delay(num_seconds):
     logger.debug(f"Sleeping for {num_seconds} seconds")
     sleep(num_seconds)
+
+
+def wait_until(condition, timeout_duration=20, time_between_retries=0.5, message=None):
+    # Calls condition() until it returns a truthy value, which is returned to the caller.
+    # An exception raised by condition() counts as not met yet, and is polled through.
+    @retry(stop=stop_after_delay(timeout_duration), wait=wait_fixed(time_between_retries), reraise=True)
+    def poll():
+        result = condition()
+        assert result, message or f"Condition not met within {timeout_duration} seconds"
+        return result
+
+    return poll()
 
 
 def gen_step_id():

--- a/tests-e2e/src/node/docker_mananger.py
+++ b/tests-e2e/src/node/docker_mananger.py
@@ -103,7 +103,7 @@ class DockerManager:
 
     @staticmethod
     def generate_random_ext_ip():
-        base_ip_fragments = ["172", "18"]
+        base_ip_fragments = SUBNET.split(".")[:2]
         ext_ip = ".".join(base_ip_fragments + [str(random.randint(0, 255)) for _ in range(2)])
         logger.debug(f"Generated random external IP {ext_ip}")
         return ext_ip

--- a/tests-e2e/src/node/waku_node.py
+++ b/tests-e2e/src/node/waku_node.py
@@ -105,7 +105,7 @@ class WakuNode:
         self._rln_creds_set = False
         logger.debug(f"WakuNode instance initialized with log path {self._log_path}")
 
-    @retry(stop=stop_after_delay(60), wait=wait_fixed(0.1), reraise=True)
+    @retry(stop=stop_after_delay(60), wait=wait_fixed(1), reraise=True)
     def start(self, wait_for_node_sec=20, **kwargs):
         logger.debug("Starting Node...")
         default_args, remove_container = self._prepare_start_context(**kwargs)
@@ -222,6 +222,12 @@ class WakuNode:
             self.ensure_ready(timeout_duration=wait_for_node_sec, rln_required=self._rln_creds_set)
         except Exception as ex:
             logger.error(f"REST service did not become ready in time: {ex}")
+            # Drop the container before the retry starts another one, so a node that never
+            # becomes ready leaves one container behind instead of one per attempt.
+            try:
+                self.stop()
+            except Exception as stop_ex:
+                logger.debug(f"Could not remove the container of a failed start: {stop_ex}")
             raise
         try:
             logger.debug(f"Node {self._image_name} reports version {self.get_debug_version()}")

--- a/tests-e2e/src/steps/filter.py
+++ b/tests-e2e/src/steps/filter.py
@@ -4,7 +4,7 @@ from src.libs.custom_logger import get_custom_logger
 from time import time
 import pytest
 import allure
-from src.libs.common import to_base64, delay
+from src.libs.common import to_base64, delay, wait_until
 from src.node.waku_message import WakuMessage
 from src.env_vars import NODE_1, NODE_2, ADDITIONAL_NODES
 from src.node.waku_node import WakuNode
@@ -201,3 +201,15 @@ class StepsFilter(StepsCommon):
             return node.get_filter_messages(content_topic)
         else:
             raise NotImplementedError("Not implemented for this node type")
+
+    @allure.step
+    def wait_for_filter_messages(self, content_topic, count, pubsub_topic=None, node=None, timeout_duration=20, time_between_retries=0.5):
+        # Each GET returns only the messages received since the previous call, so they are collected across polls.
+        messages = []
+
+        def all_messages_received():
+            messages.extend(self.get_filter_messages(content_topic, pubsub_topic=pubsub_topic, node=node))
+            return len(messages) >= count
+
+        wait_until(all_messages_received, timeout_duration, time_between_retries, f"Expected {count} filter messages")
+        return messages

--- a/tests-e2e/tests/rest/filter/test_get_messages.py
+++ b/tests-e2e/tests/rest/filter/test_get_messages.py
@@ -1,0 +1,23 @@
+import pytest
+from src.libs.common import delay
+from src.steps.filter import StepsFilter
+
+
+# here we will also implicitly test filter push, see: https://rfc.vac.dev/spec/12/#messagepush
+@pytest.mark.usefixtures("setup_main_relay_node", "setup_main_filter_node", "subscribe_main_nodes")
+class TestFilterGetMessages(StepsFilter):
+    def test_filter_get_message_after_node1_restarts(self):
+        self.check_published_message_reaches_filter_peer()
+        self.node1.restart()
+        self.node1.ensure_ready()
+        delay(2)
+        self.wait_for_subscriptions_on_main_nodes([self.test_content_topic])
+        self.check_published_message_reaches_filter_peer()
+
+    def test_filter_get_message_after_node2_restarts(self):
+        self.check_published_message_reaches_filter_peer()
+        self.node2.restart()
+        self.node2.ensure_ready()
+        delay(2)
+        self.wait_for_subscriptions_on_main_nodes([self.test_content_topic])
+        self.check_published_message_reaches_filter_peer()

--- a/tests-e2e/tests/rest/filter/test_get_messages.py
+++ b/tests-e2e/tests/rest/filter/test_get_messages.py
@@ -1,5 +1,4 @@
 import pytest
-from src.libs.common import delay
 from src.steps.filter import StepsFilter
 
 
@@ -10,7 +9,6 @@ class TestFilterGetMessages(StepsFilter):
         self.check_published_message_reaches_filter_peer()
         self.node1.restart()
         self.node1.ensure_ready()
-        delay(2)
         self.wait_for_subscriptions_on_main_nodes([self.test_content_topic])
         self.check_published_message_reaches_filter_peer()
 
@@ -18,6 +16,5 @@ class TestFilterGetMessages(StepsFilter):
         self.check_published_message_reaches_filter_peer()
         self.node2.restart()
         self.node2.ensure_ready()
-        delay(2)
         self.wait_for_subscriptions_on_main_nodes([self.test_content_topic])
         self.check_published_message_reaches_filter_peer()

--- a/tests-e2e/tests/rest/filter/test_multiple_nodes.py
+++ b/tests-e2e/tests/rest/filter/test_multiple_nodes.py
@@ -1,5 +1,4 @@
 import pytest
-from src.libs.common import delay
 from src.steps.filter import StepsFilter
 
 
@@ -16,6 +15,5 @@ class TestFilterMultipleNodes(StepsFilter):
         self.node1.send_relay_message(relay_message1, self.test_pubsub_topic)
         self.node2.unpause()
         self.node1.send_relay_message(relay_message2, self.test_pubsub_topic)
-        delay(0.5)
-        filter_messages = self.get_filter_messages(content_topic=self.test_content_topic, pubsub_topic=self.test_pubsub_topic, node=self.node2)
+        filter_messages = self.wait_for_filter_messages(self.test_content_topic, 2, pubsub_topic=self.test_pubsub_topic, node=self.node2)
         assert len(filter_messages) == 2, "Both messages should've been returned"

--- a/tests-e2e/tests/rest/filter/test_multiple_nodes.py
+++ b/tests-e2e/tests/rest/filter/test_multiple_nodes.py
@@ -1,0 +1,21 @@
+import pytest
+from src.libs.common import delay
+from src.steps.filter import StepsFilter
+
+
+@pytest.mark.usefixtures("setup_main_relay_node", "setup_main_filter_node")
+class TestFilterMultipleNodes(StepsFilter):
+    def test_filter_get_message_while_one_peer_is_paused(self):
+        self.setup_optional_filter_nodes()
+        self.wait_for_subscriptions_on_main_nodes([self.test_content_topic])
+        self.subscribe_optional_filter_nodes([self.test_content_topic])
+        self.check_published_message_reaches_filter_peer()
+        relay_message1 = self.create_message(contentTopic=self.test_content_topic)
+        relay_message2 = self.create_message(contentTopic=self.test_content_topic)
+        self.node2.pause()
+        self.node1.send_relay_message(relay_message1, self.test_pubsub_topic)
+        self.node2.unpause()
+        self.node1.send_relay_message(relay_message2, self.test_pubsub_topic)
+        delay(0.5)
+        filter_messages = self.get_filter_messages(content_topic=self.test_content_topic, pubsub_topic=self.test_pubsub_topic, node=self.node2)
+        assert len(filter_messages) == 2, "Both messages should've been returned"

--- a/tests/factory/test_node_factory.nim
+++ b/tests/factory/test_node_factory.nim
@@ -21,7 +21,6 @@ import
     net/auto_port,
     discovery/waku_discv5,
     node/waku_metrics,
-    common/rate_limit/setting,
   ],
   logos_delivery/waku/factory/[
     node_factory,
@@ -68,15 +67,16 @@ suite "Node Factory":
     let node = (await setupNode(conf, relay = Relay.new())).valueOr:
       raiseAssert error
 
-    # Then the filter is mounted with the limit the command line assigns
-    require not node.wakuFilter.isNil()
-    let filterLimit = node.wakuFilter.peerRequestRateLimiter.setting
+    # Then each protocol is mounted with the limit the command line assigns
+    let
+      filterLimit = node.wakuFilter.peerRequestRateLimiter.setting
+      lightPushLimit = node.wakuLightPush.requestRateLimiter.setting
+      peerExchangeLimit = node.wakuPeerExchange.requestRateLimiter.setting
 
     check:
-      filterLimit.isSome()
-      filterLimit.get() == (volume: 100, period: 1.seconds)
-      node.rateLimitSettings.getSetting(LIGHTPUSH) == (volume: 5, period: 1.seconds)
-      node.rateLimitSettings.getSetting(PEEREXCHG) == (volume: 5, period: 1.seconds)
+      filterLimit == Opt.some((volume: 100, period: 1.seconds))
+      lightPushLimit == Opt.some((volume: 5, period: 1.seconds))
+      peerExchangeLimit == Opt.some((volume: 5, period: 1.seconds))
 
   test "ENR configuration trims multiaddrs until record fits":
     var conf = defaultTestWakuConf()

--- a/tests/factory/test_node_factory.nim
+++ b/tests/factory/test_node_factory.nim
@@ -10,6 +10,8 @@ import
   libp2p/[crypto/crypto, multiaddress, protocols/connectivity/relay/relay],
   eth/p2p/discoveryv5/enr
 
+import tools/confutils/cli_args
+
 import
   tests/testlib/[wakunode, wakucore],
   logos_delivery/waku/[
@@ -19,6 +21,7 @@ import
     net/auto_port,
     discovery/waku_discv5,
     node/waku_metrics,
+    common/rate_limit/setting,
   ],
   logos_delivery/waku/factory/[
     node_factory,
@@ -55,6 +58,25 @@ suite "Node Factory":
       not node.isNil()
       not node.wakuStore.isNil()
       not node.wakuArchive.isNil()
+
+  asynctest "The command line default rate limits reach the mounted protocols":
+    # Given the configuration of a binary started without --rate-limit
+    let conf = defaultWakuNodeConf().get().toWakuConf().valueOr:
+        raiseAssert error
+
+    # When the node is set up
+    let node = (await setupNode(conf, relay = Relay.new())).valueOr:
+      raiseAssert error
+
+    # Then the filter is mounted with the limit the command line assigns
+    require not node.wakuFilter.isNil()
+    let filterLimit = node.wakuFilter.peerRequestRateLimiter.setting
+
+    check:
+      filterLimit.isSome()
+      filterLimit.get() == (volume: 100, period: 1.seconds)
+      node.rateLimitSettings.getSetting(LIGHTPUSH) == (volume: 5, period: 1.seconds)
+      node.rateLimitSettings.getSetting(PEEREXCHG) == (volume: 5, period: 1.seconds)
 
   test "ENR configuration trims multiaddrs until record fits":
     var conf = defaultTestWakuConf()

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -2162,9 +2162,8 @@ suite "Waku Filter - End to End":
         await allFutures(messages.mapIt(wakuFilter.handleMessage(pubsubTopic, it)))
 
         # Then the client receives every one of them
-        let deadline = Moment.now() + FUTURE_TIMEOUT_MEDIUM
-        while received.len < messageCount and Moment.now() < deadline:
-          await sleepAsync(10.milliseconds)
+        checkUntilTimeout:
+          received.len == messageCount
 
         let receivedPayloads = received.mapIt(it.payload)
         check:

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -1,13 +1,13 @@
 {.used.}
 
-import std/[sequtils, json], testutils/unittests, results, chronos
+import std/[sequtils, json], testutils/unittests, results, chronos, metrics
 
 import
   logos_delivery/waku/node/peer_manager,
   logos_delivery/waku/waku_node,
   logos_delivery/waku/waku_core,
   logos_delivery/waku/waku_filter_v2/
-    [common, client, subscriptions, protocol, rpc_codec],
+    [common, client, subscriptions, protocol, protocol_metrics, rpc_codec],
   ../testlib/[wakucore, testasync, testutils, futures, sequtils, wakunode],
   ./waku_filter_utils,
   ../resources/payloads
@@ -2131,6 +2131,46 @@ suite "Waku Filter - End to End":
         # Then the message is not pushed to the client
         check not await pushHandlerFuture.withTimeout(FUTURE_TIMEOUT)
 
+      asyncTest "Burst of Messages":
+        # Given a subscribed client whose handler only collects, so nothing is
+        # awaited between messages
+        let
+          burstClientSwitch = newStandardSwitch()
+          burstFilterClient = await newTestWakuFilterClient(burstClientSwitch)
+        await burstClientSwitch.start()
+        defer:
+          await allFutures(burstFilterClient.stop(), burstClientSwitch.stop())
+
+        var received: seq[WakuMessage]
+        burstFilterClient.registerPushHandler(
+          proc(
+              pubsubTopic: PubsubTopic, message: WakuMessage
+          ): Future[void] {.async, closure, gcsafe.} =
+            received.add(message)
+        )
+
+        let subscribeResponse = await burstFilterClient.subscribe(
+          serverRemotePeerInfo, pubsubTopic, contentTopicSeq
+        )
+        assert subscribeResponse.isOk(), $subscribeResponse.error
+
+        # When fifty messages are handled without waiting in between
+        const messageCount = 50
+        let messages = toSeq(0 ..< messageCount).mapIt(
+            fakeWakuMessage(payload = "M_" & $it, contentTopic = contentTopic)
+          )
+        await allFutures(messages.mapIt(wakuFilter.handleMessage(pubsubTopic, it)))
+
+        # Then the client receives every one of them
+        let deadline = Moment.now() + FUTURE_TIMEOUT_MEDIUM
+        while received.len < messageCount and Moment.now() < deadline:
+          await sleepAsync(10.milliseconds)
+
+        let receivedPayloads = received.mapIt(it.payload)
+        check:
+          receivedPayloads.len == messageCount
+          messages.allIt(it.payload in receivedPayloads)
+
     suite "Security and Privacy":
       asyncTest "Filter Client can receive messages after Client and Server reboot":
         # Given a clean client and server
@@ -2218,6 +2258,46 @@ suite "Waku Filter - End to End":
         check:
           pushedMsgPubsubTopic == pubsubTopic
           pushedMsg == msg
+
+      asyncTest "Filter Client is served while another subscriber's switch is stopped":
+        # Given a second subscribed client
+        let
+          stoppedClientSwitch = newStandardSwitch()
+          stoppedFilterClient = await newTestWakuFilterClient(stoppedClientSwitch)
+        await stoppedClientSwitch.start()
+        defer:
+          await stoppedFilterClient.stop()
+
+        let stoppedClientPeerId = stoppedClientSwitch.peerInfo.peerId
+
+        for client in [wakuFilterClient, stoppedFilterClient]:
+          let subscribeResponse =
+            await client.subscribe(serverRemotePeerInfo, pubsubTopic, contentTopicSeq)
+          assert subscribeResponse.isOk(), $subscribeResponse.error
+
+        check:
+          wakuFilter.subscriptions.subscribedPeerCount() == 2
+          wakuFilter.subscriptions.isSubscribed(clientPeerId)
+          wakuFilter.subscriptions.isSubscribed(stoppedClientPeerId)
+
+        # When the second client's switch is stopped
+        await stoppedClientSwitch.stop()
+
+        # And the server receives a message
+        let msg = fakeWakuMessage(contentTopic = contentTopic)
+        await wakuFilter.handleMessage(pubsubTopic, msg)
+
+        # Then the first client is served
+        check await pushHandlerFuture.withTimeout(FUTURE_TIMEOUT)
+        let (pushedMsgPubsubTopic, pushedMsg) = pushHandlerFuture.read()
+        check:
+          pushedMsgPubsubTopic == pubsubTopic
+          pushedMsg == msg
+
+        # And the stopped client is still counted as subscribed
+        check:
+          wakuFilter.subscriptions.subscribedPeerCount() == 2
+          wakuFilter.subscriptions.isSubscribed(stoppedClientPeerId)
 
   suite "Subscription timeout":
     var server {.threadvar.}: WakuNode
@@ -2544,6 +2624,7 @@ suite "Waku Filter - End to End":
 
       check not server.wakuFilter.subscriptions.isSubscribed(clientPeerId)
       check not server.wakuFilter.subscriptions.isSubscribed(clientPeerId2nd)
+      check logos_delivery_filter_subscriptions.value() == 0
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       pushHandlerFuture2nd = newPushHandlerFuture() # Clear previous future

--- a/tests/waku_filter_v2/test_waku_client.nim
+++ b/tests/waku_filter_v2/test_waku_client.nim
@@ -2266,7 +2266,7 @@ suite "Waku Filter - End to End":
           stoppedFilterClient = await newTestWakuFilterClient(stoppedClientSwitch)
         await stoppedClientSwitch.start()
         defer:
-          await stoppedFilterClient.stop()
+          await allFutures(stoppedFilterClient.stop(), stoppedClientSwitch.stop())
 
         let stoppedClientPeerId = stoppedClientSwitch.peerInfo.peerId
 
@@ -2598,6 +2598,9 @@ suite "Waku Filter - End to End":
       )
       assert subscribeResponse2nd.isOk(), $subscribeResponse2nd.error
       check server.wakuFilter.subscriptions.isSubscribed(clientPeerId2nd)
+
+      await server.wakuFilter.maintainSubscriptions()
+      check logos_delivery_filter_subscriptions.value() == 2
 
       pushHandlerFuture = newPushHandlerFuture() # Clear previous future
       pushHandlerFuture2nd = newPushHandlerFuture() # Clear previous future

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -558,29 +558,29 @@ suite "Waku v2 Rest API - Filter V2":
       await restFilterTest.client.waitForFilterMessages(DefaultContentTopic, 1)
 
     check:
-      messages.len == 1
-      messages[0].payload == base64.encode(testMessage.payload)
-      messages[0].contentTopic == Opt.some(testMessage.contentTopic)
-      messages[0].version == Opt.some(Natural(testMessage.version))
-      messages[0].timestamp == Opt.some(testMessage.timestamp)
-      messages[0].meta == Opt.some(base64.encode(testMessage.meta))
-      messages[0].ephemeral == Opt.some(testMessage.ephemeral)
+      messages.mapIt(it.payload) == @[base64.encode(testMessage.payload)]
+      messages.mapIt(it.contentTopic) == @[Opt.some(testMessage.contentTopic)]
+      messages.mapIt(it.version) == @[Opt.some(Natural(testMessage.version))]
+      messages.mapIt(it.timestamp) == @[Opt.some(testMessage.timestamp)]
+      messages.mapIt(it.meta) == @[Opt.some(base64.encode(testMessage.meta))]
+      messages.mapIt(it.ephemeral) == @[Opt.some(testMessage.ephemeral)]
 
-  asyncTest "Subscribe and unsubscribe without a pubsub topic - POST and DELETE /filter/v2/subscriptions":
+  asyncTest "Subscribe and unsubscribe without a pubsub topic under autosharding - POST and DELETE /filter/v2/subscriptions":
     # Given a subscriber whose node derives the shard from the content topic
-    let autoShardedTest = await RestFilterTest.init(autoShardCount = 8'u32)
+    let restFilterTest = await RestFilterTest.init(autoShardCount = 8'u32)
     defer:
-      await autoShardedTest.shutdown()
+      await restFilterTest.shutdown()
 
     let
-      autoPeerId = autoShardedTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
-      derivedShard = autoShardedTest.subscriberNode.wakuAutoSharding
+      subPeerId = restFilterTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
+      subscriptions = restFilterTest.serviceNode.wakuFilter.subscriptions
+      derivedShard = restFilterTest.subscriberNode.wakuAutoSharding
         .get()
         .getShard(DefaultContentTopic).valueOr:
           raiseAssert "Failed to derive the shard: " & error
 
     # When it subscribes without a pubsubTopic
-    let autoResponse = await autoShardedTest.client.filterPostSubscriptions(
+    let subscribeResponse = await restFilterTest.client.filterPostSubscriptions(
       FilterSubscribeRequest(
         requestId: "1234",
         contentFilters: @[DefaultContentTopic],
@@ -590,20 +590,33 @@ suite "Waku v2 Rest API - Filter V2":
 
     # Then the criterion lands on the derived shard
     check:
-      autoResponse.status == 200
-      autoResponse.data.statusDesc == "OK"
-      autoPeerId in
-        autoShardedTest.serviceNode.wakuFilter.subscriptions.findSubscribedPeers(
-          $derivedShard, DefaultContentTopic
-        )
+      subscribeResponse.status == 200
+      subscribeResponse.data.statusDesc == "OK"
+      subPeerId in subscriptions.findSubscribedPeers($derivedShard, DefaultContentTopic)
 
-    # Given a subscriber on static sharding
-    let staticTest = await RestFilterTest.init()
+    # When it unsubscribes without a pubsubTopic
+    let unsubscribeResponse = await restFilterTest.client.filterDeleteSubscriptions(
+      FilterUnsubscribeRequest(
+        requestId: "4321",
+        contentFilters: @[DefaultContentTopic],
+        pubsubTopic: Opt.none(string),
+      )
+    )
+
+    # Then the criterion leaves the derived shard
+    check:
+      unsubscribeResponse.status == 200
+      unsubscribeResponse.data.statusDesc == "OK"
+      subscriptions.findSubscribedPeers($derivedShard, DefaultContentTopic).len() == 0
+
+  asyncTest "Subscribe and unsubscribe without a pubsub topic under static sharding - POST and DELETE /filter/v2/subscriptions":
+    # Given a subscriber whose node cannot derive a shard
+    let restFilterTest = await RestFilterTest.init()
     defer:
-      await staticTest.shutdown()
+      await restFilterTest.shutdown()
 
     # When it subscribes without a pubsubTopic
-    let staticResponse = await staticTest.client.filterPostSubscriptions(
+    let subscribeResponse = await restFilterTest.client.filterPostSubscriptions(
       FilterSubscribeRequest(
         requestId: "1234",
         contentFilters: @[DefaultContentTopic],
@@ -613,21 +626,21 @@ suite "Waku v2 Rest API - Filter V2":
 
     # Then the request is answered UNKNOWN and no criterion is registered
     check:
-      staticResponse.status == 200
-      staticResponse.data.statusDesc == "UNKNOWN"
-      staticTest.serviceNode.wakuFilter.subscriptions
+      subscribeResponse.status == 200
+      subscribeResponse.data.statusDesc == "UNKNOWN"
+      restFilterTest.serviceNode.wakuFilter.subscriptions
         .findSubscribedPeers(DefaultPubsubTopic, DefaultContentTopic)
         .len() == 0
 
     # And the content topic is in the message cache, so a read answers with an empty list
-    let messages = await staticTest.client.filterGetMessagesV1(DefaultContentTopic)
+    let messages = await restFilterTest.client.filterGetMessagesV1(DefaultContentTopic)
 
     check:
       messages.status == 200
       messages.data.len() == 0
 
     # When it unsubscribes without a pubsubTopic
-    let staticUnsubResponse = await staticTest.client.filterDeleteSubscriptions(
+    let unsubscribeResponse = await restFilterTest.client.filterDeleteSubscriptions(
       FilterUnsubscribeRequest(
         requestId: "4321",
         contentFilters: @[DefaultContentTopic],
@@ -636,8 +649,8 @@ suite "Waku v2 Rest API - Filter V2":
     )
 
     check:
-      staticUnsubResponse.status == 200
-      staticUnsubResponse.data.statusDesc == "UNKNOWN"
+      unsubscribeResponse.status == 200
+      unsubscribeResponse.data.statusDesc == "UNKNOWN"
 
   asyncTest "Subscribe, update and unsubscribe with an invalid body - POST, PUT and DELETE /filter/v2/subscriptions":
     # Given a subscriber with a service peer, so only the body decides the response
@@ -679,9 +692,9 @@ suite "Waku v2 Rest API - Filter V2":
       },
     ]
 
-    # Then every endpoint reading it rejects the request
+    # Then both endpoints reading it reject the request
     for body in invalidBodies:
-      for meth in [MethodPost, MethodPut, MethodDelete]:
+      for meth in [MethodPost, MethodDelete]:
         let response = await issueRequest(
           restFilterTest.restServer.getAddress(ROUTE_FILTER_SUBSCRIPTIONS),
           meth,
@@ -695,6 +708,20 @@ suite "Waku v2 Rest API - Filter V2":
           data["statusDesc"].getStr().startsWith(
             "BAD_REQUEST: Failed to decode request"
           )
+
+    # And so does PUT, which shares the subscribe handler
+    let putResponse = await issueRequest(
+      restFilterTest.restServer.getAddress(ROUTE_FILTER_SUBSCRIPTIONS),
+      MethodPut,
+      jsonHeader,
+      invalidBodies[0],
+    )
+    let putData = parseJson(putResponse.data)
+
+    check:
+      putResponse.status == 400
+      putData["requestId"].getStr() == "unknown"
+      putData["statusDesc"].getStr().startsWith("BAD_REQUEST: Failed to decode request")
 
     # When the body does not decode into an unsubscribe-all request
     let invalidAllBodies =
@@ -757,7 +784,6 @@ suite "Waku v2 Rest API - Filter V2":
 
     await otherNode.mountFilterClient()
     let servicePeer = restFilterTest.serviceNode.peerInfo.toRemotePeerInfo()
-    otherNode.peerManager.addServicePeer(servicePeer, WakuFilterSubscribeCodec)
     (
       await otherNode.filterSubscribe(
         Opt.some(DefaultPubsubTopic), @[ContentTopic("3")], servicePeer

--- a/tests/wakunode_rest/test_rest_filter.nim
+++ b/tests/wakunode_rest/test_rest_filter.nim
@@ -2,6 +2,7 @@ import results
 {.used.}
 
 import
+  std/[json, sequtils, strutils],
   chronos/timer,
   stew/byteutils,
   testutils/unittests,
@@ -10,8 +11,10 @@ import
   libp2p/crypto/crypto
 import
   logos_delivery/waku/[
+    common/base64,
     rest_api/message_cache,
     waku_core,
+    waku_core/topics/sharding,
     waku_node,
     node/peer_manager,
     rest_api/endpoint/server,
@@ -23,11 +26,14 @@ import
     waku_relay,
     waku_filter_v2/subscriptions,
     waku_filter_v2/common,
+    waku_filter_v2/protocol,
     rest_api/endpoint/relay/handlers as relay_rest_interface,
     rest_api/endpoint/relay/client as relay_rest_client,
   ],
   ../testlib/wakucore,
-  ../testlib/wakunode
+  ../testlib/wakunode,
+  ../testlib/futures,
+  ../testlib/rest_requests
 
 proc testWakuNode(): WakuNode =
   let
@@ -47,7 +53,8 @@ type RestFilterTest = object
   client: RestClientRef
   clientTwdServiceNode: RestClientRef
 
-proc init(T: type RestFilterTest): Future[T] {.async.} =
+proc init(T: type RestFilterTest, autoShardCount = 0'u32): Future[T] {.async.} =
+  ## A zero shard count leaves both nodes on static sharding, the CLI default.
   var testSetup = RestFilterTest()
   testSetup.serviceNode = testWakuNode()
   testSetup.subscriberNode = testWakuNode()
@@ -56,6 +63,11 @@ proc init(T: type RestFilterTest): Future[T] {.async.} =
 
   (await testSetup.serviceNode.mountRelay()).isOkOr:
     assert false, "Failed to mount relay: " & $error
+
+  if autoShardCount > 0:
+    for node in [testSetup.serviceNode, testSetup.subscriberNode]:
+      node.mountAutoSharding(DefaultClusterId, autoShardCount).isOkOr:
+        assert false, "Failed to mount auto sharding: " & error
 
   await testSetup.serviceNode.mountFilter(messageCacheTTL = 1.seconds)
   await testSetup.subscriberNode.mountFilterClient()
@@ -102,6 +114,18 @@ proc shutdown(self: RestFilterTest) {.async.} =
   await self.restServerForService.stop()
   await self.restServerForService.closeWait()
   await allFutures(self.serviceNode.stop(), self.subscriberNode.stop())
+
+proc waitForFilterMessages(
+    client: RestClientRef, contentTopic: ContentTopic, count: int
+): Future[seq[FilterWakuMessage]] {.async.} =
+  ## Each GET clears the cache, so the messages of every poll are collected.
+  var messages: seq[FilterWakuMessage]
+  let deadline = Moment.now() + FUTURE_TIMEOUT_MEDIUM
+  while messages.len < count and Moment.now() < deadline:
+    let response = await client.filterGetMessagesV1(contentTopic)
+    messages.add(response.data)
+    await sleepAsync(50.milliseconds)
+  return messages
 
 suite "Waku v2 Rest API - Filter V2":
   asyncTest "Subscribe a node to an array of topics - POST /filter/v2/subscriptions":
@@ -486,3 +510,351 @@ suite "Waku v2 Rest API - Filter V2":
       postMsgResponse2.data == "OK"
       len(messages2.data) == 1
     await restFilterTest.shutdown()
+
+  asyncTest "A pushed message is read back field by field - GET /filter/v2/messages/{contentTopic}":
+    # Given a subscriber served by a relaying service node
+    let restFilterTest = await RestFilterTest.init()
+    defer:
+      await restFilterTest.shutdown()
+
+    let simpleHandler = proc(
+        topic: PubsubTopic, msg: WakuMessage
+    ): Future[void] {.async, gcsafe.} =
+      await sleepAsync(0.milliseconds)
+
+    restFilterTest.serviceNode.subscribe(
+      (kind: PubsubSub, topic: DefaultPubsubTopic), simpleHandler
+    ).isOkOr:
+      assert false, "Failed to subscribe to topic: " & $error
+
+    restFilterTest.messageCache.pubsubSubscribe(DefaultPubsubTopic)
+
+    let subscribeResponse = await restFilterTest.client.filterPostSubscriptions(
+      FilterSubscribeRequest(
+        requestId: "1234",
+        contentFilters: @[DefaultContentTopic],
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+    check subscribeResponse.status == 200
+
+    # When a message with every optional field set is published on the service
+    let testMessage = WakuMessage(
+      payload: "TEST-PAYLOAD-MUST-RECEIVE".toBytes(),
+      contentTopic: DefaultContentTopic,
+      version: 10,
+      timestamp: int64(1700000000000000000),
+      meta: "test-meta".toBytes(),
+      ephemeral: true,
+    )
+
+    let postMsgResponse = await restFilterTest.clientTwdServiceNode.relayPostMessagesV1(
+      DefaultPubsubTopic, toRelayWakuMessage(testMessage)
+    )
+    check postMsgResponse.status == 200
+
+    # Then the subscriber reads every field back
+    let messages =
+      await restFilterTest.client.waitForFilterMessages(DefaultContentTopic, 1)
+
+    check:
+      messages.len == 1
+      messages[0].payload == base64.encode(testMessage.payload)
+      messages[0].contentTopic == Opt.some(testMessage.contentTopic)
+      messages[0].version == Opt.some(Natural(testMessage.version))
+      messages[0].timestamp == Opt.some(testMessage.timestamp)
+      messages[0].meta == Opt.some(base64.encode(testMessage.meta))
+      messages[0].ephemeral == Opt.some(testMessage.ephemeral)
+
+  asyncTest "Subscribe and unsubscribe without a pubsub topic - POST and DELETE /filter/v2/subscriptions":
+    # Given a subscriber whose node derives the shard from the content topic
+    let autoShardedTest = await RestFilterTest.init(autoShardCount = 8'u32)
+    defer:
+      await autoShardedTest.shutdown()
+
+    let
+      autoPeerId = autoShardedTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
+      derivedShard = autoShardedTest.subscriberNode.wakuAutoSharding
+        .get()
+        .getShard(DefaultContentTopic).valueOr:
+          raiseAssert "Failed to derive the shard: " & error
+
+    # When it subscribes without a pubsubTopic
+    let autoResponse = await autoShardedTest.client.filterPostSubscriptions(
+      FilterSubscribeRequest(
+        requestId: "1234",
+        contentFilters: @[DefaultContentTopic],
+        pubsubTopic: Opt.none(string),
+      )
+    )
+
+    # Then the criterion lands on the derived shard
+    check:
+      autoResponse.status == 200
+      autoResponse.data.statusDesc == "OK"
+      autoPeerId in
+        autoShardedTest.serviceNode.wakuFilter.subscriptions.findSubscribedPeers(
+          $derivedShard, DefaultContentTopic
+        )
+
+    # Given a subscriber on static sharding
+    let staticTest = await RestFilterTest.init()
+    defer:
+      await staticTest.shutdown()
+
+    # When it subscribes without a pubsubTopic
+    let staticResponse = await staticTest.client.filterPostSubscriptions(
+      FilterSubscribeRequest(
+        requestId: "1234",
+        contentFilters: @[DefaultContentTopic],
+        pubsubTopic: Opt.none(string),
+      )
+    )
+
+    # Then the request is answered UNKNOWN and no criterion is registered
+    check:
+      staticResponse.status == 200
+      staticResponse.data.statusDesc == "UNKNOWN"
+      staticTest.serviceNode.wakuFilter.subscriptions
+        .findSubscribedPeers(DefaultPubsubTopic, DefaultContentTopic)
+        .len() == 0
+
+    # And the content topic is in the message cache, so a read answers with an empty list
+    let messages = await staticTest.client.filterGetMessagesV1(DefaultContentTopic)
+
+    check:
+      messages.status == 200
+      messages.data.len() == 0
+
+    # When it unsubscribes without a pubsubTopic
+    let staticUnsubResponse = await staticTest.client.filterDeleteSubscriptions(
+      FilterUnsubscribeRequest(
+        requestId: "4321",
+        contentFilters: @[DefaultContentTopic],
+        pubsubTopic: Opt.none(string),
+      )
+    )
+
+    check:
+      staticUnsubResponse.status == 200
+      staticUnsubResponse.data.statusDesc == "UNKNOWN"
+
+  asyncTest "Subscribe, update and unsubscribe with an invalid body - POST, PUT and DELETE /filter/v2/subscriptions":
+    # Given a subscriber with a service peer, so only the body decides the response
+    let restFilterTest = await RestFilterTest.init()
+    defer:
+      await restFilterTest.shutdown()
+
+    let jsonHeader: seq[HttpHeaderTuple] = @[("Content-Type", "application/json")]
+
+    # When the body does not decode into a subscription request
+    let invalidBodies = [
+      $ %*{"contentFilters": [DefaultContentTopic], "pubsubTopic": DefaultPubsubTopic},
+      $ %*{
+        "requestId": 1234,
+        "contentFilters": [DefaultContentTopic],
+        "pubsubTopic": DefaultPubsubTopic,
+      },
+      $ %*{"requestId": "1234", "pubsubTopic": DefaultPubsubTopic},
+      $ %*{
+        "requestId": "1234",
+        "contentFilters": DefaultContentTopic,
+        "pubsubTopic": DefaultPubsubTopic,
+      },
+      $ %*{
+        "requestId": "1234",
+        "contentFilters": [DefaultContentTopic],
+        "pubsubTopic": [DefaultPubsubTopic],
+      },
+      $ %*{
+        "requestId": "1234",
+        "contentFilters": [{"topic": DefaultContentTopic}],
+        "pubsubTopic": DefaultPubsubTopic,
+      },
+      $ %*{
+        "requestId": "1234",
+        "contentFilters": [DefaultContentTopic],
+        "pubsubTopic": DefaultPubsubTopic,
+        "extraField": "extraValue",
+      },
+    ]
+
+    # Then every endpoint reading it rejects the request
+    for body in invalidBodies:
+      for meth in [MethodPost, MethodPut, MethodDelete]:
+        let response = await issueRequest(
+          restFilterTest.restServer.getAddress(ROUTE_FILTER_SUBSCRIPTIONS),
+          meth,
+          jsonHeader,
+          body,
+        )
+        let data = parseJson(response.data)
+        check:
+          response.status == 400
+          data["requestId"].getStr() == "unknown"
+          data["statusDesc"].getStr().startsWith(
+            "BAD_REQUEST: Failed to decode request"
+          )
+
+    # When the body does not decode into an unsubscribe-all request
+    let invalidAllBodies =
+      ["{}", $ %*{"requestId": 1234}, $ %*{"requestId": "1234", "extra": "extraValue"}]
+
+    # Then the request is rejected the same way
+    for body in invalidAllBodies:
+      let response = await issueRequest(
+        restFilterTest.restServer.getAddress(ROUTE_FILTER_ALL_SUBSCRIPTIONS),
+        MethodDelete,
+        jsonHeader,
+        body,
+      )
+      let data = parseJson(response.data)
+      check:
+        response.status == 400
+        data["requestId"].getStr() == "unknown"
+        data["statusDesc"].getStr().startsWith("BAD_REQUEST: Failed to decode request")
+
+  asyncTest "Add, remove and exceed subscription criteria - PUT and DELETE /filter/v2/subscriptions":
+    # Given a subscription to one content topic
+    let restFilterTest = await RestFilterTest.init()
+    defer:
+      await restFilterTest.shutdown()
+
+    let
+      subPeerId = restFilterTest.subscriberNode.peerInfo.toRemotePeerInfo().peerId
+      subscriptions = restFilterTest.serviceNode.wakuFilter.subscriptions
+
+    let postResponse = await restFilterTest.client.filterPostSubscriptions(
+      FilterSubscribeRequest(
+        requestId: "1234",
+        contentFilters: @[ContentTopic("1")],
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+    check postResponse.status == 200
+
+    # When a PUT names a second content topic
+    let putResponse = await restFilterTest.client.filterPutSubscriptions(
+      FilterSubscribeRequest(
+        requestId: "2345",
+        contentFilters: @[ContentTopic("2")],
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+
+    # Then the service holds both
+    check:
+      putResponse.status == 200
+      putResponse.data.statusDesc == "OK"
+      subPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "1")
+      subPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "2")
+
+    # Given a second peer holding a criterion the subscriber does not
+    let otherNode = testWakuNode()
+    await otherNode.start()
+    defer:
+      await otherNode.stop()
+
+    await otherNode.mountFilterClient()
+    let servicePeer = restFilterTest.serviceNode.peerInfo.toRemotePeerInfo()
+    otherNode.peerManager.addServicePeer(servicePeer, WakuFilterSubscribeCodec)
+    (
+      await otherNode.filterSubscribe(
+        Opt.some(DefaultPubsubTopic), @[ContentTopic("3")], servicePeer
+      )
+    ).isOkOr:
+      assert false, "Failed to subscribe the second peer: " & $error
+
+    let otherPeerId = otherNode.peerInfo.toRemotePeerInfo().peerId
+
+    # When a DELETE names that criterion
+    let otherResponse = await restFilterTest.client.filterDeleteSubscriptions(
+      FilterUnsubscribeRequest(
+        requestId: "3456",
+        contentFilters: @[ContentTopic("3")],
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+
+    # Then it is answered OK and nothing is removed
+    check:
+      otherResponse.status == 200
+      otherResponse.data.statusDesc == "OK"
+      otherPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "3")
+      subPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "1")
+      subPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "2")
+
+    # When a DELETE names a criterion no peer holds
+    let unknownResponse = await restFilterTest.client.filterDeleteSubscriptions(
+      FilterUnsubscribeRequest(
+        requestId: "4567",
+        contentFilters: @[ContentTopic("4")],
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+
+    # Then it is answered "peer has no subscriptions" and the peer keeps its criteria
+    check:
+      unknownResponse.status == 404
+      unknownResponse.data.statusDesc == "NOT_FOUND: peer has no subscriptions"
+      subPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "1")
+      subPeerId in subscriptions.findSubscribedPeers(DefaultPubsubTopic, "2")
+
+    # When a request names more content topics than the maximum
+    let tooManyTopics = toSeq(0 .. MaxContentTopicsPerRequest).mapIt(ContentTopic($it))
+
+    let tooManyPostResponse = await restFilterTest.client.filterPostSubscriptions(
+      FilterSubscribeRequest(
+        requestId: "5678",
+        contentFilters: tooManyTopics,
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+    let tooManyDeleteResponse = await restFilterTest.client.filterDeleteSubscriptions(
+      FilterUnsubscribeRequest(
+        requestId: "6789",
+        contentFilters: tooManyTopics,
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+
+    # Then both carry the service's own reason
+    check:
+      tooManyPostResponse.status == 400
+      tooManyPostResponse.data.statusDesc ==
+        "BAD_REQUEST: exceeds maximum content topics: 100"
+      tooManyDeleteResponse.status == 400
+      tooManyDeleteResponse.data.statusDesc ==
+        "BAD_REQUEST: exceeds maximum content topics: 100"
+
+    # When one subscribed content topic is deleted
+    let deleteResponse = await restFilterTest.client.filterDeleteSubscriptions(
+      FilterUnsubscribeRequest(
+        requestId: "7890",
+        contentFilters: @[ContentTopic("1")],
+        pubsubTopic: Opt.some(DefaultPubsubTopic),
+      )
+    )
+
+    # Then a read of it is refused
+    let messagesAfterDelete =
+      await issueRequest(restFilterTest.restServer.getAddress("/filter/v2/messages/1"))
+
+    check:
+      deleteResponse.status == 200
+      messagesAfterDelete.status == 400
+      messagesAfterDelete.data == "Not subscribed to topic: 1"
+
+    # When the remaining subscription is deleted as a whole
+    let deleteAllResponse = await restFilterTest.client.filterDeleteAllSubscriptions(
+      FilterUnsubscribeAllRequest(requestId: "8901")
+    )
+
+    # Then a read of the content topic it held is refused too
+    let messagesAfterDeleteAll =
+      await issueRequest(restFilterTest.restServer.getAddress("/filter/v2/messages/2"))
+
+    check:
+      deleteAllResponse.status == 200
+      messagesAfterDeleteAll.status == 400
+      messagesAfterDeleteAll.data == "Not subscribed to topic: 2"


### PR DESCRIPTION
## Description

138/424 (33%) of the interop tests are resolved: 14 ported, 21 rewritten in-process, 101 closed as already covered, 2 dropped. That closes out the filter directory.

Three interop tests need real processes and are ported as they stand: two restart a container and one freezes it. Eight more become Nim tests under `make test`: five in `tests/wakunode_rest/test_rest_filter.nim`, three in `tests/waku_filter_v2/test_waku_client.nim`, one in `tests/factory/test_node_factory.nim`. The remaining sixty need no code; the table names what covers each of them.

The table lists the verdict for each filter test this PR resolves, linked to its interop source at `2b5fde90c`.

| Test | Verdict | Gate | Reason |
|---|---|---|---|
| [test filter get message after node1 restarts](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L91) | migrate | PR gate | The filter service restarts with the same key, and the light client must re-dial the peer it was started with, subscribe again and be served. Process restart has no in-process stand-in here: "Filter Client Node can receive messages after subscribing and restarting, via Filter" in tests/node/test_wakunode_filter.nim is skipped, its note saying ConnManager is not prepared for restarts. |
| [test filter get message after node2 restarts](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L99) | migrate | PR gate | The light client restarts while the service still holds its subscription, and the push must reach the new connection rather than the dead one. The skipped test named above is the client-restart one, its running sibling in tests/node/test_wakunode_filter.nim asserts only that nothing is pushed, and "Filter Client can receive messages after Client and Server reboot" in tests/waku_filter_v2/test_waku_client.nim restarts the protocol objects, not a process. |
| [test filter get message while one peer is paused](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_multiple_nodes.py#L25) | migrate | PR gate | One subscriber is frozen with docker pause while the service pushes a message, then a second follows after it resumes, and both must be in its REST cache. Only a real process can be frozen, and this test stands in for the two pause tests of the interop filter directory. |
| [test filter get message with valid timestamps](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L29) | rewrite | none | Seven accepted timestamps are each read back through the filter push. Now "A pushed message is read back field by field" in tests/wakunode_rest/test_rest_filter.nim, which publishes with an explicit timestamp, version, meta and ephemeral flag and compares the subscriber's JSON field by field. |
| [test filter get 50 messages](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L108) | rewrite | none | Fifty messages published in a burst must all reach the subscriber. Now "Burst of Messages" in tests/waku_filter_v2/test_waku_client.nim, which hands the service fifty messages without awaiting any of them and asserts the client received the whole set. |
| [test idle filter subscriptions after node disconnection](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_idle_subscriptions.py#L29) | rewrite | none | A stopped subscriber's subscription is gone after the time-to-live, observed through the subscriptions gauge. The expiry is already "client unsubscribe by timeout" and "two clients timeout maintenance" in tests/waku_filter_v2/test_waku_client.nim; the gauge is now asserted in the second of those, reading two while both peers are subscribed and zero after the maintenance loop. |
| [test filter get message after one peer was stopped](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_multiple_nodes.py#L40) | rewrite | none | After one subscriber stops, the others must still be served. Now "Filter Client is served while another subscriber's switch is stopped" in tests/waku_filter_v2/test_waku_client.nim, which also pins that a failed push removes no subscription. |
| [test filter subscribe to 29 content topics in separate calls](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L65) | rewrite | none | Forty-nine subscribe calls in seven seconds from one peer must all succeed, which holds only under the binary's default filter limit of 100 per second. Now "The command line default rate limits reach the mounted protocols" in tests/factory/test_node_factory.nim, which builds a node from the command-line defaults and reads the limit off each mounted protocol. |
| [test filter subscribe with no pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L114) | rewrite | none | Without `pubsubTopic` the node must derive the shards from the content topics. Now two tests in tests/wakunode_rest/test_rest_filter.nim, "Subscribe and unsubscribe without a pubsub topic under autosharding" and "…under static sharding": the first proves the derivation on both POST and DELETE, the second pins the static-sharding answer as it stands. |
| [test filter subscribe with invalid pubsub topic format](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L121) | rewrite | none | A `pubsubTopic` sent as a list must be rejected. Now "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim, a table of seven bodies over POST and DELETE, one over PUT, and three over DELETE all. |
| [test filter update subscription add a new content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L12) | rewrite | none | PUT adds a content topic to an existing subscription and both deliver. Now "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim, the only in-repo caller of PUT, which also covers both DELETE answers, the 101-topic limit and the reads that follow a delete. |
| [test filter get message with version](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L43) | covered | none | A version value round-trips to the filter subscriber. "A pushed message is read back field by field" in tests/wakunode_rest/test_rest_filter.nim sends version 10 and reads it back. |
| [test filter get message with meta](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L47) | covered | none | Meta round-trips to the filter subscriber. "push filtered message" in tests/wakunode_rest/test_rest_filter.nim asserts it on the cached message and "A pushed message is read back field by field" there on the JSON. |
| [test filter get message with ephemeral](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L51) | covered | none | An ephemeral message reaches the subscriber like any other. "A pushed message is read back field by field" in tests/wakunode_rest/test_rest_filter.nim sends `ephemeral: true` and reads it back; false is every other push test's default. |
| [test filter get message with extra field](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L63) | covered | none | A relay publish carrying an unknown field must get 400. The rejection comes from the relay message reader before any filter code runs, and it is a row of "Post a message with an invalid body" in tests/wakunode_rest/test_rest_relay.nim. |
| [test filter get message duplicate message](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L73) | covered | none | An identical message published twice reaches the subscriber once. "duplicate message push to filter subscriber" in tests/wakunode_rest/test_rest_filter.nim runs the same flow and gets one message then none, and its sleep variant there shows the message cache TTL is what drops the repeat. |
| [test filter get message after node pauses and pauses](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L82) | covered | none | Each node is paused and resumed with nothing published during the freeze, so every check happens after the resume. The ported tests-e2e/tests/rest/filter/test_multiple_nodes.py freezes the subscriber while a message is published and publishes again after it resumes. |
| [test filter get message with 150 kb payload](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_get_messages.py#L122) | covered | none | A payload of 100 KB reaches the subscriber through filter push. "Valid Payload Sizes" in tests/waku_filter_v2/test_waku_client.nim pushes 100 KiB and the boundary below DefaultMaxPushSize. |
| [test all nodes subscribed to the topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_multiple_nodes.py#L12) | covered | none | Four subscribers on one content topic each receive the message. "two clients shifted subscription and timeout" in tests/waku_filter_v2/test_waku_client.nim pushes one message to two clients and asserts both, over the same loop across the subscribed peers. |
| [test optional nodes not subscribed to same topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_multiple_nodes.py#L18) | covered | none | Subscribers on another content topic receive nothing while the main subscriber is served. "PubSub Topic with Single Content Topic" in tests/waku_filter_v2/test_waku_client.nim asserts that a message on a non-subscribed content topic is not pushed, and "two clients shifted subscription and timeout" there asserts delivery to two clients at once. |
| [test ping only some nodes have subscriptions](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_multiple_nodes.py#L48) | covered | none | Ping answers per peer, OK for the subscribed one and "peer has no subscriptions" for the rest. "Active Subscription Identification" and "No Active Subscription Identification" in tests/waku_filter_v2/test_waku_client.nim assert both answers, and "two clients shifted subscription and timeout" there keeps per-peer state for two clients. |
| [test filter ping on peer without subscription](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_ping.py#L12) | covered | none | A ping from a peer that never subscribed answers "peer has no subscriptions". "ping subscriber" in tests/node/test_wakunode_filter.nim asserts the protocol status and text, "ping subscribed node" in tests/wakunode_rest/test_rest_filter.nim the 404 mapping. |
| [test filter ping on unsubscribed peer](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_ping.py#L15) | covered | none | A ping fails once the last content topic is deleted. "After Unsubscription" in tests/waku_filter_v2/test_waku_client.nim runs that sequence at the protocol level and "ping subscribed node" in tests/wakunode_rest/test_rest_filter.nim over HTTP. |
| [test filter subscribe to single topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L14) | covered | none | A REST subscribe followed by a relay publish reaches the subscriber. "duplicate message push to filter subscriber" in tests/wakunode_rest/test_rest_filter.nim runs it in process, and "Client Node receives Push for a message the Server Node got via Relay" in tests/node/test_wakunode_filter.nim over a real relay hop. |
| [test filter subscribe to multiple pubsub topic from same cluster](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L18) | covered | none | Five shards of one cluster each deliver to the subscriber. The filter treats the pubsub topic as an opaque string at every layer, and "Different PubSub Topics with Different Content Topics, Unsubscribe One By One" in tests/waku_filter_v2/test_waku_client.nim asserts the pushed topic per message. |
| [test filter subscribe to pubsub topic from another cluster id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L32) | covered | none | A shard of another cluster is one more opaque string to the filter. "Different PubSub Topics with Different Content Topics, Unsubscribe One By One" in tests/waku_filter_v2/test_waku_client.nim subscribes an arbitrary pubsub topic and asserts delivery on it; whether a relay node should accept a foreign cluster's shard belongs to the sharding directory. |
| [test filter subscribe to pubsub topics from multiple clusters](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L36) | covered | none | Shards of two clusters deliver under one subscription. "Different PubSub Topics with Different Content Topics, Unsubscribe One By One" in tests/waku_filter_v2/test_waku_client.nim subscribes two pubsub topics at once and asserts the pushed topic per message. |
| [test filter subscribe to 100 content topics in one call](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L52) | covered | none | Exactly the maximum number of content topics is accepted in one call. "Max Topic Size" in tests/waku_filter_v2/test_waku_client.nim subscribes `MaxContentTopicsPerRequest` topics, and delivery per criterion of a list is "PubSub Topic with Multiple Content Topics" there. |
| [test filter subscribe to 101 content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L93) | covered | none | One topic over the maximum must be refused. "Max Topic Size" in tests/waku_filter_v2/test_waku_client.nim asserts BAD_REQUEST and "subscribe errors" in tests/node/test_wakunode_filter.nim the text "exceeds maximum content topics". |
| [test filter subscribe refresh](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L102) | covered | none | Subscribing twice to the same criterion delivers a message once. "Refreshing Subscription" in tests/waku_filter_v2/test_waku_client.nim subscribes twice and asserts a single push. |
| [test filter subscribe with multiple overlapping content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L107) | covered | none | Overlapping subscribe calls must not duplicate delivery. "Overlapping Topic Subscription" in tests/waku_filter_v2/test_waku_client.nim asserts delivery on every overlapping criterion without a duplicate, and "After refreshing a partial subscription with Multiple Content Topics, One By One" there the resulting state. |
| [test filter subscribe with no content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L128) | covered | none | A body without `contentFilters` must get 400. A row of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter subscribe with invalid content topic format](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L138) | covered | none | A content topic of the wrong JSON type must get 400. A row of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim; the interop test sends its whole description dictionary five times, so a type error is all it proves. |
| [test filter subscribe with no request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L149) | covered | none | A body without `requestId` must get 400. A row of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter subscribe with invalid request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L156) | covered | none | A `requestId` sent as an integer must get 400. A row of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter subscribe with extra field](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_create.py#L164) | covered | none | A body carrying an unknown field must get 400. A row of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim, which records the rejection the reader produces today. |
| [test filter update subscription add 30 new content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L18) | covered | none | Thirty more content topics through PUT all deliver. PUT is registered on the same handler as POST, exercised by "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim, and delivery per criterion is "PubSub Topic with Multiple Content Topics" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter update subscription add 101 new content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L35) | covered | none | A PUT over the maximum must be refused. The same limit as POST, asserted over HTTP by "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim and at the protocol level by "Max Topic Size" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter update subscription refresh existing](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L44) | covered | none | A PUT of a criterion already held delivers a message once. "Refreshing Subscription" in tests/waku_filter_v2/test_waku_client.nim asserts the single push, and the PUT route is "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter update subscription add a new pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L49) | covered | none | A second subscribe on another pubsub topic leaves both delivering. "Different PubSub Topics with Different Content Topics, Unsubscribe One By One" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter update subscription with no pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L65) | covered | none | A PUT without `pubsubTopic` takes the same handler as POST. "Subscribe and unsubscribe without a pubsub topic under autosharding" and "…under static sharding" in tests/wakunode_rest/test_rest_filter.nim cover that handler on both sharding modes; the interop test asserts nothing on the success path. |
| [test filter update subscription with pubsub topic list instead of string](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L72) | covered | none | A `pubsubTopic` sent as a list on PUT must get 400. PUT shares its handler with POST, and "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim sends that body over POST and one bad body over PUT. |
| [test filter update subscription with no content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L79) | covered | none | A PUT without `contentFilters` must get 400. PUT shares its handler with POST, and "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim sends that body over POST and one bad body over PUT. |
| [test filter update subscription with invalid content topic format](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L86) | covered | none | A content topic of the wrong JSON type on PUT must get 400. PUT shares its handler with POST, and "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim sends that body over POST and one bad body over PUT. |
| [test filter update subscription with no request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L97) | covered | none | A PUT without `requestId` must get 400. PUT shares its handler with POST, and "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim sends that body over POST and one bad body over PUT. |
| [test filter update subscription with invalid request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L104) | covered | none | A `requestId` sent as an integer on PUT must get 400. PUT shares its handler with POST, and "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim sends that body over POST and one bad body over PUT. |
| [test filter update subscription with extra field](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_subscribe_update.py#L111) | covered | none | A PUT carrying an unknown field must get 400. PUT shares its handler with POST, and "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim sends that body over POST and one bad body over PUT. |
| [test filter unsubscribe from single content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L9) | covered | none | After unsubscribing one content topic the next message is not pushed. "PubSub Topic with Single Content Topic" in tests/waku_filter_v2/test_waku_client.nim asserts that, and the REST DELETE is "Unsubscribe a node from an array of topics" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe from all subscribed content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L15) | covered | none | Both content topics unsubscribed in one call stop delivering. "PubSub Topic with Multiple Content Topics" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter unsubscribe from some of the subscribed content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L22) | covered | none | After a partial unsubscribe the remaining criterion still delivers and the removed one does not. "Different PubSub Topics with Same Content Topics, Unsubscribe Selectively" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter unsubscribe from pubsub topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L31) | covered | none | Unsubscribing one pubsub topic silences it while the other keeps delivering. "Different PubSub Topics with Different Content Topics, Unsubscribe One By One" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter unsubscribe from non existing content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L43) | covered | none | A DELETE of a criterion the peer does not hold. "With non existent content topic" in tests/waku_filter_v2/test_waku_client.nim asserts the protocol NOT_FOUND, and "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim the two HTTP answers. |
| [test filter unsubscribe from non existing pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L53) | covered | none | A DELETE naming a pubsub topic the peer does not hold. "With non existent pubsub topic" in tests/waku_filter_v2/test_waku_client.nim asserts NOT_FOUND and "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim the HTTP answer. |
| [test filter unsubscribe from 101 content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L66) | covered | none | A DELETE over the maximum must be refused. "unsubscribe errors" in tests/node/test_wakunode_filter.nim asserts BAD_REQUEST with "exceeds maximum content topics", and "Add, remove and exceed subscription criteria" in tests/wakunode_rest/test_rest_filter.nim the 400 carrying that text. |
| [test filter unsubscribe with no content topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L77) | covered | none | A DELETE without `contentFilters` must get 400. The DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe with content topic string instead of list](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L84) | covered | none | `contentFilters` sent as a string must get 400. The DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe with no pubsub topic](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L91) | covered | none | As written it sends `contentFilters` as a string, so its 400 is a decode rejection: the DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. The case it means to test, a DELETE without `pubsubTopic`, is the second half of each "Subscribe and unsubscribe without a pubsub topic" test there. |
| [test filter unsubscribe with pubsub topic string instead of list](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L98) | covered | none | A `pubsubTopic` string is the correct shape, so the 400 this test sees comes from its `contentFilters`, sent as a string. The DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe with very large request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L105) | covered | none | A very long request id must come back on the response. The REST layer only echoes it, the path "Unsubscribe a node from an array of topics" in tests/wakunode_rest/test_rest_filter.nim takes with a four-character one. |
| [test filter unsubscribe with no request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L116) | covered | none | A DELETE without `requestId` must get 400. The DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe with invalid request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L128) | covered | none | A `requestId` sent as an integer on DELETE must get 400. The DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe with extra field](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L135) | covered | none | A DELETE carrying an unknown field must get 400. The DELETE column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter resubscribe to unsubscribed topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe.py#L147) | covered | none | A fresh subscribe after a full unsubscribe delivers again. "After refreshing a partial subscription with Multiple Content Topics, One By One" in tests/waku_filter_v2/test_waku_client.nim asserts the recreated state and "PubSub Topic with Single Content Topic" there that delivery follows it. |
| [test filter unsubscribe all from few content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe_all.py#L10) | covered | none | Nothing is pushed after unsubscribing everything. "Different PubSub Topics with Different Content Topics, Unsubscribe All" in tests/waku_filter_v2/test_waku_client.nim, and the REST route is "Unsubscribe a node from an array of topics" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe all from 90 content topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe_all.py#L19) | covered | none | Unsubscribe-all removes the peer entry whatever its size. "Different PubSub Topics with Different Content Topics, Unsubscribe All" in tests/waku_filter_v2/test_waku_client.nim, and "Max Criteria Per Subscription" there holds a thousand criteria on one peer. |
| [test filter unsubscribe all from multiple pubsub topics](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe_all.py#L35) | covered | none | Unsubscribe-all clears criteria across pubsub topics. "Unsubscribe from All Topics, Multiple PubSub Topics" in tests/waku_filter_v2/test_waku_client.nim. |
| [test filter unsubscribe all on peer with no subscription](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe_all.py#L45) | covered | none | Unsubscribe-all on a peer that never subscribed answers NOT_FOUND. "unsubscribe errors" in tests/node/test_wakunode_filter.nim and "Unsubscribe from All Topics from a non-subscribed Service" in tests/waku_filter_v2/test_waku_client.nim assert it; the 404 mapping is "ping subscribed node" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe all with invalid request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe_all.py#L55) | covered | none | A `requestId` sent as an integer on unsubscribe-all must get 400. The DELETE all column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test filter unsubscribe all with extra field](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_unsubscribe_all.py#L62) | covered | none | An unsubscribe-all body carrying an unknown field must get 400. The DELETE all column of "Subscribe, update and unsubscribe with an invalid body" in tests/wakunode_rest/test_rest_filter.nim. |
| [test idle filter subscriptions for more than 5 nodes](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_idle_subscriptions.py#L16) | drop | none | Six subscribers, then after five idle minutes the subscriptions metric must read five. No behaviour produces that number: the time-to-live expires all six alike, and the per-address limit the closed issue asked for was never implemented. |
| [test filter ping without request id](https://github.com/logos-messaging/logos-delivery-interop-tests/blob/2b5fde90c10e73380c1583f691123c373e311faa/tests/filter/test_ping.py#L20) | drop | none | A ping without a request id must be rejected. No such rejection exists: the id is only echoed, an empty path segment reaches the handler like any other value, and the "bad request id" text the test expects appears nowhere in this repo. |

## Changes

- Add `tests-e2e/tests/rest/filter/` with the three ported tests. The bodies are unchanged from interop `2b5fde90c`; the only edit is dropping the imports the unported tests used. No harness change: `tests-e2e/src/steps/filter.py` already carries every step they call, and `ADDITIONAL_NODES` already defaults to three copies of `DEFAULT_NWAKU` in `tests-e2e/src/env_vars.py`, which is what the five containers of the pause test need.
- `tests/wakunode_rest/test_rest_filter.nim` gains five tests: the field-by-field round trip, the subscribe and unsubscribe without a pubsub topic on each sharding mode, the invalid-body table over the four subscription endpoints, and the subscription shapes (PUT, both DELETE answers, the 101-topic limit, the reads after a delete). `RestFilterTest.init` takes an optional shard count so a test can run its nodes with autosharding; the raw-HTTP helper is `tests/testlib/rest_requests.nim`, shared since the relay work.
- `tests/waku_filter_v2/test_waku_client.nim` gains the fifty-message burst and the stopped-subscriber test, plus two assertions in "two clients timeout maintenance" on the subscriptions gauge, reading the peer count before the maintenance loop and zero after it. The burst test registers a filter client of its own: the suite's shared push handler completes one future per message, so fifty pushes through it raise a `FutureDefect`.
- `tests/factory/test_node_factory.nim` gains one test that builds a node from `defaultWakuNodeConf()` through `setupNode` and reads the rate limit off the mounted filter, lightpush and peer-exchange protocols.