### PR TITLE
chore: bump nim-libp2p to 2.4.0

### DIFF
--- a/logos_delivery.nimble
+++ b/logos_delivery.nimble
@@ -32,7 +32,7 @@ requires "nim == 2.2.6",
   "toml_serialization",
   "faststreams",
   # Networking & P2P
-  "libp2p == 2.3.1",
+  # libp2p is a URL requirement below: 2.4.0 has no release tag yet.
   # 0.9.0 is the locked version; an unversioned "eth" resolves to nim-eth HEAD,
   # which no longer ships eth/p2p/discoveryv5/enr.
   "eth == 0.9.0",
@@ -41,7 +41,9 @@ requires "nim == 2.2.6",
   "dnsdisc",
   "dnsclient",
   "httputils >= 0.4.1",
-  "https://github.com/status-im/nim-websock#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d",
+  # v0.4.1: libp2p 2.4.0 requires websock >= 0.4.1. v0.4.2 requires
+  # chronos >= 4.4.0 (chronos is pinned < 4.4.0), so 0.4.1 exactly.
+  "https://github.com/status-im/nim-websock#0432dc445c500b20963ef4b76e585c1a3943c254",
   # Cryptography
   "nimcrypto == 0.6.4", # 0.6.4 used in libp2p. Version 0.7.3 makes test to crash on Ubuntu.
   "https://github.com/status-im/nim-secp256k1#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",
@@ -69,6 +71,11 @@ requires "nim == 2.2.6",
 # URL requirements described above.
 # For commit-pinned releases, the preceding link records the associated
 # upstream release tag at the time the revision was selected.
+
+# v2.4.0: head of https://github.com/vacp2p/nim-libp2p/tree/release/v2.4
+# ("chore: bump version to 2.4.0"). No v2.4.0 tag exists at pinning time;
+# once it does, this can become `"libp2p == 2.4.0"` in the list above.
+requires "https://github.com/vacp2p/nim-libp2p#73c3637bb7ebb6f749d74b676e9a0e461b9f30d5"
 
 # v0.3.1-rc.0: https://github.com/logos-messaging/nim-ffi/releases/tag/v0.3.1-rc.0
 requires "https://github.com/logos-messaging/nim-ffi#07ee8e1d6500762bab290465457a8d23559de546"

--- a/logos_delivery/waku/discovery/waku_kademlia.nim
+++ b/logos_delivery/waku/discovery/waku_kademlia.nim
@@ -7,20 +7,23 @@ import
   results,
   stew/byteutils,
   libp2p/[peerid, multiaddress, switch, extended_peer_record],
-  libp2p/extended_peer_record,
   libp2p/crypto/crypto,
   libp2p/crypto/rng,
   libp2p/crypto/curve25519,
   libp2p/protocols/service_discovery,
   libp2p/protocols/service_discovery/types,
   libp2p/protocols/kademlia/types,
-  libp2p_mix/mix_protocol,
-  libp2p_mix/curve25519
+  libp2p/protocols/kademlia/key_value,
+  libp2p_mix/mix_protocol
 
 import
   logos_delivery/waku/waku_core,
   logos_delivery/waku/node/peer_manager,
   logos_delivery/waku/api/events/discovery_events
+
+# `WakuKademlia.new` is generic, so `ServiceDiscovery.new` instantiates in the
+# caller, which needs `hash`/`==` of the distinct kademlia `Key` in scope.
+export key_value.hash, key_value.`==`
 
 logScope:
   topics = "waku service discovery"
@@ -38,6 +41,13 @@ type WakuKademlia* = ref object
   serviceLookupInterval: Duration
   servicesToDiscover: HashSet[string]
   servicesToAdvertise: HashSet[ServiceInfo]
+    ## Configured services. `start` advertises them, `stop` stops advertising them.
+
+# Upstream ServiceDiscovery has one set for configured and advertised services:
+# its start asserts when a first advertisement fails, and its stop keeps the
+# advertised status. So the protocol gets no services at construction, `start`
+# advertises the configured set, and `stop` stops advertising it. Remove when
+# upstream fixes both.
 
 type KademliaDiscoveryConf* = object
   bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
