### PR TITLE
fix: make CLI, library and test config defaults consistent

### DIFF
--- a/logos_delivery/api/conf/messaging_conf.nim
+++ b/logos_delivery/api/conf/messaging_conf.nim
@@ -23,6 +23,7 @@ type MessagingClientConf* = object
   quicSupport* {.name: "quic-support".}: Opt[bool] ## Enable the QUIC transport.
   quicPort* {.name: "quic-port".}: Opt[Port] ## QUIC (UDP) listening port.
   listenIpv4* {.name: "listen-address".}: Opt[IpAddress] ## Inbound bind address.
+  nat* {.name: "nat".}: Opt[string] ## Public address discovery strategy.
   maxMessageSize* {.name: "max-msg-size".}: Opt[string]
     ## Maximum accepted message size (e.g. "150 KiB").
   entryNodes* {.name: "entry-node".}: Opt[seq[string]]
@@ -100,9 +101,6 @@ proc toWakuNodeConf*(
   # Derived from a `MessagingClientConf`, so never kernel-only: don't inherit the
   # CLI default. `LogosDeliveryConf.init` overwrites this with the caller's layer.
   conf.entryLayer = EntryLayer.channels
-  # The CLI defaults to "any"; the embedded default stays "none" so library
-  # nodes probe gateways only when configured to.
-  conf.nat = "none"
 
   if self.store.isSome():
     conf.store = self.store.get()
@@ -123,6 +121,8 @@ proc toWakuNodeConf*(
     conf.numShardsInNetwork = self.numShardsInCluster.get()
   if self.listenIpv4.isSome():
     conf.listenAddress = self.listenIpv4.get()
+  if self.nat.isSome():
+    conf.nat = self.nat.get()
   if self.maxMessageSize.isSome():
     conf.maxMessageSize = self.maxMessageSize.get()
   if self.entryNodes.isSome():

--- a/tests/api/test_api_health.nim
+++ b/tests/api/test_api_health.nim
@@ -3,8 +3,7 @@
 import results, std/[sequtils, times]
 import chronos, testutils/unittests, stew/byteutils, libp2p/[switch, peerinfo]
 import brokers/broker_context
-import logos_delivery/waku/persistency/persistency
-import ../testlib/[common, wakucore, wakunode, testasync]
+import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 
 import
   logos_delivery,
@@ -83,7 +82,7 @@ suite "LM API health checking":
       serviceNode = newTestWakuNode(generateSecp256k1Key())
       (await serviceNode.mountRelay()).isOkOr:
         raiseAssert error
-      serviceNode.mountMetadata(3, @[0'u16]).isOkOr:
+      serviceNode.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert error
       await serviceNode.mountLibp2pPing()
       await serviceNode.start()
@@ -92,18 +91,7 @@ suite "LM API health checking":
     serviceNode.wakuRelay.subscribe(DefaultShard, dummyHandler)
 
     lockNewGlobalBrokerContext:
-      var conf = MessagingClientConf().toWakuNodeConf(Core).valueOr:
-          raiseAssert error
-      conf.listenAddress = parseIpAddress("0.0.0.0")
-      conf.tcpPort = Port(0)
-      conf.discv5UdpPort = Port(0)
-      conf.clusterId = Opt.some(3'u16)
-      conf.numShardsInNetwork = 1
-      conf.rest = false
-      # This suite does not test persistence. Keep the node off the shared ./data root.
-      conf.localStoragePath = InMemoryStoragePath
-
-      client = (await LogosDelivery.new(conf)).valueOr:
+      client = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await client.start()).isOkOr:
         raiseAssert error
@@ -274,15 +262,8 @@ suite "LM API health checking":
     var edgeWaku: LogosDelivery
 
     lockNewGlobalBrokerContext:
-      var edgeConf = MessagingClientConf().toWakuNodeConf(Edge).valueOr:
-          raiseAssert error
-      edgeConf.listenAddress = parseIpAddress("0.0.0.0")
-      edgeConf.tcpPort = Port(0)
-      edgeConf.discv5UdpPort = Port(0)
-      edgeConf.clusterId = Opt.some(3'u16)
+      var edgeConf = defaultTestWakuNodeConf(mode = Edge)
       edgeConf.maxMessageSize = "150 KiB"
-      edgeConf.rest = false
-      edgeConf.localStoragePath = InMemoryStoragePath
 
       edgeWaku = (await LogosDelivery.new(edgeConf)).valueOr:
         raiseAssert "Failed to create edge node: " & error

--- a/tests/api/test_api_receive.nim
+++ b/tests/api/test_api_receive.nim
@@ -4,7 +4,7 @@ import results, std/[sequtils, net, sets, os, osproc, tempfiles, strutils]
 import chronos, testutils/unittests, stew/byteutils
 import libp2p/[peerid, peerinfo, crypto/crypto]
 import brokers/broker_context
-import ../testlib/[common, wakucore, wakunode, testasync]
+import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 import ../waku_archive/archive_utils
 import logos_delivery/messaging/messaging_client
 import logos_delivery/messaging/messaging_client_lifecycle
@@ -90,16 +90,9 @@ proc waitForConnectionStatus(
     await EventConnectionStatusChange.dropListener(brokerCtx, handle)
 
 proc createApiNodeConf(numShards: uint16 = 1): WakuNodeConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = numShards
-  conf.rest = false
-  conf.localStoragePath = InMemoryStoragePath
+  ## The shared test defaults, plus a resolver that stays on this machine: the
+  ## restarted child process must not wait on a real DNS server.
+  var conf = defaultTestWakuNodeConf(numShards = numShards)
   conf.dnsAddrsNameServers = @[parseIpAddress("127.0.0.1")]
   return conf
 
@@ -150,7 +143,7 @@ proc setupNetwork(
   var archiveDriver: ArchiveDriver
   lockNewGlobalBrokerContext:
     storeNode = newTestWakuNode(generateSecp256k1Key())
-    storeNode.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+    storeNode.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
       "Failed to mount metadata on storeNode"
     )
     (await storeNode.mountRelay()).expect("Failed to mount relay on storeNode")
@@ -169,7 +162,7 @@ proc setupNetwork(
   var publisher: WakuNode
   lockNewGlobalBrokerContext:
     publisher = newTestWakuNode(generateSecp256k1Key())
-    publisher.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+    publisher.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
       "Failed to mount metadata on publisher"
     )
     (await publisher.mountRelay()).expect("Failed to mount relay on publisher")

--- a/tests/api/test_api_send.nim
+++ b/tests/api/test_api_send.nim
@@ -3,8 +3,7 @@
 import results, std/strutils
 import chronos, testutils/unittests, stew/byteutils, libp2p/[switch, peerinfo]
 import brokers/broker_context
-import logos_delivery/waku/persistency/persistency
-import ../testlib/[common, wakucore, wakunode, testasync]
+import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 import ../waku_archive/archive_utils
 import logos_delivery, logos_delivery/waku/[waku_node, waku_core, waku_relay/protocol]
 import logos_delivery/waku/factory/waku_conf
@@ -121,21 +120,6 @@ proc validate(
   for requestId in manager.errorRequestIds:
     check requestId == expectedRequestId
 
-proc createApiNodeConf(
-    mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core
-): WakuNodeConf =
-  var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  conf.rest = false
-  # This suite does not test persistence. Keep the node off the shared ./data root.
-  conf.localStoragePath = InMemoryStoragePath
-  result = conf
-
 suite "Waku API - Send":
   var
     relayNode1 {.threadvar.}: WakuNode
@@ -157,7 +141,7 @@ suite "Waku API - Send":
   asyncSetup:
     lockNewGlobalBrokerContext:
       relayNode1 = newTestWakuNode(generateSecp256k1Key())
-      relayNode1.mountMetadata(3, @[0'u16]).isOkOr:
+      relayNode1.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert "Failed to mount metadata: " & error
       (await relayNode1.mountRelay()).isOkOr:
         raiseAssert "Failed to mount relay"
@@ -166,7 +150,7 @@ suite "Waku API - Send":
 
     lockNewGlobalBrokerContext:
       relayNode2 = newTestWakuNode(generateSecp256k1Key())
-      relayNode2.mountMetadata(3, @[0'u16]).isOkOr:
+      relayNode2.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert "Failed to mount metadata: " & error
       (await relayNode2.mountRelay()).isOkOr:
         raiseAssert "Failed to mount relay"
@@ -175,7 +159,7 @@ suite "Waku API - Send":
 
     lockNewGlobalBrokerContext:
       lightpushNode = newTestWakuNode(generateSecp256k1Key())
-      lightpushNode.mountMetadata(3, @[0'u16]).isOkOr:
+      lightpushNode.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert "Failed to mount metadata: " & error
       (await lightpushNode.mountRelay()).isOkOr:
         raiseAssert "Failed to mount relay"
@@ -186,7 +170,7 @@ suite "Waku API - Send":
 
     lockNewGlobalBrokerContext:
       storeNode = newTestWakuNode(generateSecp256k1Key())
-      storeNode.mountMetadata(3, @[0'u16]).isOkOr:
+      storeNode.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert "Failed to mount metadata: " & error
       (await storeNode.mountRelay()).isOkOr:
         raiseAssert "Failed to mount relay"
@@ -239,7 +223,7 @@ suite "Waku API - Send":
   asyncTest "Check API availability (unhealthy node)":
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (await LogosDelivery.new(createApiNodeConf())).valueOr:
+      node = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -261,7 +245,7 @@ suite "Waku API - Send":
   asyncTest "Send fully validated":
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (await LogosDelivery.new(createApiNodeConf())).valueOr:
+      node = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -295,7 +279,7 @@ suite "Waku API - Send":
   asyncTest "Send only propagates":
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (await LogosDelivery.new(createApiNodeConf())).valueOr:
+      node = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -325,7 +309,7 @@ suite "Waku API - Send":
   asyncTest "Send only propagates fallback to lightpush":
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (await LogosDelivery.new(createApiNodeConf())).valueOr:
+      node = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -359,7 +343,7 @@ suite "Waku API - Send":
     lockNewGlobalBrokerContext:
       node = (
         await LogosDelivery.new(
-          createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge)
+          defaultTestWakuNodeConf(messaging_conf.LogosDeliveryMode.Edge)
         )
       ).valueOr:
         raiseAssert error
@@ -398,7 +382,7 @@ suite "Waku API - Send":
     lockNewGlobalBrokerContext:
       node = (
         await LogosDelivery.new(
-          createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge)
+          defaultTestWakuNodeConf(messaging_conf.LogosDeliveryMode.Edge)
         )
       ).valueOr:
         raiseAssert error
@@ -438,7 +422,7 @@ suite "Waku API - Send":
   asyncTest "Send fully validates fallback to lightpush":
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (await LogosDelivery.new(createApiNodeConf())).valueOr:
+      node = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error
@@ -470,7 +454,7 @@ suite "Waku API - Send":
     var fakeLightpushNode: WakuNode
     lockNewGlobalBrokerContext:
       fakeLightpushNode = newTestWakuNode(generateSecp256k1Key())
-      fakeLightpushNode.mountMetadata(3, @[0'u16]).isOkOr:
+      fakeLightpushNode.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert "Failed to mount metadata: " & error
       (await fakeLightpushNode.mountRelay()).isOkOr:
         raiseAssert "Failed to mount relay"
@@ -493,7 +477,7 @@ suite "Waku API - Send":
     lockNewGlobalBrokerContext:
       node = (
         await LogosDelivery.new(
-          createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge)
+          defaultTestWakuNodeConf(messaging_conf.LogosDeliveryMode.Edge)
         )
       ).valueOr:
         raiseAssert error
@@ -531,7 +515,7 @@ suite "Waku API - Send":
     var isolatedStoreNode: WakuNode
     lockNewGlobalBrokerContext:
       isolatedStoreNode = newTestWakuNode(generateSecp256k1Key())
-      isolatedStoreNode.mountMetadata(3, @[0'u16]).isOkOr:
+      isolatedStoreNode.mountMetadata(TestClusterId, @[0'u16]).isOkOr:
         raiseAssert "Failed to mount metadata: " & error
       (await isolatedStoreNode.mountRelay()).isOkOr:
         raiseAssert "Failed to mount relay"
@@ -547,7 +531,7 @@ suite "Waku API - Send":
 
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
-      node = (await LogosDelivery.new(createApiNodeConf())).valueOr:
+      node = (await LogosDelivery.new(defaultTestWakuNodeConf())).valueOr:
         raiseAssert error
       (await node.start()).isOkOr:
         raiseAssert "Failed to start Waku node: " & error

--- a/tests/api/test_api_subscription.nim
+++ b/tests/api/test_api_subscription.nim
@@ -4,8 +4,7 @@ import results, std/[strutils, sequtils, net, sets, tables]
 import chronos, testutils/unittests, stew/byteutils
 import libp2p/[peerid, peerinfo, multiaddress, crypto/crypto]
 import brokers/broker_context
-import logos_delivery/waku/persistency/persistency
-import ../testlib/[common, wakucore, wakunode, testasync]
+import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 import logos_delivery/messaging/messaging_client
 
 import
@@ -69,22 +68,6 @@ type TestNetwork = ref object
     # The receiver node in tests. Edge node in edge tests, Core node in relay tests.
   publisherPeerInfo: RemotePeerInfo
 
-proc createApiNodeConf(
-    mode: messaging_conf.LogosDeliveryMode = messaging_conf.LogosDeliveryMode.Core,
-    numShards: uint16 = 1,
-): WakuNodeConf =
-  var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = numShards
-  conf.rest = false
-  # This suite does not test persistence. Keep the node off the shared ./data root.
-  conf.localStoragePath = InMemoryStoragePath
-  result = conf
-
 proc setupSubscriberNode(conf: WakuNodeConf): Future[LogosDelivery] {.async.} =
   var node: LogosDelivery
   lockNewGlobalBrokerContext:
@@ -100,7 +83,7 @@ proc setupNetwork(
 
   lockNewGlobalBrokerContext:
     net.publisher = newTestWakuNode(generateSecp256k1Key())
-    net.publisher.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+    net.publisher.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
       "Failed to mount metadata"
     )
     (await net.publisher.mountRelay()).expect("Failed to mount relay")
@@ -126,7 +109,7 @@ proc setupNetwork(
   if mode == messaging_conf.LogosDeliveryMode.Edge:
     lockNewGlobalBrokerContext:
       net.meshBuddy = newTestWakuNode(generateSecp256k1Key())
-      net.meshBuddy.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+      net.meshBuddy.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
         "Failed to mount metadata on meshBuddy"
       )
       (await net.meshBuddy.mountRelay()).expect("Failed to mount relay on meshBuddy")
@@ -139,7 +122,7 @@ proc setupNetwork(
 
     await net.meshBuddy.connectToNodes(@[net.publisherPeerInfo])
 
-  net.subscriber = await setupSubscriberNode(createApiNodeConf(mode, numShards))
+  net.subscriber = await setupSubscriberNode(defaultTestWakuNodeConf(mode, numShards))
 
   await net.subscriber.waku.node.connectToNodes(@[net.publisherPeerInfo])
 
@@ -626,7 +609,7 @@ suite "Messaging API, SubscriptionManager":
     var publisher: WakuNode
     lockNewGlobalBrokerContext:
       publisher = newTestWakuNode(generateSecp256k1Key())
-      publisher.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+      publisher.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
         "Failed to mount metadata on publisher"
       )
       (await publisher.mountRelay()).expect("Failed to mount relay on publisher")
@@ -644,7 +627,7 @@ suite "Messaging API, SubscriptionManager":
     var meshBuddy: WakuNode
     lockNewGlobalBrokerContext:
       meshBuddy = newTestWakuNode(generateSecp256k1Key())
-      meshBuddy.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+      meshBuddy.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
         "Failed to mount metadata on meshBuddy"
       )
       (await meshBuddy.mountRelay()).expect("Failed to mount relay on meshBuddy")
@@ -661,7 +644,7 @@ suite "Messaging API, SubscriptionManager":
 
     await meshBuddy.connectToNodes(@[publisherPeerInfo])
 
-    let conf = createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge, numShards)
+    let conf = defaultTestWakuNodeConf(messaging_conf.LogosDeliveryMode.Edge, numShards)
     var subscriber: LogosDelivery
     lockNewGlobalBrokerContext:
       subscriber =
@@ -735,7 +718,7 @@ suite "Messaging API, SubscriptionManager":
     var publisher: WakuNode
     lockNewGlobalBrokerContext:
       publisher = newTestWakuNode(generateSecp256k1Key())
-      publisher.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+      publisher.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
         "Failed to mount metadata on publisher"
       )
       (await publisher.mountRelay()).expect("Failed to mount relay on publisher")
@@ -753,7 +736,7 @@ suite "Messaging API, SubscriptionManager":
     var meshBuddy: WakuNode
     lockNewGlobalBrokerContext:
       meshBuddy = newTestWakuNode(generateSecp256k1Key())
-      meshBuddy.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+      meshBuddy.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
         "Failed to mount metadata on meshBuddy"
       )
       (await meshBuddy.mountRelay()).expect("Failed to mount relay on meshBuddy")
@@ -771,7 +754,7 @@ suite "Messaging API, SubscriptionManager":
     var sparePeer: WakuNode
     lockNewGlobalBrokerContext:
       sparePeer = newTestWakuNode(generateSecp256k1Key())
-      sparePeer.mountMetadata(3, toSeq(0'u16 ..< numShards)).expect(
+      sparePeer.mountMetadata(TestClusterId, toSeq(0'u16 ..< numShards)).expect(
         "Failed to mount metadata on sparePeer"
       )
       (await sparePeer.mountRelay()).expect("Failed to mount relay on sparePeer")
@@ -789,7 +772,7 @@ suite "Messaging API, SubscriptionManager":
     await meshBuddy.connectToNodes(@[publisherPeerInfo])
     await sparePeer.connectToNodes(@[publisherPeerInfo])
 
-    let conf = createApiNodeConf(messaging_conf.LogosDeliveryMode.Edge, numShards)
+    let conf = defaultTestWakuNodeConf(messaging_conf.LogosDeliveryMode.Edge, numShards)
     var subscriber: LogosDelivery
     lockNewGlobalBrokerContext:
       subscriber =

--- a/tests/api/test_conf.nim
+++ b/tests/api/test_conf.nim
@@ -6,6 +6,7 @@ import logos_delivery
 import logos_delivery/api/conf/logos_delivery_conf_json
 import logos_delivery/waku/factory/[waku_conf, networks_config]
 import logos_delivery/waku/common/logging
+import ../testlib/wakunodeconf
 
 suite "MessagingClientConf - mode expansion (toWakuNodeConf)":
   test "Core mode enables relay + service protocols":
@@ -53,6 +54,22 @@ suite "MessagingClientConf - field mapping + transport policy":
       kc.discv5UdpPort == Port(0)
       kc.websocketSupport == false
       kc.quicSupport == false
+
+  test "nat and storage defaults are the CLI defaults":
+    let kc = MessagingClientConf().toWakuNodeConf(LogosDeliveryMode.Core).valueOr:
+        raiseAssert error
+    let cli = defaultWakuNodeConf().valueOr:
+      raiseAssert error
+    check:
+      kc.nat == cli.nat
+      kc.localStoragePath == cli.localStoragePath
+
+  test "an explicit nat overrides the default":
+    let kc = MessagingClientConf(nat: Opt.some("none")).toWakuNodeConf(
+      LogosDeliveryMode.Core
+    ).valueOr:
+      raiseAssert error
+    check kc.nat == "none"
 
   test "explicit transport overrides win":
     let mc = MessagingClientConf(
@@ -160,6 +177,15 @@ suite "parseLogosDeliveryConf - JSON parsing":
     ).valueOr:
       raiseAssert error
     check WakuNodeConf(lc.kernelConf).localStoragePath == "/tmp/inst-1/data"
+
+  test "nat override maps to the kernel":
+    ## The structured shape is what the FFI and the JSON config use; without
+    ## this the only way to reach `nat` was the legacy flat blob.
+    let lc = parseLogosDeliveryConf(
+      """{"mode": "Core", "messagingOverrides": {"nat": "none"}}"""
+    ).valueOr:
+      raiseAssert error
+    check WakuNodeConf(lc.kernelConf).nat == "none"
 
   test "messaging overrides are recorded verbatim, unset fields left none":
     let lc = parseLogosDeliveryConf("""{"messagingOverrides": {"clusterId": 7}}""").valueOr:
@@ -408,10 +434,7 @@ suite "MessagingClientConf - anonymity level":
 
 suite "LogosDelivery.new - raw kernel construction":
   asyncTest "a kernel-only node mounts the kernel only; start/stop tolerate the nil layers":
-    let kernel = MessagingClientConf(listenIpv4: Opt.some(parseIpAddress("0.0.0.0"))).toWakuNodeConf(
-      LogosDeliveryMode.Core
-    ).valueOr:
-      raiseAssert error
+    let kernel = defaultTestWakuNodeConf()
     var node: LogosDelivery
     lockNewGlobalBrokerContext:
       node = (await LogosDelivery.new(KernelConf(kernel))).valueOr:

--- a/tests/api/test_entry_layer.nim
+++ b/tests/api/test_entry_layer.nim
@@ -9,8 +9,7 @@ import
   logos_delivery/messaging/rest_api/client as messaging_rest_client,
   logos_delivery/waku/rest_api/endpoint/client
 import tools/confutils/cli_args
-import logos_delivery/waku/persistency/persistency
-import ../testlib/testasync
+import ../testlib/[testasync, wakunodeconf]
 
 ## Validates the layer-selection invariant of `LogosDelivery.new(WakuNodeConf)`:
 ## `messagingClient` (and `reliableChannelManager`) are instantiated only for the
@@ -21,23 +20,7 @@ import ../testlib/testasync
 ##   channels  -> waku + messagingClient + reliableChannelManager
 
 proc nodeConf(entryLayer: EntryLayer, rest = false): WakuNodeConf =
-  var conf = defaultWakuNodeConf().valueOr:
-    raiseAssert error
-  conf.entryLayer = entryLayer
-  conf.mode = LogosDeliveryMode.Core
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  # The CLI default is "any"; keep test nodes off real gateway discovery.
-  conf.nat = "none"
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  # This suite does not test persistence. Keep the node off the shared ./data root.
-  conf.localStoragePath = InMemoryStoragePath
-  conf.rest = rest
-  conf.restAddress = parseIpAddress("127.0.0.1")
-  conf.restPort = 0'u16 # bind to an ephemeral port
-  return conf
+  defaultTestWakuNodeConf(entryLayer = entryLayer, rest = rest)
 
 proc restClientFor(node: LogosDelivery): RestClientRef =
   let boundPort = node.waku.restServer.httpServer.address.port

--- a/tests/api/test_messaging_rest.nim
+++ b/tests/api/test_messaging_rest.nim
@@ -15,8 +15,7 @@ import
   logos_delivery/waku/rest_api/endpoint/client,
   logos_delivery/waku/common/base64
 import tools/confutils/cli_args
-import logos_delivery/waku/persistency/persistency
-import ../testlib/[wakucore, testasync]
+import ../testlib/[wakucore, testasync, wakunodeconf]
 
 ## Integration test for the messaging REST endpoints and their event cache.
 ##
@@ -28,23 +27,7 @@ import ../testlib/[wakucore, testasync]
 ## network delivery.
 
 proc restNodeConf(): WakuNodeConf =
-  var conf = defaultWakuNodeConf().valueOr:
-    raiseAssert error
-  conf.entryLayer = EntryLayer.messaging
-  conf.mode = LogosDeliveryMode.Core
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  # The CLI default is "any"; keep test nodes off real gateway discovery.
-  conf.nat = "none"
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  # This suite does not test persistence. Keep the node off the shared ./data root.
-  conf.localStoragePath = InMemoryStoragePath
-  conf.rest = true
-  conf.restAddress = parseIpAddress("127.0.0.1")
-  conf.restPort = 0'u16 # bind to an ephemeral port
-  return conf
+  defaultTestWakuNodeConf(entryLayer = EntryLayer.messaging, rest = true)
 
 proc restClientFor(node: LogosDelivery): RestClientRef =
   let boundPort = node.waku.restServer.httpServer.address.port

--- a/tests/channels/test_reliable_channel_send_receive.nim
+++ b/tests/channels/test_reliable_channel_send_receive.nim
@@ -5,7 +5,7 @@ from std/times import epochTime
 import chronos, testutils/unittests, stew/byteutils
 import brokers/broker_context
 
-import ../testlib/[common, wakucore, wakunode, testasync]
+import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 
 import logos_delivery
 import logos_delivery/waku/[waku_node, waku_core]
@@ -28,16 +28,7 @@ import snapshot_codec
 const TestTimeout = chronos.seconds(15)
 
 proc createApiNodeConf(): WakuNodeConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  conf.rest = false
-  return conf
+  defaultTestWakuNodeConf()
 
 proc oneSegment(payload: seq[byte]): seq[byte] =
   ## The wire unit a peer actually sends: one encoded `SegmentMessage`. Every

--- a/tests/messaging/test_rln_proof_attach.nim
+++ b/tests/messaging/test_rln_proof_attach.nim
@@ -1,30 +1,20 @@
 {.used.}
 
-import std/[options, net, osproc]
+import std/[options, osproc]
 import chronos, testutils/unittests, results, stew/byteutils
 import
   logos_delivery/waku/[waku, waku_core, rln],
   logos_delivery/waku/node/waku_node,
   logos_delivery/waku/node/waku_node/relay,
   logos_delivery/waku/api/publish,
-  logos_delivery/api/conf/messaging_conf,
   logos_delivery/waku/factory/waku_conf
 import
-  ../testlib/testasync,
+  ../testlib/[testasync, wakunodeconf],
   ../waku_rln_relay/utils_onchain,
   ../waku_rln_relay/rln/waku_rln_relay_utils
 
 proc testConf(): WakuConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  conf.rest = false
-  return conf.toWakuConf().valueOr:
+  defaultTestWakuNodeConf().toWakuConf().valueOr:
     raiseAssert error
 
 proc testMessage(): WakuMessage =

--- a/tests/messaging/test_send_service_mix.nim
+++ b/tests/messaging/test_send_service_mix.nim
@@ -1,6 +1,5 @@
 {.used.}
 
-import std/net
 import chronos, chronicles, testutils/unittests, results, stew/byteutils
 
 import
@@ -15,12 +14,11 @@ import
   logos_delivery/waku/waku_lightpush/common,
   logos_delivery/waku/waku_core,
   logos_delivery/api/types,
-  logos_delivery/api/conf/messaging_conf,
   logos_delivery/waku/factory/waku_conf,
   logos_delivery/messaging/rate_limit_manager/rate_limit_manager,
   logos_delivery/messaging/delivery_service/send_service/
     [send_service, send_processor, mix_processor, delivery_task]
-import ../testlib/[testasync, wakucore]
+import ../testlib/[testasync, wakucore, wakunodeconf]
 
 ## Tests for the anonymity levels of the send path. The mix processor keeps the
 ## task for the mix window. Only a `Preferred` chain gives the task to the relay
@@ -39,16 +37,7 @@ method sendImpl(self: PlainSendProcessor, task: DeliveryTask): Future[void] {.as
   task.firstPropagatedTime = Opt.some(Moment.now())
 
 proc testConf(): WakuConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  conf.rest = false
-  return conf.toWakuConf().valueOr:
+  defaultTestWakuNodeConf().toWakuConf().valueOr:
     raiseAssert error
 
 suite "SendService - anonymity level":

--- a/tests/messaging/test_send_service_scheduler.nim
+++ b/tests/messaging/test_send_service_scheduler.nim
@@ -1,18 +1,16 @@
 {.used.}
 
-import std/net
 import chronos, chronicles, testutils/unittests, results, stew/byteutils
 
 import
   logos_delivery/waku/waku,
   logos_delivery/waku/waku_core,
   logos_delivery/api/types,
-  logos_delivery/api/conf/messaging_conf,
   logos_delivery/waku/factory/waku_conf,
   logos_delivery/messaging/rate_limit_manager/rate_limit_manager,
   logos_delivery/messaging/delivery_service/send_service/
     [send_service, send_processor, delivery_task]
-import ../testlib/testasync
+import ../testlib/[testasync, wakunodeconf]
 
 ## Scheduler-level coverage for the send service's rate-limit seam: a task is
 ## charged exactly once however many rounds it takes, and an over-budget task
@@ -33,16 +31,7 @@ method process(self: FakeSendProcessor, task: DeliveryTask): Future[void] {.asyn
     task.firstPropagatedTime = Opt.some(Moment.now())
 
 proc testConf(): WakuConf =
-  var conf = MessagingClientConf()
-    .toWakuNodeConf(messaging_conf.LogosDeliveryMode.Core).valueOr:
-      raiseAssert error
-  conf.listenAddress = parseIpAddress("0.0.0.0")
-  conf.tcpPort = Port(0)
-  conf.discv5UdpPort = Port(0)
-  conf.clusterId = Opt.some(3'u16)
-  conf.numShardsInNetwork = 1
-  conf.rest = false
-  return conf.toWakuConf().valueOr:
+  defaultTestWakuNodeConf().toWakuConf().valueOr:
     raiseAssert error
 
 proc fixedEpochQuota(epoch: ptr uint64, userMessageLimit: uint64): QuotaProvider =

--- a/tests/test_waku.nim
+++ b/tests/test_waku.nim
@@ -1,21 +1,16 @@
 {.used.}
 
-import results, std/net
+import results
 
 import chronos, testutils/unittests
 
 import logos_delivery
-import tools/confutils/cli_args
-import logos_delivery/waku/factory/networks_config
-import logos_delivery/waku/factory/conf_builder/conf_builder
+import ./testlib/wakunodeconf
 
 suite "LogosDelivery API - Create node":
   asyncTest "Create node with minimal configuration":
     ## Given
-    var nodeConf = MessagingClientConf().toWakuNodeConf(Core).valueOr:
-        raiseAssert "toWakuNodeConf failed: " & error
-    nodeConf.clusterId = Opt.some(3'u16)
-    nodeConf.rest = false
+    let nodeConf = defaultTestWakuNodeConf()
 
     # This is the actual minimal config but as the node auto-start, it is not suitable for tests
 
@@ -31,10 +26,8 @@ suite "LogosDelivery API - Create node":
 
   asyncTest "Create node with full configuration":
     ## Given
-    var nodeConf = MessagingClientConf().toWakuNodeConf(Core).valueOr:
-        raiseAssert "toWakuNodeConf failed: " & error
+    var nodeConf = defaultTestWakuNodeConf()
     nodeConf.clusterId = Opt.some(99'u16)
-    nodeConf.rest = false
     nodeConf.numShardsInNetwork = 16
     nodeConf.maxMessageSize = "1024 KiB"
     nodeConf.entryNodes = @[
@@ -62,10 +55,8 @@ suite "LogosDelivery API - Create node":
 
   asyncTest "Create node with mixed entry nodes (enrtree, multiaddr)":
     ## Given
-    var nodeConf = MessagingClientConf().toWakuNodeConf(Core).valueOr:
-        raiseAssert "toWakuNodeConf failed: " & error
+    var nodeConf = defaultTestWakuNodeConf()
     nodeConf.clusterId = Opt.some(42'u16)
-    nodeConf.rest = false
     nodeConf.entryNodes = @[
       "enrtree://AIRVQ5DDA4FFWLRBCHJWUWOO6X6S4ZTZ5B667LQ6AJU6PEYDLRD5O@sandbox.waku.nodes.status.im",
       "/ip4/127.0.0.1/tcp/60000/p2p/16Uuu2HBmAcHvhLqQKwSSbX6BG5JLWUDRcaLVrehUVqpw7fz1hbYc",

--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -20,6 +20,7 @@ import
     factory/conf_builder/conf_builder,
     factory/builder,
     common/logging,
+    persistency/persistency,
   ],
   ./common
 
@@ -35,6 +36,7 @@ proc defaultTestWakuConfBuilder*(): WakuConfBuilder =
   )
   # The "none" strategy keeps tests off real UPnP/NAT-PMP gateway discovery.
   builder.withNatStrategy("none")
+  builder.withLocalStoragePath(InMemoryStoragePath)
   builder.withMaxConnections(150)
   builder.withRelayServiceRatio("50:50")
   builder.withMaxMessageSize("1024 KiB")

--- a/tests/testlib/wakunodeconf.nim
+++ b/tests/testlib/wakunodeconf.nim
@@ -1,0 +1,35 @@
+## Node configuration for tests. The shipped defaults suit a deployed node, not
+## a test process: nodes in one process share the working directory, so storage
+## stays in memory, and no test node should look for a real NAT gateway, so NAT
+## discovery is off. Override the returned configuration for anything else.
+
+import std/net, results
+import
+  logos_delivery/api/conf/messaging_conf,
+  logos_delivery/waku/persistency/persistency,
+  tools/confutils/cli_args
+
+export cli_args
+
+const TestClusterId* = 3'u16
+
+proc defaultTestWakuNodeConf*(
+    mode = LogosDeliveryMode.Core,
+    numShards: uint16 = 1,
+    entryLayer = EntryLayer.channels,
+    rest = false,
+): WakuNodeConf =
+  var conf = MessagingClientConf().toWakuNodeConf(mode).valueOr:
+      raiseAssert error
+  conf.entryLayer = entryLayer
+  conf.listenAddress = parseIpAddress("0.0.0.0")
+  conf.tcpPort = Port(0)
+  conf.discv5UdpPort = Port(0)
+  conf.clusterId = Opt.some(TestClusterId)
+  conf.numShardsInNetwork = numShards
+  conf.nat = "none"
+  conf.localStoragePath = InMemoryStoragePath
+  conf.rest = rest
+  conf.restAddress = parseIpAddress("127.0.0.1")
+  conf.restPort = 0'u16 # bind to an ephemeral port
+  return conf


### PR DESCRIPTION
## Description

This PR centralizes the test node configuration in `tests/testlib/wakunodeconf.nim`. One builder gives all test nodes the same test-friendly defaults of in-memory storage and no NAT discovery.

A library node has the same `nat` default as the CLI, `"any"`, and tries to find a NAT gateway at start. `MessagingClientConf` now has a `nat` field, so the JSON configuration and the FFI can give `"none"`.

## Changes

* add `tests/testlib/wakunodeconf.nim`, a shared test node config
* build the test node configs with `defaultTestWakuNodeConf`
* pin `InMemoryStoragePath` in the kernel test harness
* use the CLI `nat` default in the library
* add `nat` to `MessagingClientConf`
* add tests

## Issue

Maintenance Y2026H2 #4043
