### PR TITLE
fix(tests): make WakuConf (kernel) TCP, Discv5, REST auto-port

### DIFF
--- a/tests/testlib/wakunode.nim
+++ b/tests/testlib/wakunode.nim
@@ -32,7 +32,10 @@ import
 proc defaultTestWakuConfBuilder*(): WakuConfBuilder =
   var builder = WakuConfBuilder.init()
   builder.withP2pListenAddress(parseIpAddress("0.0.0.0"))
+  builder.withP2pTcpPort(Port(0))
+  builder.discv5Conf.withUdpPort(Port(0))
   builder.restServerConf.withListenAddress(parseIpAddress("127.0.0.1"))
+  builder.restServerConf.withPort(Port(0))
   builder.withDnsAddrsNameServers(
     @[parseIpAddress("1.1.1.1"), parseIpAddress("1.0.0.1")]
   )


### PR DESCRIPTION
## Description

Fix kernel test fixture port defaults for p2pTcp, discv5 UDP and REST to auto-port allocation, to avoid port-already-in-use collisions.

## Changes

* set the TCP, discv5 UDP and REST ports of `defaultTestWakuConfBuilder` to 0

## Issue

Maintenance Y2026H2 #4043