@@ -210,13 +220,14 @@ proc new*(
   if bootstrapNodes.len == 0:
     debug "Creating service discovery as seed node (no bootstrap nodes)"
 
+  ## `start` advertises the configured set, see above.
   let protocol = ServiceDiscovery.new(
     switch,
     bootstrapNodes = bootstrapNodes,
     config = kadDhtConfig,
     rng = rng,
     client = clientMode,
-    services = servicesToAdvertise.toSeq(),
+    services = @[],
     discoConfig = discoConfig,
     xprPublishing = xprPublishing,
   )
@@ -232,9 +243,27 @@ proc new*(
 
   return ok(self)
 
+proc advertiseConfiguredServices(self: WakuKademlia) =
+  ## Advertises the configured services not advertised yet. Failures stay configured.
+  var added = false
+  for service in self.servicesToAdvertise:
+    if service in self.protocol.services:
+      continue
+    self.protocol.startAdvertising(service).isOkOr:
+      warn "Failed to advertise configured service", service = service.id, error = error
+      continue
+    added = true
+
+  ## Republish the self record: it listed no services at protocol start.
+  if added:
+    self.protocol.addressChanged.fire()
+
 proc start*(self: WakuKademlia) {.async: (raises: []).} =
   for serviceId in self.servicesToDiscover:
     discard self.protocol.registerInterest(serviceId)
+
+  ## Runs after switch.start, so the record has the announced addresses.
+  self.advertiseConfiguredServices()
 
   if self.randomLookupLoop.isNil():
     self.randomLookupLoop = self.runRandomLookupLoop()
@@ -252,6 +281,11 @@ proc stop*(self: WakuKademlia) {.async: (raises: []).} =
   if not self.randomLookupLoop.isNil():
     await self.randomLookupLoop.cancelAndWait()
     self.randomLookupLoop = nil
+
+  ## Stopped services stay marked as provided upstream and a restart rejects
+  ## them, so stop advertising them here. noCancel: a cancelled stop must finish.
+  for service in self.servicesToAdvertise.toSeq():
+    await noCancel self.protocol.stopAdvertising(service.id)
 
   info "Kademlia discovery stopped"
 

--- a/logos_delivery/waku/factory/node_factory.nim
+++ b/logos_delivery/waku/factory/node_factory.nim
@@ -105,12 +105,18 @@ proc initNode(
     agentString = Opt.some(conf.agentString),
   )
   builder.withColocationLimit(conf.colocationLimit)
-  builder.withNatConfig(
-    natConfig(
-      conf.endpointConf.natStrategy,
-      conf.endpointConf.natDiscoveryTimeoutMs.int64.milliseconds,
-    )
+  let natConf = natConfig(
+    conf.endpointConf.natStrategy,
+    conf.endpointConf.natDiscoveryTimeoutMs.int64.milliseconds,
   )
+  if conf.endpointConf.extMultiAddrsOnly:
+    ## libp2p announces this list as is. Port mapping would target listed
+    ## ports that need not be bound, so leave it off.
+    if natConf.isSome():
+      info "Automatic NAT port mapping stays off under ext-multiaddr-only",
+        natStrategy = $conf.endpointConf.natStrategy
+  else:
+    builder.withNatConfig(natConf)
 
   if conf.maxRelayPeers.isSome():
     let

--- a/logos_delivery/waku/net/net_config.nim
+++ b/logos_delivery/waku/net/net_config.nim
@@ -1,6 +1,6 @@
 {.push raises: [].}
 
-import std/[sequtils, strutils, net], results, stew/endians2, chronicles
+import std/[sequtils, net], results, stew/endians2
 import libp2p/[multiaddress, multicodec, wire]
 import ../../waku/waku_core/peers
 import ../waku_enr
@@ -60,18 +60,30 @@ template ipQuicEndPoint(address: IpAddress, port: Port): MultiAddress =
 template dns4QuicEndPoint(dns4DomainName: string, port: Port): MultiAddress =
   dns4Ma(dns4DomainName) & udpPortMa(port) & quicFlag()
 
-func hasZeroPort*(ma: MultiAddress): bool =
-  ## Port 0 means "the kernel picks a port at bind time".
-  ## initTAddress cannot parse dns-hosted entries, so read the port
-  ## bytes from the tcp or udp component directly.
+func transportPort*(ma: MultiAddress): Opt[Port] =
+  ## Port of the tcp or udp component, read from its bytes (works for dns hosts).
   for code in [multiCodec("tcp"), multiCodec("udp")]:
     let part = ma[code].valueOr:
       continue
     let portBytes = part.protoArgument().valueOr:
       continue
-    if portBytes.len == 2 and uint16.fromBytesBE(portBytes) == 0:
-      return true
-  return false
+    if portBytes.len == 2:
+      return Opt.some(Port(uint16.fromBytesBE(portBytes)))
+  Opt.none(Port)
+
+func hasZeroPort*(ma: MultiAddress): bool =
+  ## Port 0 means "the kernel picks a port at bind time".
+  let port = ma.transportPort().valueOr:
+    return false
+  port == Port(0)
+
+const WildcardHosts = [parseIpAddress("0.0.0.0"), parseIpAddress("::")]
+
+func isWildcardHost*(ma: MultiAddress): bool =
+  ## True for a 0.0.0.0 or :: host.
+  let ip = ma.getIp().valueOr:
+    return false
+  ip in WildcardHosts
 
 proc isWsAddress*(ma: MultiAddress): bool =
   let
@@ -130,38 +142,48 @@ func replacePort*(ma: MultiAddress, port: Port): Opt[MultiAddress] =
         return Opt.none(MultiAddress)
   return Opt.some(res)
 
-proc substituteBoundPorts*(
-    addrs: seq[MultiAddress], listenAddrs: seq[MultiAddress]
+func sameTransport(a, b: MultiAddress): bool =
+  ## Same transport: ws/wss, quic, or plain tcp.
+  a.isWsAddress() == b.isWsAddress() and a.isQuicAddress() == b.isQuicAddress()
+
+func resolveAnnouncedAddresses*(
+    intent: seq[MultiAddress], listenAddrs: seq[MultiAddress]
 ): seq[MultiAddress] =
-  ## Replace port 0 with the port the entry's transport bound.
-  ## Drop a port-0 entry whose transport did not bind.
-  ## Entries with concrete ports pass through unchanged.
-  if not addrs.anyIt(it.hasZeroPort()):
-    return addrs
-
-  let bound = getPorts(listenAddrs).valueOr:
-    ## If getPorts fails, drop the zero-port entries.
-    error "failed to read bound ports; dropping zero-port entries", error = error
-    return addrs.filterIt(not it.hasZeroPort())
-
+  ## Resolves `intent` against the bound `listenAddrs`. A wildcard host and port 0
+  ## take the bound address of the same transport, e.g. /ip4/0.0.0.0/tcp/0 with
+  ## bound /ip4/10.0.0.5/tcp/60001 gives /ip4/10.0.0.5/tcp/60001. Unresolved
+  ## entries are dropped, concrete entries pass through.
   var resolved: seq[MultiAddress]
-  for ma in addrs:
-    if not ma.hasZeroPort():
-      resolved.add(ma)
+  for entry in intent:
+    let
+      wildcardHost = entry.isWildcardHost()
+      zeroPort = entry.hasZeroPort()
+    if not wildcardHost and not zeroPort:
+      if entry notin resolved:
+        resolved.add(entry)
       continue
-    let port = (
-      if ma.isWsAddress():
-        bound.websocketPort
-      elif ma.isQuicAddress():
-        bound.quicPort
-      else:
-        bound.tcpPort
-    ).valueOr:
-      continue
-    let substituted = ma.replacePort(port).valueOr:
-      continue
-    resolved.add(substituted)
-  return resolved
+    for bound in listenAddrs:
+      if not bound.sameTransport(entry):
+        continue
+      var concrete = entry
+      if wildcardHost:
+        let host = bound.getIp().valueOr:
+          continue
+        concrete = concrete.replaceIp(host).valueOr:
+          continue
+      if zeroPort:
+        let port = bound.transportPort().valueOr:
+          continue
+        concrete = concrete.replacePort(port).valueOr:
+          continue
+      if concrete.isWildcardHost() or concrete.hasZeroPort():
+        continue
+      if concrete notin resolved:
+        resolved.add(concrete)
+      if not wildcardHost:
+        ## One bound port per concrete host.
+        break
+  resolved
 
 proc containsWsAddress(extMultiAddrs: seq[MultiAddress]): bool =
   return extMultiAddrs.filterIt(it.isWsAddress()).len > 0
@@ -194,8 +216,7 @@ proc init*(
   ## Initialize and validate waku node network configuration
 
   if extMultiAddrsOnly:
-    ## libp2p applies `announcedAddrs` only when non-empty, and the override
-    ## skips port resolution. So require concrete addresses here.
+    ## libp2p announces this list as is, so it needs concrete ports.
     if extMultiAddrs.len == 0:
       return err("extMultiAddrsOnly requires at least one ext multiaddr")
     for ma in extMultiAddrs:

--- a/logos_delivery/waku/node/waku_node.nim
+++ b/logos_delivery/waku/node/waku_node.nim
@@ -1,7 +1,7 @@
 {.push raises: [].}
 
 import
-  std/[tables, strutils, sequtils, os, net, random, sets],
+  std/[tables, sequtils, os, net, random, sets],
   chronos,
   chronicles,
   metrics,
@@ -13,12 +13,11 @@ import
   eth/p2p/discoveryv5/enr,
   libp2p/crypto/crypto,
   libp2p/crypto/curve25519,
-  libp2p/[multiaddress, multicodec, peerinfo, wire],
+  libp2p/[multiaddress, multicodec, peerinfo, wire, address_manager],
   libp2p/protocols/ping,
   libp2p/protocols/pubsub/gossipsub,
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/builders,
-  libp2p/transports/transport,
   libp2p/transports/tcptransport,
   libp2p/transports/wstransport,
   libp2p/utils/offsettedseq,
@@ -126,19 +125,14 @@ type
     wakuRendezvous*: WakuRendezVous
     wakuRendezvousClient*: rendezvous_client.WakuRendezVousClient
     announcedAddresses*: seq[MultiAddress]
-      ## Copy of the committed peerInfo addresses once start resolves them.
+      ## Copy of peerInfo.addrs. Holds the configured addresses until the first start.
     configuredAnnounced: seq[MultiAddress]
-      ## Operator-configured addresses, set at construction.
-      ## Every recomputation of the announced addresses starts from this field.
-    baseAnnounced: Opt[seq[MultiAddress]]
-      ## The configured addresses made concrete at start: bound ports
-      ## substituted, wildcard hosts rewritten to the primary IP.
-      ## The first mapper in the chain answers with this set.
+      ## Operator-configured addresses. Input of the base mapper.
+    baseMapper: AddressMapper
+      ## First mapper in the AddressManager. NAT and relay mappers run after it.
     onCommittedAddresses*: proc() {.gcsafe, raises: [].}
       ## Runs after every copy of the committed addresses.
       ## waku.nim uses it to refresh the ENR.
-    extMultiAddrsOnly: bool
-      ## Announce only the configured addresses. Set at construction.
     started*: bool # Indicates that node has started listening
     topicSubscriptionQueue*: AsyncEventQueue[SubscriptionEvent]
     rateLimitSettings*: ProtocolRateLimitSettings
@@ -221,10 +215,7 @@ proc getWakuPeerRecordGetter(node: WakuNode): GetWakuPeerRecord =
     )
 
 proc copyCommittedAddresses*(node: WakuNode) =
-  ## Copy the committed peerInfo addresses into announcedAddresses
-  ## and run the ENR refresh callback, once start has resolved the addresses.
-  if node.baseAnnounced.isNone():
-    return
+  ## Copy peerInfo.addrs into announcedAddresses and run the ENR refresh callback.
   node.announcedAddresses = node.switch.peerInfo.addrs
   if not node.onCommittedAddresses.isNil():
     node.onCommittedAddresses()
@@ -254,26 +245,21 @@ proc new*(
     enr: enr,
     announcedAddresses: netConfig.announcedAddresses,
     configuredAnnounced: netConfig.announcedAddresses,
-    extMultiAddrsOnly: netConfig.extMultiAddrsOnly,
     topicSubscriptionQueue: queue,
     rateLimitSettings: rateLimitSettings,
     ports: BoundPorts.init(),
   )
 
-  if node.extMultiAddrsOnly:
-    ## Set before start. libp2p skips the mapper chain when this is non-empty.
-    ## NetConfig.init guarantees non-empty entries with concrete ports.
+  if netConfig.extMultiAddrsOnly:
+    ## libp2p announces this list as is. NetConfig.init guarantees concrete entries.
     switch.peerInfo.announcedAddrs = netConfig.announcedAddresses
 
-  ## The base mapper answers with the resolved addresses.
-  ## NAT and relay mappers run after it. Until then it drops zero-port entries.
-  let baseMapper = proc(
+  ## Resolves the configured addresses against the listen addresses libp2p
+  ## passes in. After the bind, this gives the announced addresses.
+  node.baseMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
-    let base = node.baseAnnounced.valueOr:
-      return listenAddrs.filterIt(not it.hasZeroPort())
-    return base
-  switch.peerInfo.addressMappers.add(baseMapper)
+    return resolveAnnouncedAddresses(node.configuredAnnounced, listenAddrs)
   switch.peerInfo.addObserver(
     proc(p: PeerInfo) {.gcsafe, raises: [].} =
       node.copyCommittedAddresses()
@@ -504,49 +490,6 @@ proc mountRendezvous*(
   except LPError:
     error "Failed to mount wakuRendezvous", error = getCurrentExceptionMsg()
 
-proc resolveAnnouncedBaseAddresses(node: WakuNode) =
-  ## Runs once per start, after the sockets bind.
-  ## Here the configured addresses become real: port 0 becomes
-  ## the bound port, and a wildcard host becomes the primary IP.
-  ## Everything the node announces builds on this set.
-  if node.extMultiAddrsOnly:
-    ## announcedAddrs bypasses the mappers. The configured set is final.
-    node.baseAnnounced = Opt.some(node.configuredAnnounced)
-    node.announcedAddresses = node.configuredAnnounced
-    return
-
-  let substituted =
-    substituteBoundPorts(node.configuredAnnounced, node.switch.peerInfo.listenAddrs)
-
-  const LoopbackIp = parseIpAddress("127.0.0.1")
-  const RewrittenHosts =
-    [static(parseIpAddress("0.0.0.0")), static(parseIpAddress("::"))]
-  var primaryIp = LoopbackIp
-  try:
-    primaryIp = getPrimaryIPAddr()
-  except Exception as e:
-    ## getPrimaryIPAddr declares a bare Exception effect on Windows, so
-    ## a narrower catch fails the raises check there.
-    debug "Could not retrieve the primary IP address", msg = e.msg
-
-  var resolved = newSeq[MultiAddress](0)
-  for address in substituted:
-    let ip = address.getIp().valueOr:
-      resolved.add(address)
-      continue
-    if ip notin RewrittenHosts:
-      resolved.add(address)
-      continue
-    let rewritten = address.replaceIp(primaryIp).valueOr:
-      resolved.add(address)
-      continue
-    resolved.add(rewritten)
-
-  let base = resolved.filterIt(not it.hasZeroPort())
-  node.baseAnnounced = Opt.some(base)
-  node.announcedAddresses = base
-  info "Announced base resolved", addrs = $base
-
 proc startProvidersAndListeners*(node: WakuNode) =
   RequestRelayShard.setProvider(
     node.brokerCtx,
@@ -636,14 +579,17 @@ proc start*(node: WakuNode) {.async.} =
   if not node.wakuRendezvousClient.isNil():
     await node.wakuRendezvousClient.start()
 
+  ## The AddressManager drops its mappers on stop. Add ours before the services do.
+  node.switch.addressManager.removeMapper(node.baseMapper)
+  node.switch.addressManager.addMapper(node.baseMapper, AddrSource.Listen)
+
+  ## Binds the transports, resolves peerInfo.addrs, then starts the protocols.
   ## NOTE: This will dispatch gossipsub start to the WakuRelay.start method override
   await node.switch.start()
 
-  ## The sockets are bound now. Resolve the announced addresses, commit
-  ## them, and copy once. The observer fires only on a changed commit.
-  resolveAnnouncedBaseAddresses(node)
-  await node.switch.peerInfo.update()
+  ## Copy again: the observer skips an unchanged restart.
   node.copyCommittedAddresses()
+  info "Announced addresses resolved", addrs = $node.announcedAddresses
 
   # Reconnect to known relay peers in the background; it waits a prune backoff
   # and must not block startup.
@@ -706,7 +652,6 @@ proc stop*(node: WakuNode) {.async.} =
     await node.wakuRendezvousClient.stopWait()
 
   node.started = false
-  node.baseAnnounced = Opt.none(seq[MultiAddress])
 
 proc isReady*(node: WakuNode): Future[bool] {.async: (raises: [Exception]).} =
   if node.rln == nil:

--- a/logos_delivery/waku/node/waku_switch.nim
+++ b/logos_delivery/waku/node/waku_switch.nim
@@ -2,8 +2,10 @@
 {.push raises: [].}
 
 import
+  std/net,
   results,
   chronos,
+  chronos/transports/osnet,
   chronicles,
   eth/keys,
   libp2p/crypto/crypto,
@@ -21,6 +23,41 @@ import ./delivery_dialer
 const MaxConnectionsPerPeer* = 1
 
 const MaxConnections* = 50
+
+logScope:
+  topics = "waku switch"
+
+const
+  ## The destinations a route lookup probes. No traffic is sent.
+  Ipv4Probe = parseIpAddress("8.8.8.8")
+  Ipv6Probe = parseIpAddress("2001:4860:4860::8888")
+  Ipv4Loopback = parseIpAddress("127.0.0.1")
+
+proc primaryInterfaceProvider*(
+    addrFamily: AddressFamily
+): seq[InterfaceAddress] {.gcsafe, raises: [].} =
+  ## One address per IP family for a wildcard bind: the default-route
+  ## interface. IPv4 falls back to loopback, IPv6 to nothing.
+  let probe =
+    case addrFamily
+    of AddressFamily.IPv4:
+      Ipv4Probe
+    of AddressFamily.IPv6:
+      Ipv6Probe
+    else:
+      return @[]
+  let ip =
+    try:
+      getPrimaryIPAddr(probe)
+    except Exception as e:
+      ## getPrimaryIPAddr has a bare Exception effect on Windows.
+      debug "Could not retrieve the primary IP address",
+        family = addrFamily, error = e.msg
+      if addrFamily == AddressFamily.IPv6:
+        return @[]
+      Ipv4Loopback
+  let prefix = if ip.family == IpAddressFamily.IPv4: 32 else: 128
+  @[InterfaceAddress.init(initTAddress(ip, Port(0)), prefix)]
 
 proc withWsTransport*(b: SwitchBuilder): SwitchBuilder =
   b.withTransport(
@@ -142,9 +179,8 @@ proc newWakuSwitch*(
     b = b.withRendezVous()
 
   let switch = b.build()
-  # The upstream wildcard service stays off. Its start mutates the
-  # mapper seq mid-walk. Even fixed it stays off: it expands a wildcard
-  # to every interface, and this node announces one primary-IP address.
-  # The base mapper resolves wildcards instead.
+  # The upstream wildcard service would announce every interface. This node
+  # announces one primary address per family through the provider instead.
+  switch.addressManager.networkInterfaceProvider = primaryInterfaceProvider
   DeliveryDialer.install(switch)
   switch

--- a/nimble.lock
+++ b/nimble.lock
@@ -214,7 +214,7 @@
       }
     },
     "libplum": {
-      "version": "#v0.6.3",
+      "version": "0.6.3",
       "vcsRevision": "189a4984d15f0c60780d6ea5a2ab46bbf6a350f8",
       "url": "https://github.com/logos-storage/nim-libplum",
       "downloadMethod": "git",
@@ -259,7 +259,7 @@
     },
     "snappy": {
       "version": "0.1.0",
-      "vcsRevision": "da2f0c7b6ce9053106e9bb098204fe5319038387",
+      "vcsRevision": "a99d113197e81bf764a3b005b0ade3f9f3758069",
       "url": "https://github.com/status-im/nim-snappy",
       "downloadMethod": "git",
       "dependencies": [
@@ -271,7 +271,7 @@
         "testutils"
       ],
       "checksums": {
-        "sha1": "d02c6657cc4df57c03ec8b84d0dd74007f6ebd07"
+        "sha1": "72fb32f879c2d0f4296e18e946d15daae993e32b"
       }
     },
     "serialization": {
@@ -432,6 +432,20 @@
         "sha1": "9b292b0d627e6f6132a01e00f14e0f0527c6704a"
       }
     },
+    "leopard": {
+      "version": "#0478b12df90cbbe531efa69422cff67b5a3a5d93",
+      "vcsRevision": "0478b12df90cbbe531efa69422cff67b5a3a5d93",
+      "url": "https://github.com/status-im/nim-leopard",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "unittest2",
+        "results"
+      ],
+      "checksums": {
+        "sha1": "9352901ef26dfdc51dfc76c500be05a3c89abb1b"
+      }
+    },
     "taskpools": {
       "version": "0.2.1",
       "vcsRevision": "7d96007793fdb2d244d392eb7c5cfa4a695d4ecc",
@@ -543,8 +557,8 @@
       }
     },
     "websock": {
-      "version": "#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d",
-      "vcsRevision": "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d",
+      "version": "#0432dc445c500b20963ef4b76e585c1a3943c254",
+      "vcsRevision": "0432dc445c500b20963ef4b76e585c1a3943c254",
       "url": "https://github.com/status-im/nim-websock",
       "downloadMethod": "git",
       "dependencies": [
@@ -559,7 +573,7 @@
         "zlib"
       ],
       "checksums": {
-        "sha1": "fd17a854686d9a19af40aba51f05d06b82fc30ec"
+        "sha1": "7c240c080f618855411bb0ee3984f6062123bcd4"
       }
     },
     "json_rpc": {
@@ -584,6 +598,23 @@
         "sha1": "596db0aafcb3c83f5dba6d42993f2276e0d00eb5"
       }
     },
+    "segmentation": {
+      "version": "#0593ef7c9267b0204093fe202bec477b2dbf824c",
+      "vcsRevision": "0593ef7c9267b0204093fe202bec477b2dbf824c",
+      "url": "https://github.com/logos-messaging/nim-segmentation",
+      "downloadMethod": "git",
+      "dependencies": [
+        "nim",
+        "results",
+        "nimcrypto",
+        "protobuf_serialization",
+        "unittest2",
+        "leopard"
+      ],
+      "checksums": {
+        "sha1": "44f5ffa727c58f581b356e8d1c6a3b167f32dee8"
+      }
+    },
     "secp256k1": {
       "version": "#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",
       "vcsRevision": "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15",
@@ -600,8 +631,8 @@
       }
     },
     "libp2p": {
-      "version": "2.3.1",
-      "vcsRevision": "391e403cc274ab8623fb1106f2c2827e09c6c89f",
+      "version": "#73c3637bb7ebb6f749d74b676e9a0e461b9f30d5",
+      "vcsRevision": "73c3637bb7ebb6f749d74b676e9a0e461b9f30d5",
       "url": "https://github.com/vacp2p/nim-libp2p",
       "downloadMethod": "git",
       "dependencies": [
@@ -623,38 +654,7 @@
         "libplum"
       ],
       "checksums": {
-        "sha1": "62b44f7fdcdb170f83cc8e03e6da2f675b4deaf7"
-      }
-    },
-    "leopard": {
-      "version": "#0478b12df90cbbe531efa69422cff67b5a3a5d93",
-      "vcsRevision": "0478b12df90cbbe531efa69422cff67b5a3a5d93",
-      "url": "https://github.com/status-im/nim-leopard",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "unittest2",
-        "results"
-      ],
-      "checksums": {
-        "sha1": "9352901ef26dfdc51dfc76c500be05a3c89abb1b"
-      }
-    },
-    "segmentation": {
-      "version": "#0593ef7c9267b0204093fe202bec477b2dbf824c",
-      "vcsRevision": "0593ef7c9267b0204093fe202bec477b2dbf824c",
-      "url": "https://github.com/logos-messaging/nim-segmentation",
-      "downloadMethod": "git",
-      "dependencies": [
-        "nim",
-        "results",
-        "nimcrypto",
-        "protobuf_serialization",
-        "unittest2",
-        "leopard"
-      ],
-      "checksums": {
-        "sha1": "44f5ffa727c58f581b356e8d1c6a3b167f32dee8"
+        "sha1": "17d8e6d46acd72d119fa5a0188f48625b1918d40"
       }
     },
     "sds": {

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -138,8 +138,8 @@
 
   snappy = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-snappy";
-    rev = "da2f0c7b6ce9053106e9bb098204fe5319038387";
-    sha256 = "1jmjh1b70wkhzmyzvp46y50x3i1f0hkdrpy6msvqix60xwkxf1zy";
+    rev = "a99d113197e81bf764a3b005b0ade3f9f3758069";
+    sha256 = "0fbr352m01psi3f25c3gi95yimrjmvsh10wckywscn0603iqzpjl";
     fetchSubmodules = true;
   };
 
@@ -213,6 +213,13 @@
     fetchSubmodules = true;
   };
 
+  leopard = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-leopard";
+    rev = "0478b12df90cbbe531efa69422cff67b5a3a5d93";
+    sha256 = "1lfwsqrdc3nzdc3a2v4fmx2ilqxyipb8v3n08ffcf2zj5nrjgql4";
+    fetchSubmodules = true;
+  };
+
   taskpools = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-taskpools";
     rev = "7d96007793fdb2d244d392eb7c5cfa4a695d4ecc";
