### PR TITLE
fix(rest): skip the value of an unknown field in the custom readers

### DIFF
--- a/logos_delivery/waku/rest_api/endpoint/serdes.nim
+++ b/logos_delivery/waku/rest_api/endpoint/serdes.nim
@@ -20,12 +20,21 @@ createJsonFlavor RestJson
 
 Json.setWriter JsonWriter, PreferredOutput = string
 
-template unrecognizedFieldWarning*(field: typed) =
+template unrecognizedFieldLog*(field: typed) =
   # TODO: There should be a different notification mechanism for informing the
   #       caller of a deserialization routine for unexpected fields.
   #       The chonicles import in this module should be removed.
   warn "JSON field not recognized by the current version of nwaku. Consider upgrading",
     fieldName, typeName = typetraits.name(typeof field)
+
+template unrecognizedFieldWarning*(field: typed) {.dirty.} =
+  ## For the `else` branch of a `readObjectFields(reader)` loop. Logs the
+  ## field and consumes its value, or the next loop step fails on it and a
+  ## field added by a newer node breaks an older client instead of being
+  ## ignored. Dirty so that `reader` is the caller's JsonReader: a hygienic
+  ## template binds it to json_serialization's `reader` module.
+  unrecognizedFieldLog(field)
+  reader.skipSingleJsValue()
 
 type SerdesResult*[T] = Result[T, cstring]
 

--- a/tests/wakunode_rest/test_rest_debug_serdes.nim
+++ b/tests/wakunode_rest/test_rest_debug_serdes.nim
@@ -21,6 +21,21 @@ suite "Waku v2 REST API - Debug -  serialization":
         value.listenAddresses == @["123"]
         value.enrUri.isNone()
 
+    test "unknown field is skipped":
+      # A newer node can add a field. An older client logs it and decodes the
+      # rest, instead of failing on the value it did not read.
+      let jsonBytes = toBytes(
+        """{ "listenAddresses":["123"], "added":[1,{"nested":2}], "enrUri":"enr:-x" }"""
+      )
+
+      let res = decodeFromJsonBytes(DebugWakuInfo, jsonBytes, requireAllFields = true)
+
+      require(res.isOk())
+      let value = res.get()
+      check:
+        value.listenAddresses == @["123"]
+        value.enrUri == Opt.some("enr:-x")
+
   suite "DebugWakuInfo - encode":
     test "optional field is none":
       # Given


### PR DESCRIPTION
## Description

Each custom REST reader loops over `readObjectFields(reader)` and calls `unrecognizedFieldWarning(value)` for a field it does not know. The template writes a warning and returns. It does not read the value of the field. The next loop step finds that value where it expects a comma or a closing brace, and the decode fails with `',' expected`.

A field that a newer node adds to a response breaks an older client. #4247 adds `source` to `ReceivedMessageRecord`. A client built before it fails on `GET /messaging/v1/events/received`. The `allowUnknownFields = true` flag in `decodeFromJsonString` does not apply here. It controls the generated readers only, not a custom `readValue`.

The template now calls `reader.skipSingleJsValue()` after the warning. It is `{.dirty.}` so that `reader` is the parameter of the caller and not the `reader` module of json_serialization.

Verified `test_rest_debug_serdes.nim`: 3 tests passed, including an unknown nested field followed by a recognized field.

Stacked on #4247.

## Changes

* skip the value of an unknown field in `unrecognizedFieldWarning`
* split the warning into `unrecognizedFieldLog`
* add "unknown field is skipped" to `tests/wakunode_rest/test_rest_debug_serdes.nim`

## Issue

Maintenance Y2026H2 #4043
