### PR TITLE
refactor: stop relying on libp2p's internal withValue helper

### DIFF
--- a/logos_delivery/waku/common/rate_limit/request_limiter.nim
+++ b/logos_delivery/waku/common/rate_limit/request_limiter.nim
@@ -20,8 +20,7 @@ import
   std/math,
   chronicles,
   chronos/timer,
-  libp2p/stream/connection,
-  libp2p/utils/opt
+  libp2p/stream/connection
 
 import std/times except TimeInterval, Duration, seconds, minutes
 
@@ -138,33 +137,31 @@ template checkUsageLimit*(
 
 # TODO: review these ratio assumptions! Debatable!
 func calcPeriodRatio(settingOpt: Opt[RateLimitSetting]): int =
-  settingOpt.withValue(setting):
-    if setting.isUnlimited():
-      return UNLIMITED_RATIO
-
-    if setting.period <= 1.seconds:
-      return MILISECONDS_RATIO
-
-    if setting.period <= 1.minutes:
-      return SECONDS_RATIO
-
-    return MINUTES_RATIO
-  do:
-    # when setting is none
+  let setting = settingOpt.valueOr:
     return UNLIMITED_RATIO
+
+  if setting.isUnlimited():
+    return UNLIMITED_RATIO
+
+  if setting.period <= 1.seconds:
+    return MILISECONDS_RATIO
+
+  if setting.period <= 1.minutes:
+    return SECONDS_RATIO
+
+  return MINUTES_RATIO
 
 # calculates peer cache items timeout
 # effectively if a peer does not issue any requests for this amount of time will be forgotten.
 func calcCacheTimeout(settingOpt: Opt[RateLimitSetting], ratio: int): Duration =
-  settingOpt.withValue(setting):
-    if setting.isUnlimited():
-      return UNLIMITED_TIMEOUT
-
-    # CacheTimout for peers is double the replensih period for peers
-    return setting.period * ratio * 2
-  do:
-    # when setting is none
+  let setting = settingOpt.valueOr:
     return UNLIMITED_TIMEOUT
+
+  if setting.isUnlimited():
+    return UNLIMITED_TIMEOUT
+
+  # CacheTimout for peers is double the replensih period for peers
+  return setting.period * ratio * 2
 
 func calcPeerTokenSetting(
     setting: Opt[RateLimitSetting], ratio: int

--- a/logos_delivery/waku/common/rate_limit/request_limiter.nim
+++ b/logos_delivery/waku/common/rate_limit/request_limiter.nim
@@ -15,12 +15,7 @@
 
 {.push raises: [].}
 
-import
-  results,
-  std/math,
-  chronicles,
-  chronos/timer,
-  libp2p/stream/connection
+import results, std/math, chronicles, chronos/timer, libp2p/stream/connection
 
 import std/times except TimeInterval, Duration, seconds, minutes
 

--- a/logos_delivery/waku/node/waku_switch.nim
+++ b/logos_delivery/waku/node/waku_switch.nim
@@ -13,8 +13,7 @@ import
   libp2p/nameresolving/nameresolver,
   libp2p/builders,
   libp2p/switch,
-  libp2p/transports/[transport, tcptransport, wstransport],
-  libp2p/utils/opt
+  libp2p/transports/[transport, tcptransport, wstransport]
 import ./delivery_dialer
 
 # override nim-libp2p default value (which is also 1)
@@ -97,8 +96,8 @@ proc newWakuSwitch*(
 
   # UPnP and NAT-PMP port mapping via libp2p's NATService.
   # The extip strategy stays static in NetConfig.
-  natConfig.withValue(config):
-    b = b.withNAT(config)
+  if natConfig.isSome():
+    b = b.withNAT(natConfig.get())
 
   # libp2p 2.0.0 folded withMaxConnections and withMaxInOut into a single
   # `limits` field: they are mutually exclusive (last one wins), and


### PR DESCRIPTION
## Description

nim-libp2p renamed its `Opt` helper `withValue` to `ifValue` in vacp2p/nim-libp2p#3105. The libp2p maintainers see it as an internal utility, so code outside libp2p shouldn't rely on it. We used it in three places. Once the rename ships in a libp2p release, bumping libp2p would break the build here.

This PR replaces those three uses with plain nim-results, so we no longer depend on the helper and the next bump won't break here.

## Changes

- `request_limiter.nim`: `calcPeriodRatio` and `calcCacheTimeout` now use `valueOr` for the `none` case, in place of `withValue(...) do:`. Behaviour is unchanged.
- `waku_switch.nim`: the NAT config is applied with `isSome()` / `get()`.
- Both files no longer import `libp2p/utils/opt`, since nothing else from it is used.

The standard library's `Table.withValue(key, value)` calls are unrelated and left as they are.

## Notes

- Works with the current libp2p pin (2.3.1) and with later releases that include the rename, so it can be merged before any libp2p bump.
- nim-libp2p-mix also uses `withValue`, so it will need its own update before we can move to the libp2p version with the rename.

## How to test

```bash
make test tests/common/test_requestratelimiter.nim
make test tests/common/test_ratelimit_setting.nim
make test tests/test_waku_switch.nim
make test tests/test_nat_config.nim
```

All four pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