@@ -271,8 +278,8 @@
 
   websock = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-websock";
-    rev = "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d";
-    sha256 = "1v0m3x96fbp9jdzsys6mbxxc2xw3k3dqiv7wksfla89gc6z8w377";
+    rev = "0432dc445c500b20963ef4b76e585c1a3943c254";
+    sha256 = "17kdlywwrlnqx8chf8l1b5gsbix5mmgkpgcwrxgj58af029h4yhr";
     fetchSubmodules = true;
   };
 
@@ -280,6 +287,13 @@
     url = "https://github.com/status-im/nim-json-rpc";
     rev = "6f1fff8ba685c9192fab153a9d66484ad9066e78";
     sha256 = "1r4xlis5fxcmp1cdqskb25nzmxckfkl8lndshvl76kcqrb0hl88d";
+    fetchSubmodules = true;
+  };
+
+  segmentation = pkgs.fetchgit {
+    url = "https://github.com/logos-messaging/nim-segmentation";
+    rev = "0593ef7c9267b0204093fe202bec477b2dbf824c";
+    sha256 = "0liwh3v8af3achqlzrlsg7p9nphf7zgxw05hip1v24zd0klsl77g";
     fetchSubmodules = true;
   };
 
@@ -292,22 +306,8 @@
 
   libp2p = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-libp2p";
