### PR TITLE
feat(messaging): tag MessageReceivedEvent with its source, live or history

### DIFF
--- a/library/MESSAGE_EVENTS.md
+++ b/library/MESSAGE_EVENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The liblogosdelivery library emits three types of message delivery events that clients can listen to by registering a per-event callback with `logosdelivery_add_event_listener()`. The events are delivered under the wire names `onMessageSent`, `onMessagePropagated` and `onMessageError` (the JSON `eventType` inside each payload is `message_sent` / `message_propagated` / `message_error`).
+The liblogosdelivery library emits three types of message delivery events and one message receipt event that clients can listen to by registering a per-event callback with `logosdelivery_add_event_listener()`. The events are delivered under the wire names `onMessageSent`, `onMessagePropagated`, `onMessageError` and `onMessageReceived` (the JSON `eventType` inside each payload is `message_sent` / `message_propagated` / `message_error` / `message_received`).
 
 ## Event Types
 
@@ -59,6 +59,35 @@ Emitted when an error occurs during message sending or propagation.
 - `messageHash`: Hash of the message that failed
 - `error`: Description of what went wrong
 
+### 4. message_received
+Emitted once for every message accepted on a subscribed content topic, whether it arrived live from the network or was recovered from a Store peer (at startup, or after a connectivity gap). The `source` field tells the two apart.
+
+**JSON Structure:**
+```json
+{
+  "eventType": "message_received",
+  "messageHash": "0x...",
+  "message": {
+    "payload": "base64...",
+    "contentTopic": "/myapp/1/chat/proto",
+    "version": 0,
+    "timestamp": 1700000000000000000,
+    "ephemeral": false,
+    "meta": "",
+    "proof": ""
+  },
+  "source": "live"
+}
+```
+
+**Fields:**
+- `eventType`: Always "message_received"
+- `messageHash`: Hash of the received message
+- `message`: The received message; `payload`, `meta` and `proof` are base64-encoded
+- `source`: `"live"` when the message was delivered as it was published (relay or filter), `"history"` when it was recovered from Store
+
+Duplicate suppression is best effort. The node remembers the hashes it has delivered for a few minutes, in memory only, so a live message that a Store check returns within that window is not reported again. After a restart, or when a Store recovery returns a message later than that, the same message can be reported a second time as `history`. Consumers that need exactly-once delivery should deduplicate by `messageHash`.
+
 ## Usage
 
 ### 1. Define an Event Callback
@@ -79,6 +108,8 @@ void event_callback(int ret, const char *msg, size_t len, void *userData) {
         // Handle message propagated
     } else if (eventType == "message_error") {
         // Handle message error
+    } else if (eventType == "message_received") {
+        // Handle message received; check "source" for "live" or "history"
     }
 }
 ```
@@ -97,6 +128,7 @@ void *rawCtx = ctx->ptr;
 logosdelivery_add_event_listener(rawCtx, "onMessageSent", event_callback, NULL);
 logosdelivery_add_event_listener(rawCtx, "onMessagePropagated", event_callback, NULL);
 logosdelivery_add_event_listener(rawCtx, "onMessageError", event_callback, NULL);
+logosdelivery_add_event_listener(rawCtx, "onMessageReceived", event_callback, NULL);
 ```
 
 ### 3. Start the Node
@@ -141,7 +173,7 @@ For a failed message send:
 See `examples/liblogosdelivery_example.c` for a complete working example that:
 - Registers an event callback
 - Sends a message
-- Receives and prints all three event types
+- Receives and prints all four event types
 - Properly parses the JSON event structure
 
 ## Debugging Events

--- a/library/examples/json_utils.c
+++ b/library/examples/json_utils.c
@@ -60,36 +60,60 @@ const char* extract_json_object(const char *json, const char *field, size_t *out
     return NULL;
 }
 
