### PR TITLE
ci: run the required checks in the merge queue

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   pull_request:
     branches: [master]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
 
 permissions:
   contents: read
@@ -13,6 +14,9 @@ permissions:
 
 jobs:
   labels:
+    # Only comments on PRs. It still has to report in the merge queue because
+    # it is a required check, and a skipped job counts as passing.
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -5,6 +5,7 @@ permissions:
 on:
   pull_request:
     branches: [master]
+  merge_group:
 
 jobs:
   # PR check: logos_delivery.nimble version must be >= the nearest tag reachable from
@@ -12,8 +13,11 @@ jobs:
   # Because we check out the PR HEAD (not the simulated merge ref), a branch
   # that predates a release tag does not see that tag in its history, so a
   # newly pushed tag does NOT break in-flight PRs. Once the branch merges/
-  # rebases past the tag, the bump is then enforced. This keeps logos_delivery.nimble
-  # fixed as early as possible, independent of whether a release is cut.
+  # rebases past the tag, the bump is then enforced. In the merge queue there
+  # is no pull_request payload, so the checkout falls back to the queue commit
+  # (the PR on top of the latest master), which is exactly what would land.
+  # This keeps logos_delivery.nimble fixed as early as possible, independent
+  # of whether a release is cut.
   # The exact tag==nimble guarantee at release time lives in
   # release-assets.yml, which gates artifact publishing on it.
   nimble-not-behind-tag:


### PR DESCRIPTION
## Description

Today a PR needs 23 green checks, and it must be up to date with master before it can merge. CI takes about 45 minutes. When master moves, the branch has to be updated and every check runs again. On a busy day that repeats: 109 of the last 200 CI runs were cancelled.

A [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) fixes that. You click **Merge when ready** once. GitHub puts the PR on top of the latest master, runs CI on that result, and merges it if it passes. Master stays just as protected, and nobody has to keep updating branches.

This PR is the code side: the workflows that produce required checks also run for the queue.

## Changes

- `ci.yml`, `ci-nix.yml` and `version-check.yml` also run on `merge_group`. Between them they produce every required check except `labels`.
- `pr-lint.yml` also runs on `merge_group`, but its `labels` job is skipped there. The job only comments on PRs, and a skipped job still counts as passed for a required check.

These triggers do nothing until the queue is turned on, so this is safe to merge as it is.

## After merging

An admin turns on the queue in the repo settings:

1. **Settings → Rules → Rulesets → New branch ruleset**, target `master`:
   - **Require merge queue**: squash, only merge non-failing PRs, build up to 3 at a time, status check timeout 120 min.
   - **Require status checks to pass**: the same checks as today, with "require branches to be up to date" **off**.
2. **Settings → Branches → master**: remove the required status checks there. The ruleset now holds them. Reviews and signed commits stay as they are.

To undo, disable the ruleset.

nim-libp2p already runs this setup and merged 143 PRs through its queue in the last 30 days.

## Issue

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