-    rev = "391e403cc274ab8623fb1106f2c2827e09c6c89f";
-    sha256 = "04hn4q73c598hh8hxs9y1s3zq6zhijb74776z23q4adlymy15x5q";
-    fetchSubmodules = true;
-  };
-
-  leopard = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-leopard";
-    rev = "0478b12df90cbbe531efa69422cff67b5a3a5d93";
-    sha256 = "1lfwsqrdc3nzdc3a2v4fmx2ilqxyipb8v3n08ffcf2zj5nrjgql4";
-    fetchSubmodules = true;
-  };
-
-  segmentation = pkgs.fetchgit {
-    url = "https://github.com/logos-messaging/nim-segmentation";
-    rev = "0593ef7c9267b0204093fe202bec477b2dbf824c";
-    sha256 = "0liwh3v8af3achqlzrlsg7p9nphf7zgxw05hip1v24zd0klsl77g";
+    rev = "73c3637bb7ebb6f749d74b676e9a0e461b9f30d5";
+    sha256 = "1ibf196jfwlhrbnxjl346z0ciwzf5a5x8gjwncq4s99yhfi1v2ml";
     fetchSubmodules = true;
   };
 

--- a/tests/all_tests_waku.nim
+++ b/tests/all_tests_waku.nim
@@ -65,7 +65,8 @@ import
   ./test_waku_rendezvous,
   ./test_waku_metadata,
   ./waku_discv5/test_waku_discv5,