-int decode_json_byte_array(const char *json, const char *field, char *buffer, size_t bufSize) {
+static int base64_value(char c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+int decode_json_base64_field(const char *json, const char *field, char *buffer, size_t bufSize) {
     char searchStr[256];
-    snprintf(searchStr, sizeof(searchStr), "\"%s\":[", field);
+    snprintf(searchStr, sizeof(searchStr), "\"%s\":\"", field);
 
     const char *start = strstr(json, searchStr);
-    if (!start) {
+    if (!start || bufSize == 0) {
         return -1;
     }
-
-    // Advance to the opening bracket
-    start = strchr(start, '[');
-    if (!start) {
+    start += strlen(searchStr);
+    const char *end = strchr(start, '"');
+    if (!end) {
         return -1;
     }
-    start++; // skip '['
 
     size_t pos = 0;
-    const char *p = start;
-    while (*p && *p != ']' && pos < bufSize - 1) {
-        // Skip whitespace and commas
-        while (*p == ' ' || *p == ',' || *p == '\n' || *p == '\r' || *p == '\t') p++;
-        if (*p == ']') break;
-
-        // Parse integer
-        int val = 0;
-        while (*p >= '0' && *p <= '9') {
-            val = val * 10 + (*p - '0');
-            p++;
+    size_t chars = 0; // base64 digits seen
+    size_t pads = 0;  // '=' seen, only allowed at the end
+    unsigned int acc = 0;
+    int bits = 0;
+    for (const char *p = start; p < end; p++) {
+        if (*p == '=') {
+            pads++;
+            continue;
         }
-        buffer[pos++] = (char)val;
+        int v = base64_value(*p);
+        if (v < 0 || pads > 0) {
+            return -1; // not base64, or a digit after the padding
+        }
+        chars++;
+        acc = (acc << 6) | (unsigned int)v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            if (pos >= bufSize - 1) {
+                return -1;
+            }
+            buffer[pos++] = (char)((acc >> bits) & 0xFF);
+        }
+    }
+    // A group of 4 digits gives 3 bytes; a final group of 2 or 3 digits is a
+    // short one, a final group of 1 digit cannot be. Padding, when present,
+    // must complete the final group exactly.
+    size_t rem = chars % 4;
+    if (rem == 1 || (pads != 0 && pads != (4 - rem) % 4)) {
+        return -1;
     }
     buffer[pos] = '\0';
     return (int)pos;

--- a/library/examples/json_utils.h
+++ b/library/examples/json_utils.h
@@ -13,9 +13,11 @@ const char* extract_json_field(const char *json, const char *field, char *buffer
 // Handles nested braces.
 const char* extract_json_object(const char *json, const char *field, size_t *outLen);
 
-// Decode a JSON array of integers (byte values) into a buffer.
-// Parses e.g. [72,101,108,108,111] into "Hello".
-// Returns number of bytes decoded, or -1 on error.
-int decode_json_byte_array(const char *json, const char *field, char *buffer, size_t bufSize);
+// Decode a base64 JSON string field into buffer. The FFI renders the byte
+// fields of a message (payload, meta, proof) as base64 strings.
+// Returns the number of bytes decoded, or -1 when the field is missing, the
+// base64 is invalid, or the output does not fit in bufSize - 1 bytes. The
+// output is NUL-terminated so a text payload prints as a string.
+int decode_json_base64_field(const char *json, const char *field, char *buffer, size_t bufSize);
 
 #endif // JSON_UTILS_H

--- a/library/examples/logosdelivery_example.c
+++ b/library/examples/logosdelivery_example.c
@@ -67,7 +67,9 @@ void event_callback(int ret, const char *msg, size_t len, void *userData) {
 
     } else if (strcmp(eventType, "message_received") == 0) {
         char messageHash[128];
+        char source[32]; // "live" from the network, "history" from Store
         extract_json_field(eventJson, "messageHash", messageHash, sizeof(messageHash));
+        extract_json_field(eventJson, "source", source, sizeof(source));
 
         // Extract the nested "message" object
         size_t msgObjLen = 0;
@@ -82,11 +84,12 @@ void event_callback(int ret, const char *msg, size_t len, void *userData) {
                 char contentTopic[256];
                 extract_json_field(msgJson, "contentTopic", contentTopic, sizeof(contentTopic));
 
-                // Decode payload from JSON byte array to string
+                // The payload arrives base64-encoded; decode it for display
                 char payload[4096];
-                int payloadLen = decode_json_byte_array(msgJson, "payload", payload, sizeof(payload));
+                int payloadLen = decode_json_base64_field(msgJson, "payload", payload, sizeof(payload));
 
-                printf("[EVENT] Message received - Hash: %s, ContentTopic: %s\n", messageHash, contentTopic);
+                printf("[EVENT] Message received - Hash: %s, ContentTopic: %s, Source: %s\n",
+                       messageHash, contentTopic, source);
                 if (payloadLen > 0) {
                     printf("        Payload (%d bytes): %.*s\n", payloadLen, payloadLen, payload);
                 } else {
@@ -96,7 +99,8 @@ void event_callback(int ret, const char *msg, size_t len, void *userData) {
                 free(msgJson);
             }
         } else {
-            printf("[EVENT] Message received - Hash: %s (could not parse message)\n", messageHash);
+            printf("[EVENT] Message received - Hash: %s, Source: %s (could not parse message)\n",
+                   messageHash, source);
         }
         got_message_received = 1;
 

--- a/logos_delivery/api/events/messaging_client_events.nim
+++ b/logos_delivery/api/events/messaging_client_events.nim
@@ -24,7 +24,9 @@ EventBroker:
     messageHash*: string
 
 EventBroker:
-  # Event emitted when a message is received via Waku
+  # Event emitted when a message is received via Waku, live from the network
+  # or recovered from Store. `source` tells the two apart.
   type MessageReceivedEvent* = object
     messageHash*: string
     message*: WakuMessage
+    source*: MessageSource

--- a/logos_delivery/api/events/messaging_client_events.nim
+++ b/logos_delivery/api/events/messaging_client_events.nim
@@ -24,8 +24,8 @@ EventBroker:
     messageHash*: string
 
 EventBroker:
-  # Event emitted when a message is received via Waku, live from the network
-  # or recovered from Store. `source` tells the two apart.
+  # Event emitted when either a message belongs to Live communication or
+  # or recovered from Store. The source field has this information.
   type MessageReceivedEvent* = object
     messageHash*: string
     message*: WakuMessage

--- a/logos_delivery/api/events/messaging_client_events.nim
+++ b/logos_delivery/api/events/messaging_client_events.nim
@@ -25,7 +25,7 @@ EventBroker:
 
 EventBroker:
   # Event emitted when either a message belongs to Live communication or
-  # or recovered from Store. The source field has this information.
+  # recovered from Store. The source field has this information.
   type MessageReceivedEvent* = object
     messageHash*: string
     message*: WakuMessage

--- a/logos_delivery/api/types.nim
+++ b/logos_delivery/api/types.nim
@@ -25,9 +25,6 @@ type
     Connected
 
   MessageSource* {.pure.} = enum
-    ## How a received message reached this node. Carried by
-    ## `MessageReceivedEvent`, so an app can tell a message that was
-    ## published while it listened from one it recovered afterwards.
     Live = "live" ## delivered as it was published, over relay or filter
     History = "history" ## recovered from a Store peer, at start or after a gap
 

--- a/logos_delivery/api/types.nim
+++ b/logos_delivery/api/types.nim
@@ -24,6 +24,13 @@ type
     PartiallyConnected
     Connected
 
+  MessageSource* {.pure.} = enum
+    ## How a received message reached this node. Carried by
+    ## `MessageReceivedEvent`, so an app can tell a message that was
+    ## published while it listened from one it recovered afterwards.
+    Live = "live" ## delivered as it was published, over relay or filter
+    History = "history" ## recovered from a Store peer, at start or after a gap
+
   PeerConnInfo* = object ## structured connected-peer info for the api boundary
     peerId*: string
     protocols*: seq[string]

--- a/logos_delivery/messaging/delivery_service/recv_service/recv_service.nim
+++ b/logos_delivery/messaging/delivery_service/recv_service/recv_service.nim
@@ -14,7 +14,8 @@ import
   logos_delivery/waku/api/[store, subscriptions]
 import
   logos_delivery/api/events/kernel_events,
-  logos_delivery/api/events/messaging_client_events # MessageReceivedEvent
+  logos_delivery/api/events/messaging_client_events, # MessageReceivedEvent
+  logos_delivery/messaging/messaging_metrics
 
 const MaxMessageLife = chronos.minutes(7) ## Max time we will keep track of rx messages
 
@@ -127,6 +128,7 @@ proc processIncomingMessage(
   # Local receipt time: a message recovered from Store stays known for the
   # full period whatever its own timestamp.
   self.recentReceivedMsgs[msgHash] = getNowInNanosecondTime()
+  recordReceived(source, message.payload.len)
   info "Message received",
     msg_hash = msgHash.to0xHex(),
     contentTopic = message.contentTopic,

--- a/logos_delivery/messaging/delivery_service/recv_service/recv_service.nim
+++ b/logos_delivery/messaging/delivery_service/recv_service/recv_service.nim
@@ -104,11 +104,12 @@ proc getMissingMsgsFromStore(
   )
 
 proc processIncomingMessage(
-    self: RecvService, pubsubTopic: string, message: WakuMessage
+    self: RecvService, pubsubTopic: string, message: WakuMessage, source: MessageSource
 ): bool =
   ## Return false if the incoming message is from a non-subscribed topic,
   ## or if the message is a duplicate (recently-seen). Otherwise, save it as
-  ## recently-seen, emit a MessageReceivedEvent, and return true.
+  ## recently-seen, emit a MessageReceivedEvent tagged with `source`, and
+  ## return true.
 
   if not self.waku.isContentSubscribed(pubsubTopic, message.contentTopic):
     trace "skipping message as I am not subscribed",
@@ -129,13 +130,14 @@ proc processIncomingMessage(
   info "Message received",
     msg_hash = msgHash.to0xHex(),
     contentTopic = message.contentTopic,
-    pubsubTopic = pubsubTopic
-  MessageReceivedEvent.emit(self.brokerCtx, msgHash.to0xHex(), message)
+    pubsubTopic = pubsubTopic,
+    source = source
+  MessageReceivedEvent.emit(self.brokerCtx, msgHash.to0xHex(), message, source)
   return true
 
 proc checkStore*(self: RecvService) {.async.} =
   ## Checks the store for messages that were not received directly and
-  ## delivers them via MessageReceivedEvent.
+  ## delivers them via MessageReceivedEvent, as `MessageSource.History`.
   if not self.waku.isStoreMounted():
     debug "recv service has no store client mounted, skipping store check"
     return
@@ -172,7 +174,9 @@ proc checkStore*(self: RecvService) {.async.} =
       let missingMsgsRet = await self.getMissingMsgsFromStore(missedHashes)
       if missingMsgsRet.isOk():
         for msgTuple in missingMsgsRet.get():
-          if self.processIncomingMessage(msgTuple.pubsubTopic, msgTuple.msg):
+          if self.processIncomingMessage(
+            msgTuple.pubsubTopic, msgTuple.msg, MessageSource.History
+          ):
             debug "recv service store-recovered message",
               msg_hash = shortLog(msgTuple.hash), pubsubTopic = msgTuple.pubsubTopic
       else:
@@ -251,7 +255,7 @@ proc startupCatchUp(self: RecvService, job: persistency.Job) {.async.} =
   ): bool {.gcsafe, raises: [].} =
     if not self.waku.isContentSubscribed(pubsubTopic, message.contentTopic):
       return false
-    discard self.processIncomingMessage(pubsubTopic, message)
+    discard self.processIncomingMessage(pubsubTopic, message, MessageSource.History)
     return true
   let wake = newAsyncEvent() # a new subscription or a connectivity change
   let onSubscribed = proc(event: ContentTopicSubscribedEvent) {.async: (raises: []).} =
@@ -365,7 +369,8 @@ proc startRecvService*(self: RecvService, job: persistency.Job) =
   self.seenMsgListener = MessageSeenEvent.listen(
     self.brokerCtx,
     proc(event: MessageSeenEvent) {.async: (raises: []).} =
-      discard self.processIncomingMessage(event.topic, event.message),
+      discard
+        self.processIncomingMessage(event.topic, event.message, MessageSource.Live),
   ).valueOr:
     error "Failed to set MessageSeenEvent listener", error = error
     quit(QuitFailure)

--- a/logos_delivery/messaging/delivery_service/send_service/send_service.nim
+++ b/logos_delivery/messaging/delivery_service/send_service/send_service.nim
@@ -2,7 +2,7 @@
 ##
 
 import std/[sequtils, tables, typetraits]
-import chronos, chronicles, metrics
+import chronos, chronicles
 import brokers/broker_context
 import
   ./[send_processor, relay_processor, lightpush_processor, mix_processor, delivery_task],
@@ -12,12 +12,10 @@ import
   logos_delivery/messaging/rate_limit_manager/rate_limit_manager
 import logos_delivery/api/events/messaging_client_events
 import logos_delivery/api/conf/modes
+import logos_delivery/messaging/messaging_metrics
 
 logScope:
   topics = "send service"
-
-declarePublicCounter logos_delivery_send_store_validation_timeout_total,
-  "messages propagated but dropped without store-node validation within the retry window"
 
 # This useful util is missing from sequtils, this extends applyIt with predicate...
 template applyItIf*(varSeq, pred, op: untyped) =
@@ -277,7 +275,7 @@ proc evaluateAndCleanUp(self: SendService) =
         requestId = task.requestId,
         msgHash = task.msgHash.to0xHex(),
         propagationAge = task.propagationAge()
-      logos_delivery_send_store_validation_timeout_total.inc()
+      recordStoreValidationTimeout()
 
   self.taskCache.keepItIf(
     not (

--- a/logos_delivery/messaging/messaging_metrics.nim
+++ b/logos_delivery/messaging/messaging_metrics.nim
@@ -1,0 +1,34 @@
+## Messaging layer counters.
+##
+## A send that no store node validates in time is logged at DEBUG, and a
+## received message is logged at INFO; these counters are what makes both
+## visible in aggregate, with receipts split by where the message came from.
+##
+## Label cardinality is bounded by construction: the recorder below takes the
+## package's enum rather than a string, so `source` can only ever be one of the
+## two `MessageSource` values (Live, History). Four series in total, and
+## nothing a peer sends can reach a label.
+
+{.push raises: [].}
+
+import metrics
+import logos_delivery/api/types
+
+declarePublicCounter logos_delivery_send_store_validation_timeout_total,
+  "messages propagated but dropped without store-node validation within the retry window"
+declarePublicCounter logos_delivery_recv_messages_total,
+  "messages delivered to the application, live from the network or history from Store",
+  ["source"]
+declarePublicCounter logos_delivery_recv_message_bytes_total,
+  "payload bytes of the messages delivered to the application, by source", ["source"]
+
+proc recordStoreValidationTimeout*() =
+  logos_delivery_send_store_validation_timeout_total.inc()
+
+proc recordReceived*(source: MessageSource, payloadBytes: int) =
+  logos_delivery_recv_messages_total.inc(labelValues = [$source])
+  logos_delivery_recv_message_bytes_total.inc(
+    payloadBytes.int64, labelValues = [$source]
+  )
+
+{.pop.}

--- a/logos_delivery/messaging/messaging_metrics.nim
+++ b/logos_delivery/messaging/messaging_metrics.nim
@@ -1,13 +1,8 @@
 ## Messaging layer counters.
 ##
-## A send that no store node validates in time is logged at DEBUG, and a
-## received message is logged at INFO; these counters are what makes both
-## visible in aggregate, with receipts split by where the message came from.
-##
-## Label cardinality is bounded by construction: the recorder below takes the
-## package's enum rather than a string, so `source` can only ever be one of the
-## two `MessageSource` values (Live, History). Four series in total, and
-## nothing a peer sends can reach a label.
+## Label cardinality is bounded by construction: `recordReceived` takes the
+## `MessageSource` enum rather than a string, so `source` can only ever be
+## `live` or `history`. Four receive series in total, plus the send counter.
 
 {.push raises: [].}
 
@@ -21,6 +16,12 @@ declarePublicCounter logos_delivery_recv_messages_total,
   ["source"]
 declarePublicCounter logos_delivery_recv_message_bytes_total,
   "payload bytes of the messages delivered to the application, by source", ["source"]
+
+# A labelled series exists from its first increment. Start every source at zero,
+# so the series are scraped before the first message and can be read at any time.
+for source in MessageSource:
+  logos_delivery_recv_messages_total.inc(0, labelValues = [$source])
+  logos_delivery_recv_message_bytes_total.inc(0, labelValues = [$source])
 
 proc recordStoreValidationTimeout*() =
   logos_delivery_send_store_validation_timeout_total.inc()

--- a/logos_delivery/messaging/rest_api/event_cache.nim
+++ b/logos_delivery/messaging/rest_api/event_cache.nim
@@ -73,11 +73,14 @@ proc recordSend*(
     status[].events.add(record)
 
 proc recordReceived*(
-    self: MessagingEventCache, messageHash: string, message: RelayWakuMessage
+    self: MessagingEventCache,
+    messageHash: string,
+    message: RelayWakuMessage,
+    source: MessageSource,
 ) =
   ## Buffer a received message, dropping the oldest past the ring capacity.
   self.received.addLast(
-    ReceivedMessageRecord(messageHash: messageHash, message: message)
+    ReceivedMessageRecord(messageHash: messageHash, message: message, source: source)
   )
 
   while self.received.len > self.maxReceived:

--- a/logos_delivery/messaging/rest_api/handlers.nim
+++ b/logos_delivery/messaging/rest_api/handlers.nim
@@ -53,7 +53,7 @@ proc installEventListeners(brokerCtx: BrokerContext, cache: MessagingEventCache)
   discard MessageReceivedEvent.listen(
     brokerCtx,
     proc(evt: MessageReceivedEvent): Future[void] {.async: (raises: []).} =
-      cache.recordReceived(evt.messageHash, toRelayWakuMessage(evt.message)),
+      cache.recordReceived(evt.messageHash, toRelayWakuMessage(evt.message), evt.source),
   )
 
 proc installMessagingApiHandlers*(router: var RestRouter, client: MessagingClient) =

--- a/logos_delivery/messaging/rest_api/types.nim
+++ b/logos_delivery/messaging/rest_api/types.nim
@@ -144,8 +144,9 @@ proc readValue*(
 ##
 ## Send-related events (sent / propagated / error) are grouped per request id.
 ## Received messages carry the full `WakuMessage` (serialized as
-## `RelayWakuMessage`), matching the nim `MessageReceivedEvent`. Both surfaces
-## are populated by the broker listeners installed in the messaging handlers.
+## `RelayWakuMessage`) and the `source` it came from (`live` / `history`),
+## matching the nim `MessageReceivedEvent`. Both surfaces are populated by the
+## broker listeners installed in the messaging handlers.
 
 type
   SendEventKind* {.pure.} = enum
@@ -166,6 +167,7 @@ type
   ReceivedMessageRecord* = object
     messageHash*: string
     message*: RelayWakuMessage ## the received WakuMessage, full fidelity
+    source*: MessageSource ## `live` from the network, `history` from Store
 
 #### Event DTO serialization
 
@@ -194,6 +196,7 @@ proc writeValue*(
   writer.beginRecord()
   writer.writeField("messageHash", value.messageHash)
   writer.writeField("message", value.message)
+  writer.writeField("source", $value.source)
   writer.endRecord()
 
 proc readValue*(
@@ -209,6 +212,18 @@ proc readValue*(
     value = SendEventKind.Error
   else:
     reader.raiseUnexpectedValue("Invalid send event kind: " & s)
+
+proc readValue*(
+    reader: var JsonReader[RestJson], value: var MessageSource
+) {.raises: [SerializationError, IOError].} =
+  let s = reader.readValue(string)
+  case s
+  of "live":
+    value = MessageSource.Live
+  of "history":
+    value = MessageSource.History
+  else:
+    reader.raiseUnexpectedValue("Invalid message source: " & s)
 
 proc readValue*(
     reader: var JsonReader[RestJson], value: var SendEventRecord
@@ -263,6 +278,7 @@ proc readValue*(
   var
     messageHash = ""
     message = RelayWakuMessage()
+    source = Opt.none(MessageSource)
 
   for fieldName in readObjectFields(reader):
     case fieldName
@@ -270,7 +286,14 @@ proc readValue*(
       messageHash = reader.readValue(string)
     of "message":
       message = reader.readValue(RelayWakuMessage)
+    of "source":
+      source = Opt.some(reader.readValue(MessageSource))
     else:
       unrecognizedFieldWarning(value)
 
-  value = ReceivedMessageRecord(messageHash: messageHash, message: message)
+  if source.isNone():
+    reader.raiseUnexpectedValue("Field `source` is missing")
+
+  value = ReceivedMessageRecord(
+    messageHash: messageHash, message: message, source: source.get()
+  )

--- a/tests/api/test_api_receive.nim
+++ b/tests/api/test_api_receive.nim
@@ -1,12 +1,13 @@
 {.used.}
 
 import results, std/[sequtils, net, sets, os, osproc, tempfiles, strutils]
-import chronos, testutils/unittests, stew/byteutils
+import chronos, metrics, testutils/unittests, stew/byteutils
 import libp2p/[peerid, peerinfo, crypto/crypto]
 import brokers/broker_context
 import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 import ../waku_archive/archive_utils
 import logos_delivery/messaging/messaging_client
+import logos_delivery/messaging/messaging_metrics
 import logos_delivery/messaging/messaging_client_lifecycle
 import logos_delivery/messaging/delivery_service/recv_service
 import logos_delivery/messaging/delivery_service/recv_service/backfill
@@ -633,6 +634,9 @@ suite "Messaging API, Receive Service (store recovery)":
   asyncTest "recv_service recovers a missed message through a known Store peer":
     # Phase 1: the startup catch-up dials the known Store peer.
     block:
+      let history = $MessageSource.History
+      let countBefore = logos_delivery_recv_messages_total.value([history])
+      let bytesBefore = logos_delivery_recv_message_bytes_total.value([history])
       let net = await setupNetwork(ContentTopic("/waku/2/recv-test/proto"))
       defer:
         await net.teardown()
@@ -642,6 +646,9 @@ suite "Messaging API, Receive Service (store recovery)":
       if eventManager.receivedMessages.len > 0:
         check eventManager.receivedMessages[0].payload == net.missedPayload
         check eventManager.receivedSources[0] == MessageSource.History
+      check logos_delivery_recv_messages_total.value([history]) == countBefore + 1
+      check logos_delivery_recv_message_bytes_total.value([history]) ==
+        bytesBefore + float64(net.missedPayload.len)
 
     # Phase 2: a Store peer learned after the subscription, by connecting to
     # it, is asked as soon as the connection is reported.

--- a/tests/api/test_api_receive.nim
+++ b/tests/api/test_api_receive.nim
@@ -37,6 +37,7 @@ type ReceiveEventListenerManager = ref object
   receivedListener: MessageReceivedEventListener
   receivedEvent: AsyncEvent
   receivedMessages: seq[WakuMessage]
+  receivedSources: seq[MessageSource] ## one per `receivedMessages` entry
   targetCount: int
 
 proc newReceiveEventListenerManager(
@@ -52,6 +53,7 @@ proc newReceiveEventListenerManager(
       brokerCtx,
       proc(event: MessageReceivedEvent) {.async: (raises: []).} =
         manager.receivedMessages.add(event.message)
+        manager.receivedSources.add(event.source)
         if manager.receivedMessages.len >= manager.targetCount:
           manager.receivedEvent.fire()
       ,
@@ -284,6 +286,9 @@ proc runRestartedReceiver(
   if expectedCount > 0:
     for i in 0 ..< OfflineCount:
       doAssert "process-offline-" & $i in payloads
+  # Everything a restarted process recovers comes from Store.
+  doAssert events.receivedSources.allIt(it == MessageSource.History),
+    "recovered messages must be reported as history, got " & $events.receivedSources
   await events.teardown()
   (await subscriber.stop()).expect("stop new process subscriber")
 
@@ -587,6 +592,9 @@ suite "Messaging API, Receive Service (store recovery)":
       await net.publishLive(topic, "live three")
       check await events.waitForEvents(TestTimeout)
       discard await job.waitForAdvance(afterFirst)
+      # The setup message came from Store, the published ones came live.
+      check events.receivedSources[0] == MessageSource.History
+      check events.receivedSources[1 ..^ 1].allIt(it == MessageSource.Live)
 
     # Phase 7: the hint moves on a live receipt while the catch-up waits on a
     # Store peer that it cannot get to. The catch-up continues to retry behind it.
@@ -617,9 +625,10 @@ suite "Messaging API, Receive Service (store recovery)":
       check await events.waitForEvents(TestTimeout)
       let moved = await job.waitForAdvance(atStart)
       check moved <= now()
-      check events.receivedMessages.mapIt(string.fromBytes(it.payload)).anyIt(
-        it == "live while Store is dead"
-      )
+      let liveIdx = events.receivedMessages.mapIt(string.fromBytes(it.payload)).find(
+          "live while Store is dead"
+        )
+      check liveIdx >= 0 and events.receivedSources[liveIdx] == MessageSource.Live
 
   asyncTest "recv_service recovers a missed message through a known Store peer":
     # Phase 1: the startup catch-up dials the known Store peer.
@@ -632,6 +641,7 @@ suite "Messaging API, Receive Service (store recovery)":
       check eventManager.receivedMessages.len == 1
       if eventManager.receivedMessages.len > 0:
         check eventManager.receivedMessages[0].payload == net.missedPayload
+        check eventManager.receivedSources[0] == MessageSource.History
 
     # Phase 2: a Store peer learned after the subscription, by connecting to
     # it, is asked as soon as the connection is reported.
@@ -683,6 +693,9 @@ suite "Messaging API, Receive Service (store recovery)":
       check await eventManager.waitForEvents(TestTimeout)
       check eventManager.receivedMessages.len == 2 and
         eventManager.receivedMessages[^1].payload == gapMsg.payload
+      # The setup message and the gap message were both recovered from Store.
+      check eventManager.receivedSources ==
+        @[MessageSource.History, MessageSource.History]
 
   asyncTest "a topic subscribed while the catch-up settles is caught up to its own time":
     ## The app restores its subscriptions one call at a time. After the first

--- a/tests/api/test_api_subscription.nim
+++ b/tests/api/test_api_subscription.nim
@@ -1,11 +1,13 @@
 {.used.}
 
 import results, std/[strutils, sequtils, net, sets, tables]
-import chronos, testutils/unittests, stew/byteutils
+import chronos, metrics, testutils/unittests, stew/byteutils
 import libp2p/[peerid, peerinfo, multiaddress, crypto/crypto]
 import brokers/broker_context
 import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 import logos_delivery/messaging/messaging_client
+import logos_delivery/messaging/messaging_metrics
+import logos_delivery/messaging/delivery_service/recv_service
 
 import
   logos_delivery,
@@ -219,14 +221,19 @@ suite "Messaging API, SubscriptionManager":
     defer:
       await eventManager.teardown()
 
-    discard (await net.publishToMesh(testTopic, "Hello, world!".toBytes())).expect(
-      "Publish failed"
-    )
+    let live = $MessageSource.Live
+    let countBefore = logos_delivery_recv_messages_total.value([live])
+    let bytesBefore = logos_delivery_recv_message_bytes_total.value([live])
+    let payload = "Hello, world!".toBytes()
+    discard (await net.publishToMesh(testTopic, payload)).expect("Publish failed")
 
     require await eventManager.waitForEvents(TestTimeout)
     require eventManager.receivedMessages.len == 1
     check eventManager.receivedMessages[0].contentTopic == testTopic
     check eventManager.receivedSources[0] == MessageSource.Live
+    check logos_delivery_recv_messages_total.value([live]) == countBefore + 1
+    check logos_delivery_recv_message_bytes_total.value([live]) ==
+      bytesBefore + float64(payload.len)
 
   asyncTest "Subscription API, relay node ignores unsubscribed content topics on same shard":
     let net = await setupNetwork(1)

--- a/tests/api/test_api_subscription.nim
+++ b/tests/api/test_api_subscription.nim
@@ -7,7 +7,6 @@ import brokers/broker_context
 import ../testlib/[common, wakucore, wakunode, wakunodeconf, testasync]
 import logos_delivery/messaging/messaging_client
 import logos_delivery/messaging/messaging_metrics
-import logos_delivery/messaging/delivery_service/recv_service
 
 import
   logos_delivery,

--- a/tests/api/test_api_subscription.nim
+++ b/tests/api/test_api_subscription.nim
@@ -29,6 +29,7 @@ type ReceiveEventListenerManager = ref object
   receivedListener: MessageReceivedEventListener
   receivedEvent: AsyncEvent
   receivedMessages: seq[WakuMessage]
+  receivedSources: seq[MessageSource] ## one per `receivedMessages` entry
   targetCount: int
 
 proc newReceiveEventListenerManager(
@@ -44,6 +45,7 @@ proc newReceiveEventListenerManager(
       brokerCtx,
       proc(event: MessageReceivedEvent) {.async: (raises: []).} =
         manager.receivedMessages.add(event.message)
+        manager.receivedSources.add(event.source)
 
         if manager.receivedMessages.len >= manager.targetCount:
           manager.receivedEvent.fire()
@@ -224,6 +226,7 @@ suite "Messaging API, SubscriptionManager":
     require await eventManager.waitForEvents(TestTimeout)
     require eventManager.receivedMessages.len == 1
     check eventManager.receivedMessages[0].contentTopic == testTopic
+    check eventManager.receivedSources[0] == MessageSource.Live
 
   asyncTest "Subscription API, relay node ignores unsubscribed content topics on same shard":
     let net = await setupNetwork(1)
@@ -481,6 +484,7 @@ suite "Messaging API, SubscriptionManager":
     require await eventManager.waitForEvents(TestTimeout)
     require eventManager.receivedMessages.len == 1
     check eventManager.receivedMessages[0].contentTopic == testTopic
+    check eventManager.receivedSources[0] == MessageSource.Live
 
   asyncTest "Subscription API, edge node ignores unsubscribed content topics":
     let net = await setupNetwork(1, messaging_conf.LogosDeliveryMode.Edge)

--- a/tests/api/test_messaging_rest.nim
+++ b/tests/api/test_messaging_rest.nim
@@ -135,13 +135,16 @@ suite "Messaging REST API":
     let client = restClientFor(node)
     let brokerCtx = node.waku.brokerCtx
 
-    # Emit more than the cache capacity (50); oldest must be dropped.
+    # Emit more than the cache capacity (50); oldest must be dropped. Odd
+    # messages come from Store, so the source travels with each record.
     const total = 55
     for i in 0 ..< total:
       let wm =
         fakeWakuMessage(payload = "msg-" & $i, contentTopic = "/test/1/recv/proto")
+      let source = if i mod 2 == 0: MessageSource.Live else: MessageSource.History
       MessageReceivedEvent.emit(
-        brokerCtx, MessageReceivedEvent(messageHash: "0x" & $i, message: wm)
+        brokerCtx,
+        MessageReceivedEvent(messageHash: "0x" & $i, message: wm, source: source),
       )
     await sleepAsync(settleDelay)
 
@@ -151,7 +154,9 @@ suite "Messaging REST API":
       resp.data.len == 50 # capped at DefaultMaxReceived
       # oldest (0..4) evicted, newest retained, oldest-first ordering
       resp.data[0].messageHash == "0x5"
+      resp.data[0].source == MessageSource.History
       resp.data[^1].messageHash == "0x" & $(total - 1)
+      resp.data[^1].source == MessageSource.Live
 
     let emptyResp = await client.messagingGetReceivedMessagesV1()
     check:


### PR DESCRIPTION
## Description

`MessageReceivedEvent` now says where a message came from. The new `source` field is `live` for a message that arrived from the network and `history` for a message that the receive service got from Store. An application can show a live message at once and merge history into its timeline.

`recv_service.nim` sets the source in `processIncomingMessage`. The `MessageSeenEvent` listener, the relay and filter path, gives `live`. The reconnection check `checkStore` from #3941 and the startup catch-up from #4227 give `history`. A message is reported once, with the source of its first delivery. The duplicate filter is `recentReceivedMsgs`, in memory, for `MaxMessageLife` (7 min).

The field is on both API surfaces. The records of `GET /messaging/v1/events/received` carry `source`, and the reader requires it. The FFI `message_received` JSON carries `"source"` with no change in `node_api.nim`, because std/json writes an enum as its string value. `library/MESSAGE_EVENTS.md` now describes `message_received`, with the duplicate rule.

The C example decodes the payload again. #4170 changed the FFI byte fields to base64, and the example kept the JSON byte array format. `decode_json_base64_field` replaces `decode_json_byte_array` and validates the padding.

## Changes

* add `MessageSource` with `live` and `history`
* add `source` to `MessageReceivedEvent`
* tag a message from the `MessageSeenEvent` listener as `live`
* tag a message from `checkStore` and the startup catch-up as `history`
* add `source` to REST (`GET /messaging/v1/events/received`)
* describe `message_received` in `library/MESSAGE_EVENTS.md`
* fix the payload decode of the C example (base64 since #4170)
* add tests

## Issue

closes logos-messaging/pm#471