-  ./waku_kademlia/test_waku_kademlia
+  ./waku_kademlia/test_waku_kademlia,
+  ./waku_kademlia/test_node_advertising
 
 # Waku Keystore test suite
 import ./test_waku_keystore_keyfile, ./test_waku_keystore

--- a/tests/app/test_app.nim
+++ b/tests/app/test_app.nim
@@ -88,6 +88,17 @@ suite "Node app - Waku initialization":
     check:
       services.filterIt(it of NATService).len == 1
 
+  test "ext-multiaddr-only leaves automatic NAT port mapping off":
+    ## libp2p runs the mappers even with an explicit list, so the factory configures none.
+    var conf = defaultTestWakuConf()
+    conf.endpointConf.extMultiAddrs =
+      @[MultiAddress.init("/ip4/203.0.113.44/tcp/60123").get()]
+    conf.endpointConf.extMultiAddrsOnly = true
+    conf.endpointConf.natStrategy = parseNatStrategy("upnp").expect("upnp")
+    let waku = (waitFor Waku.new(conf)).valueOr:
+      raiseAssert error
+    check waku.node.switch.services.filterIt(it of NATService).len == 0
+
   test "a post-start commit reaches the ENR through the production hook":
     ## Deleting the onCommittedAddresses callback fails this.
     ## So does setting it after the first refresh.

--- a/tests/test_announced_addresses.nim
+++ b/tests/test_announced_addresses.nim
@@ -1,15 +1,17 @@
 {.used.}
 
-## libp2p commits the final announced addresses into peerInfo after
-## the address mappers run. These tests check that node.announcedAddresses
-## and the ENR multiaddrs field copy that committed set.
+## libp2p resolves peerInfo.addrs inside switch.start, before the mounted
+## protocols start. These tests check that result and its copies (ENR, API).
 
 import results
 import std/[net, sequtils, strutils]
 import testutils/unittests, chronos
 import libp2p/[multiaddress, switch, wire]
 import libp2p/crypto/crypto as libp2pcrypto
+import libp2p/protocols/protocol
+import libp2p/stream/connection
 import libp2p/services/natservice
+import chronos/transports/osnet
 import libp2p/services/nat/portmapper
 import eth/p2p/discoveryv5/protocol as discv5_protocol
 import ../logos_delivery/waku/discovery/waku_discv5
@@ -30,11 +32,6 @@ type RecordingMapper = ref object of PortMapper
   grantPort: Port
   mappedInternal: seq[Port]
 
-method discover(
-    self: RecordingMapper, timeout: Duration
-): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  return ok(self.grantIp)
-
 method map(
     self: RecordingMapper, internalPort: Port, externalPort: Port, proto: MapProto
 ): Future[Result[MappedPort, string]] {.async: (raises: [CancelledError]), gcsafe.} =
@@ -49,19 +46,41 @@ method unmap(
 method close(self: RecordingMapper) {.async: (raises: []), gcsafe.} =
   discard
 
-type EagerUpdate = ref object of Service
-  ## Runs a peerInfo update while the switch starts, before the node
-  ## resolves its announced addresses. The base mapper must drop port-0
-  ## entries during that update, or the NATService maps port 0.
+type UpdateBeforeBind = ref object of Service
+  ## Calls peerInfo.update() before the transports bind, as libp2p's AutonatService
+  ## does in production. The base mapper must drop port-0 entries in that update.
 
-method setup(self: EagerUpdate, switch: Switch) {.raises: [ServiceSetupError].} =
+method setup(self: UpdateBeforeBind, switch: Switch) {.raises: [ServiceSetupError].} =
   discard
 
-method start(self: EagerUpdate, switch: Switch) {.async: (raises: [CancelledError]).} =
+method start(
+    self: UpdateBeforeBind, switch: Switch
+) {.async: (raises: [CancelledError]).} =
   await switch.peerInfo.update()
 
-method stop(self: EagerUpdate, switch: Switch) {.async: (raises: [CancelledError]).} =
+method stop(
+    self: UpdateBeforeBind, switch: Switch
+) {.async: (raises: [CancelledError]).} =
   discard
+
+const PrivateInterfaceIp = static(parseIpAddress("192.168.9.9"))
+
+proc privateInterfaceProvider(
+    addrFamily: AddressFamily
+): seq[InterfaceAddress] {.gcsafe, raises: [].} =
+  ## A deterministic stand-in for the primary interface: a private IPv4.
+  if addrFamily != AddressFamily.IPv4:
+    return @[]
+  @[InterfaceAddress.init(initTAddress(PrivateInterfaceIp, Port(0)), 24)]
+
+type AddressProbe = ref object of LPProtocol
+  ## Records peerInfo.addrs when the switch starts the mounted protocols.
+  switch: Switch
+  addrsAtStart: seq[MultiAddress]
+
+method start(p: AddressProbe) {.async: (raises: [CancelledError]).} =
+  p.addrsAtStart = p.switch.peerInfo.addrs
+  p.started = true
 
 suite "Announced addresses":
   asyncTest "the resolved base reaches peerInfo and the API projection":
@@ -73,6 +92,28 @@ suite "Announced addresses":
       node.announcedAddresses == node.switch.peerInfo.addrs
       node.announcedAddresses.allIt("/tcp/0" notin $it and "/udp/0/" notin $it)
       node.announcedAddresses.allIt("0.0.0.0" notin $it)
+    await node.stop()
+
+  asyncTest "a wildcard bind is resolved in peerInfo.addrs before the mounted protocols start":
+    ## The helper rewrites 0.0.0.0 to loopback when quic is on, so quic is off.
+    let node = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0), quicEnabled = false
+    )
+    let probe = AddressProbe(switch: node.switch)
+    probe.codec = "/waku/test/address-probe/1.0.0"
+    probe.handler = proc(
+        stream: Stream, proto: string
+    ) {.async: (raises: [CancelledError]).} =
+      discard
+    node.switch.mount(probe)
+
+    await node.start()
+    check:
+      probe.addrsAtStart.len > 0
+      probe.addrsAtStart.allIt("0.0.0.0" notin $it and "/tcp/0" notin $it)
+      ## Nothing after switch.start changed peerInfo.addrs.
+      probe.addrsAtStart == node.switch.peerInfo.addrs
+      probe.addrsAtStart == node.announcedAddresses
     await node.stop()
 
   asyncTest "a loopback bind stays loopback in the base":
@@ -153,9 +194,9 @@ suite "Announced addresses":
       extMultiAddrs = @[MultiAddress.init("/ip4/192.168.77.7/tcp/60111").get()],
     )
     let natSvc = NATService.new(upnpConfig(), rng(), portMapperFactory = factory)
-    ## The eager service updates before start resolves the announced addresses.
-    node.switch.services.add(Service(EagerUpdate()))
+    ## NAT first, then the update, as in Waku.new.
     node.switch.services.add(Service(natSvc))
+    node.switch.services.add(Service(UpdateBeforeBind()))
 
     await node.start()
     let mappersAfterFirstStart = node.switch.peerInfo.addressMappers.len
@@ -170,6 +211,90 @@ suite "Announced addresses":
       ## The new grant is announced. The mapper got the configured address.
       node.announcedAddresses.anyIt("203.0.113.77" in $it and "62002" in $it)
       recorders.allIt(Port(0) notin it.mappedInternal)
+    await node.stop()
+
+  asyncTest "NAT maps the port a wildcard bind actually bound":
+    ## The wildcard bind resolves onto the provider's interface before the NAT
+    ## mapper runs, so NAT maps the bound port and the granted address is announced.
+    var recorders: seq[RecordingMapper]
+    let grantIp = parseIpAddress("203.0.113.77")
+    let factory = proc(mode: PortMappingMode): Opt[PortMapper] {.gcsafe, raises: [].} =
+      let rec = RecordingMapper(grantIp: grantIp, grantPort: Port(62010))
+      {.gcsafe.}:
+        recorders.add(rec)
+      Opt.some(PortMapper(rec))
+
+    ## The helper rewrites 0.0.0.0 to loopback when quic is on, so quic is off.
+    let node = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0), quicEnabled = false
+    )
+    node.switch.addressManager.networkInterfaceProvider = privateInterfaceProvider
+    node.switch.services.add(
+      Service(NATService.new(upnpConfig(), rng(), portMapperFactory = factory))
+    )
+
+    await node.start()
+    let bound = node.boundTcpPort()
+    check:
+      bound != Port(0)
+      recorders.len >= 1
+      recorders.allIt(it.mappedInternal.len >= 1)
+      recorders.allIt(it.mappedInternal.allIt(it == bound))
+      node.announcedAddresses.anyIt("203.0.113.77" in $it and "62010" in $it)
+    await node.stop()
+
+  asyncTest "a fixed port is mapped in both mapper runs and announced once":
+    ## Production binds a fixed port and AutonatService updates peerInfo during the
+    ## bind, so the mappers run twice. Both runs map the configured port, never 0.
+    var recorders: seq[RecordingMapper]
+    let grantIp = parseIpAddress("203.0.113.77")
+    let factory = proc(mode: PortMappingMode): Opt[PortMapper] {.gcsafe, raises: [].} =
+      let rec = RecordingMapper(grantIp: grantIp, grantPort: Port(62020))
+      {.gcsafe.}:
+        recorders.add(rec)
+      Opt.some(PortMapper(rec))
+
+    const FixedPort = Port(61020)
+    let node = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress("0.0.0.0"), FixedPort, quicEnabled = false
+    )
+    node.switch.addressManager.networkInterfaceProvider = privateInterfaceProvider
+    node.switch.services.add(
+      Service(NATService.new(upnpConfig(), rng(), portMapperFactory = factory))
+    )
+    node.switch.services.add(Service(UpdateBeforeBind()))
+
+    await node.start()
+    check:
+      recorders.len >= 1
+      recorders.allIt(it.mappedInternal == @[FixedPort, FixedPort])
+      node.announcedAddresses.filterIt("203.0.113.77" in $it and "62020" in $it).len == 1
+    await node.stop()
+
+  asyncTest "a later update announces the current primary interface":
+    ## The provider runs on every update, so a changed primary IP replaces the old one.
+    var primary = parseIpAddress("192.168.9.9")
+    let movingProvider = proc(
+        addrFamily: AddressFamily
+    ): seq[InterfaceAddress] {.gcsafe, raises: [].} =
+      if addrFamily != AddressFamily.IPv4:
+        return @[]
+      {.gcsafe.}:
+        @[InterfaceAddress.init(initTAddress(primary, Port(0)), 24)]
+
+    let node = newTestWakuNode(
+      generateSecp256k1Key(), parseIpAddress("0.0.0.0"), Port(0), quicEnabled = false
+    )
+    node.switch.addressManager.networkInterfaceProvider = movingProvider
+    await node.start()
+    let bound = node.boundTcpPort()
+    check node.announcedAddresses ==
+      @[MultiAddress.init("/ip4/192.168.9.9/tcp/" & $bound).get()]
+
+    primary = parseIpAddress("192.168.9.10")
+    await node.switch.peerInfo.update()
+    check node.announcedAddresses ==
+      @[MultiAddress.init("/ip4/192.168.9.10/tcp/" & $bound).get()]
     await node.stop()
 
   asyncTest "an unchanged owned update needs the explicit copy":
@@ -206,7 +331,7 @@ suite "Announced addresses":
     ## The override is active from construction, before any start.
     check node.switch.peerInfo.announcedAddrs == @[ext]
 
-    node.switch.services.add(Service(EagerUpdate()))
+    node.switch.services.add(Service(UpdateBeforeBind()))
     node.switch.services.add(
       Service(NATService.new(upnpConfig(), rng(), portMapperFactory = factory))
     )
@@ -214,7 +339,8 @@ suite "Announced addresses":
     check:
       node.announcedAddresses == @[ext]
       node.switch.peerInfo.addrs == @[ext]
-      ## libp2p skipped the chain. The factory ran and every mapper stayed idle.
+      ## The mappers ran over the configured list, which has nothing private to map.
+      ## libp2p announced that list itself. Every mapper stayed idle.
       recorders.len >= 1
       recorders.allIt(it.mappedInternal.len == 0)
     await node.stop()

--- a/tests/test_nat_config.nim
+++ b/tests/test_nat_config.nim
@@ -127,14 +127,13 @@ suite "NAT config - NATService pipeline":
     let switch =
       newTestSwitch(address = Opt.some(MultiAddress.init("/ip4/0.0.0.0/tcp/0").get()))
     switch.services.keepItIf(it of NATService)
-    ## The same shape as the production base mapper. It answers with
-    ## the resolved private addresses.
-    switch.peerInfo.addressMappers.insert(
+    ## Stand-in for the production base mapper: first in the AddressManager.
+    switch.addressManager.addMapper(
       proc(
           addrs: seq[MultiAddress]
       ): Future[seq[MultiAddress]] {.gcsafe, async: (raises: [CancelledError]).} =
         return privateBase,
-      0,
+      AddrSource.Listen,
     )
     let svc = NATService.new(
       natConfig(parseNatStrategy("pmp").get()).get(),
@@ -156,8 +155,28 @@ suite "NAT config - NATService pipeline":
     await switch.stop()
 
 suite "NAT config - switch composition":
-  test "the switch has no wildcard service and no build-time mappers":
-    let switch = newWakuSwitch(rng = rng(), circuitRelay = Relay.new())
+  asyncTest "a wildcard bind is expanded onto one primary address, with no build-time mappers":
+    ## Waku's provider replaces the upstream wildcard service, which announces every interface.
+    let switch = newWakuSwitch(
+      rng = rng(),
+      address = MultiAddress.init("/ip4/0.0.0.0/tcp/0").get(),
+      circuitRelay = Relay.new(),
+    )
     check:
       not switch.services.anyIt(it of WildcardAddressResolverService)
       switch.peerInfo.addressMappers.len == 0
+    await switch.start()
+    check:
+      switch.peerInfo.addrs.len == 1
+      "0.0.0.0" notin $switch.peerInfo.addrs[0]
+      "/tcp/0" notin $switch.peerInfo.addrs[0]
+    await switch.stop()
+
+  test "the primary interface provider answers one address per family, never a wildcard":
+    let v4 = primaryInterfaceProvider(AddressFamily.IPv4)
+    check:
+      v4.len == 1
+      $v4[0].host.toIpAddress() != "0.0.0.0"
+      ## One primary IPv6, or none on a host without an IPv6 route.
+      primaryInterfaceProvider(AddressFamily.IPv6).len <= 1
+      primaryInterfaceProvider(AddressFamily.Unix).len == 0

--- a/tests/test_waku_netconfig.nim
+++ b/tests/test_waku_netconfig.nim
@@ -1,6 +1,7 @@
 import results
 {.used.}
 
+import std/strutils
 import chronos, confutils/toml/std/net, libp2p/multiaddress, testutils/unittests
 
 import ./testlib/wakunode, logos_delivery/waku/waku_enr/capabilities
@@ -538,3 +539,68 @@ suite "Waku NetConfig":
       MultiAddress.init("/ip4/1.2.3.4/udp/0/quic-v1").get().hasZeroPort()
       not MultiAddress.init("/ip4/1.2.3.4/tcp/60000").get().hasZeroPort()
       not MultiAddress.init("/dns4/x.example.org/tcp/443/wss").get().hasZeroPort()
+
+proc resolveMa(s: string): MultiAddress =
+  MultiAddress.init(s).get()
+
+suite "Waku NetConfig - resolveAnnouncedAddresses":
+  test "a wildcard host and port 0 take the bound address of the same transport":
+    let intent = @[
+      resolveMa("/ip4/0.0.0.0/tcp/0"),
+      resolveMa("/ip4/0.0.0.0/tcp/0/ws"),
+      resolveMa("/ip4/0.0.0.0/udp/0/quic-v1"),
+    ]
+    let bound = @[
+      resolveMa("/ip4/192.0.2.10/tcp/60001"),
+      resolveMa("/ip4/192.0.2.10/tcp/60002/ws"),
+      resolveMa("/ip4/192.0.2.10/udp/60003/quic-v1"),
+    ]
+    check resolveAnnouncedAddresses(intent, bound) == bound
+
+  test "a concrete host keeps its host and takes only the bound port":
+    check:
+      resolveAnnouncedAddresses(
+        @[resolveMa("/ip4/127.0.0.1/tcp/0")], @[resolveMa("/ip4/127.0.0.1/tcp/60001")]
+      ) == @[resolveMa("/ip4/127.0.0.1/tcp/60001")]
+      ## A dns host with port 0 takes the bound tcp port.
+      resolveAnnouncedAddresses(
+        @[resolveMa("/dns4/x.example.org/tcp/0")],
+        @[resolveMa("/ip4/192.0.2.10/tcp/60001")],
+      ) == @[resolveMa("/dns4/x.example.org/tcp/60001")]
+
+  test "concrete entries pass through and duplicates collapse":
+    let ext = resolveMa("/ip4/203.0.113.9/tcp/60123")
+    let tricky = resolveMa("/ip4/10.0.0.0/tcp/60123")
+    check resolveAnnouncedAddresses(@[ext, ext, tricky], @[]) == @[ext, tricky]
+
+  test "an entry whose transport has not bound is dropped":
+    check:
+      ## Before the bind, the listen addresses still carry port 0.
+      resolveAnnouncedAddresses(
+        @[resolveMa("/ip4/0.0.0.0/tcp/0")], @[resolveMa("/ip4/0.0.0.0/tcp/0")]
+      ).len == 0
+      ## No ws transport bound: the ws entry goes, the tcp entry resolves.
+      resolveAnnouncedAddresses(
+        @[resolveMa("/ip4/0.0.0.0/tcp/0"), resolveMa("/ip4/0.0.0.0/tcp/0/ws")],
+        @[resolveMa("/ip4/192.0.2.10/tcp/60001")],
+      ) == @[resolveMa("/ip4/192.0.2.10/tcp/60001")]
+
+  test "a wildcard host resolves onto every bound address of its transport":
+    ## A dual-stack bind expands to one address per family.
+    let bound = @[
+      resolveMa("/ip6/2001:db8::10/tcp/60001"), resolveMa("/ip4/192.0.2.10/tcp/60001")
+    ]
+    check resolveAnnouncedAddresses(@[resolveMa("/ip6/::/tcp/0")], bound) == bound
+
+  test "isWildcardHost and transportPort read the address shapes":
+    check:
+      resolveMa("/ip4/0.0.0.0/tcp/1").isWildcardHost()
+      resolveMa("/ip6/::/tcp/1").isWildcardHost()
+      not resolveMa("/ip4/10.0.0.0/tcp/1").isWildcardHost()
+      not resolveMa("/dns4/x.example.org/tcp/1").isWildcardHost()
+      resolveMa("/ip4/1.2.3.4/udp/60003/quic-v1").transportPort() ==
+        Opt.some(Port(60003))
+      resolveMa("/dns4/x.example.org/tcp/443/wss").transportPort() == Opt.some(
+        Port(443)
+      )
+      resolveMa("/ip4/1.2.3.4").transportPort().isNone()

--- a/tests/waku_kademlia/test_node_advertising.nim
+++ b/tests/waku_kademlia/test_node_advertising.nim
@@ -1,0 +1,121 @@
+{.used.}
+
+import std/[net, sequtils, sets, strutils, tables]
+import testutils/unittests, chronos, results
+import libp2p/extended_peer_record
+import libp2p/protocols/service_discovery/types as sd_types
+import libp2p/protocols/kademlia/types
+import
+  logos_delivery/waku/node/waku_node,
+  logos_delivery/waku/discovery/waku_kademlia,
+  ../testlib/[wakucore, wakunode, testasync]
+
+## The default deployment binds 0.0.0.0. switch.start resolves peerInfo.addrs
+## before it starts ServiceDiscovery. The node advertises its services after.
+
+proc isAdvertised(node: WakuNode, service: ServiceInfo): bool =
+  let disco = node.wakuKademlia.protocol
+  service in disco.services and
+    disco.advertiser.providedAdverts.hasKey(service.id.hashServiceId())
+
+proc publishedRecord(node: WakuNode): Opt[ExtendedPeerRecord] =
+  ## The self record the protocol stored in its own table.
+  let disco = node.wakuKademlia.protocol
+  let entry = disco.dataTable.get(node.switch.peerInfo.peerId.toKey()).valueOr:
+    return Opt.none(ExtendedPeerRecord)
+  let record = SignedExtendedPeerRecord.decode(entry.value.toBytes()).valueOr:
+    return Opt.none(ExtendedPeerRecord)
+  Opt.some(record.data)
+
+proc publishedServices(node: WakuNode): seq[ServiceInfo] =
+  let record = node.publishedRecord().valueOr:
+    return @[]
+  record.services
+
+proc publishedAddresses(node: WakuNode): seq[MultiAddress] =
+  let record = node.publishedRecord().valueOr:
+    return @[]
+  record.addresses.mapIt(it.address)
+
+proc newAdvertisingNode(
+    bindIp: IpAddress, service: ServiceInfo, extMultiAddrs: seq[MultiAddress] = @[]
+): WakuNode =
+  ## The helper rewrites 0.0.0.0 to loopback when quic is on, so quic is off.
+  let node = newTestWakuNode(
+    generateSecp256k1Key(),
+    bindIp,
+    Port(0),
+    extMultiAddrs = extMultiAddrs,
+    quicEnabled = false,
+  )
+  node.mountKademlia(
+    KademliaDiscoveryConf(
+      servicesToAdvertise: toHashSet([service]),
+      randomLookupInterval: 10.seconds,
+      serviceLookupInterval: 10.seconds,
+      kadDhtConfig: KadDHTConfig.new(),
+      discoConfig: sd_types.ServiceDiscoveryConfig.new(),
+      xprPublishing: true,
+    )
+  ).isOkOr:
+    raiseAssert error
+  node
+
+suite "Waku Kademlia node advertising":
+  asyncTest "a configured service is advertised on a wildcard bind, and after a restart":
+    let service = ServiceInfo(id: "/test/service/1.0.0", data: Opt.none(seq[byte]))
+    let node = newAdvertisingNode(parseIpAddress("0.0.0.0"), service)
+
+    await node.start()
+    check node.isAdvertised(service)
+    ## The record published before the service was added listed no services.
+    checkUntilTimeout:
+      service in node.publishedServices()
+    ## peerInfo.addrs was resolved before the protocol started, so the record is dialable.
+    check:
+      node.publishedAddresses().len > 0
+      node.publishedAddresses().allIt("0.0.0.0" notin $it and "/tcp/0" notin $it)
+      node.publishedAddresses() == node.announcedAddresses
+    await node.stop()
+    check not node.isAdvertised(service)
+    ## The stored record survives the stop. Delete it so the restart must publish anew.
+    node.wakuKademlia.protocol.dataTable.del(node.switch.peerInfo.peerId.toKey())
+
+    await node.start()
+    check node.isAdvertised(service)
+    checkUntilTimeout:
+      service in node.publishedServices()
+    await node.stop()
+
+  asyncTest "a record the protocol cannot build leaves the node running and the service configured":
+    ## 200 addresses push the record past its size cap. Through the constructor this
+    ## trips an upstream assertion at start. Here it is a warning, on every start.
+    let service = ServiceInfo(id: "/test/service/1.0.0", data: Opt.none(seq[byte]))
+    let ext = (0 ..< 200).mapIt(
+      MultiAddress
+        .init("/ip4/10.0." & $(it div 250) & "." & $(it mod 250) & "/tcp/60000")
+        .get()
+    )
+    let node = newAdvertisingNode(parseIpAddress("127.0.0.1"), service, ext)
+
+    await node.start()
+    check:
+      node.started
+      node.wakuKademlia.protocol.record().isErr()
+      not node.isAdvertised(service)
+    await node.stop()
+
+    await node.start()
+    check not node.isAdvertised(service)
+    await node.stop()
+
+  asyncTest "a concrete bind republishes the record once the service is added":
+    ## The first record precedes the service, and a concrete bind changes no address.
+    let service = ServiceInfo(id: "/test/service/1.0.0", data: Opt.none(seq[byte]))
+    let node = newAdvertisingNode(parseIpAddress("127.0.0.1"), service)
+
+    await node.start()
+    check node.isAdvertised(service)
+    checkUntilTimeout:
+      service in node.publishedServices()
+    await node.stop()

--- a/tests/waku_relay/test_protocol.nim
+++ b/tests/waku_relay/test_protocol.nim
@@ -1117,7 +1117,7 @@ suite "Waku Relay":
         (pubsubTopic, msg3) == handlerFuture.read()
         (pubsubTopic, msg3) == otherHandlerFuture.read()
 
-      # When sending the 'DefaultMaxWakuMessageSize - sizeEmptyMsg - 38' message
+      # When sending the 'DefaultMaxWakuMessageSize - sizeEmptyMsg - 26' message
       handlerFuture = newPushHandlerFuture()
       otherHandlerFuture = newPushHandlerFuture()
       discard await node.publish(pubsubTopic, msg4)
@@ -1129,27 +1129,27 @@ suite "Waku Relay":
         (pubsubTopic, msg4) == handlerFuture.read()
         (pubsubTopic, msg4) == otherHandlerFuture.read()
 
-      # When sending the 'DefaultMaxWakuMessageSize - sizeEmptyMsg - 37' message
+      # When sending the 'DefaultMaxWakuMessageSize - sizeEmptyMsg - 25' message
       handlerFuture = newPushHandlerFuture()
       otherHandlerFuture = newPushHandlerFuture()
-      discard await node.publish(pubsubTopic, msg5)
+      let msg5Res = await node.publish(pubsubTopic, msg5)
 
-      # Then the message is received in self, because there's no checking, but not in other node
+      # Then publish rejects the message before the local delivery, so no node receives it
       check:
-        await handlerFuture.withTimeout(FUTURE_TIMEOUT)
+        msg5Res.isErr()
+        not await handlerFuture.withTimeout(FUTURE_TIMEOUT)
         not await otherHandlerFuture.withTimeout(FUTURE_TIMEOUT)
-        (pubsubTopic, msg5) == handlerFuture.read()
 
       # When sending the 'DefaultMaxWakuMessageSize' message
       handlerFuture = newPushHandlerFuture()
       otherHandlerFuture = newPushHandlerFuture()
-      discard await node.publish(pubsubTopic, msg6)
+      let msg6Res = await node.publish(pubsubTopic, msg6)
 
-      # Then the message is received in self, because there's no checking, but not in other node
+      # Then publish rejects the message before the local delivery, so no node receives it
       check:
-        await handlerFuture.withTimeout(FUTURE_TIMEOUT)
+        msg6Res.isErr()
+        not await handlerFuture.withTimeout(FUTURE_TIMEOUT)
         not await otherHandlerFuture.withTimeout(FUTURE_TIMEOUT)
-        (pubsubTopic, msg6) == handlerFuture.read()
 
       # Finally stop the other node
       await allFutures(otherSwitch.stop(), otherNode.stop())


### PR DESCRIPTION
## Description

This PR bumps `nim-libp2p` to 2.4.0 and moves Waku's announced-address resolution into libp2p's `AddressManager`. The switch resolves the announced addresses and writes them to `peerInfo.addrs` before it starts the mounted protocols, so `ServiceDiscovery` publishes them in its first record.

Waku's mapper, `resolveAnnouncedAddresses` in `net_config.nim`, runs before the NAT and relay mappers on every start. It resolves wildcard hosts (`0.0.0.0`, `::`) and port 0 against the bound listen addresses of the same transport, keeps concrete addresses, and drops addresses of transports that have not bound. Example: `/ip4/0.0.0.0/tcp/0` with bound `/ip4/192.168.1.20/tcp/60123` gives `/ip4/192.168.1.20/tcp/60123`. `primaryInterfaceProvider` in `waku_switch.nim` supplies the interface for a wildcard bind, one per IP family from `getPrimaryIPAddr`. `peerInfo.addrs` feeds `WakuNode.announcedAddresses` and the ENR through `refreshEnrAddrs`.

This PR removes `baseAnnounced` and the post-start resolution path, `resolveAnnouncedBaseAddresses` and `substituteBoundPorts`. `initNode` disables NAT port mapping under `--ext-multiaddr-only`, because libp2p 2.4 runs the address mappers even when `peerInfo.announcedAddrs` is set.

`WakuKademlia` starts its service advertisements after `switch.start()` and stops them in `WakuKademlia.stop`. This avoids the upstream assertion on a failed initial advertisement and clears the advertised status for a restart.

## Changes

* pin `libp2p` to 2.4.0 commit
* pin `websock` to 0.4.1
* regenerate `nimble.lock`
* regenerate `nix/deps.nix`
* add `resolveAnnouncedAddresses` mapper
* add `primaryInterfaceProvider` for wildcard bind
* register base mapper first in `AddressManager`
* copy `peerInfo.addrs` into `announcedAddresses`
* remove `baseAnnounced`
* remove `resolveAnnouncedBaseAddresses`
* remove `substituteBoundPorts`
* advertise services from `WakuKademlia.start`
* stop advertising in `WakuKademlia.stop`
* export kademlia `Key` operators
* disable NAT mapping under `--ext-multiaddr-only`
* expect oversized publish to fail in `test_protocol.nim`
* fix NAT restart test order in `test_announced_addresses.nim` (#4145)
* add tests

## Issue

Maintenance Y2026H2 #4043